### PR TITLE
feat: scaffold internal guardrails distribution

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -43,7 +43,47 @@
 
 ---
 
-### التثبيت
+### About This Fork
+
+This repository is the Cor-Incorporated fork of OpenCode.
+
+- It tracks upstream OpenCode and keeps compatibility where practical.
+- It adds a thin internal distribution layer rather than a deep rewrite.
+- Internal product work lives under `docs/ai-guardrails/` and `packages/guardrails/`.
+- It is not an official OpenCode team repository or release channel.
+
+If you are reading this fork for internal implementation work, start here:
+
+- Plan and ADRs: `docs/ai-guardrails/README.md`
+- Migration inventory: `docs/ai-guardrails/migration/claude-code-skills-inventory.md`
+- Thin distribution package: `packages/guardrails/`
+- GitHub tracker: `Cor-Incorporated/opencode` issues `#1` to `#7`
+
+### حول هذا الـ fork
+
+هذا المستودع هو fork خاص بـ Cor-Incorporated من OpenCode.
+
+- يحافظ على التوافق مع OpenCode الاصلي قدر الامكان.
+- يضيف طبقة توزيع داخلية خفيفة بدلا من تحويل الـ fork الى اعادة كتابة عميقة.
+- اعمال المنتج الداخلية الحالية موجودة تحت `docs/ai-guardrails/` و `packages/guardrails/`.
+- هذا ليس مستودعا رسميا لفريق OpenCode ولا قناة اصدار رسمية لهم.
+
+اذا كنت تقرأ هذا الـ fork بغرض العمل الداخلي، ابدأ من:
+
+- الخطة و ADRs: `docs/ai-guardrails/README.md`
+- جرد الترحيل: `docs/ai-guardrails/migration/claude-code-skills-inventory.md`
+- حزمة التوزيع الخفيفة: `packages/guardrails/`
+
+### تثبيت النسخة الاصلية
+
+الاوامر التالية تثبت OpenCode الاصلي، وليس التوزيع الداخلي الخاص بهذا الـ fork.
+
+يحافظ هذا الـ fork حاليا على التوافق مع النسخة الاصلية ويطوّر طبقة داخلية اضافية فوقها. اذا نشرت Cor-Incorporated لاحقا مسار تثبيت خاصا بها او توزيعة باسم مختلف، فيجب توثيق ذلك بشكل منفصل عن تعليمات التثبيت الاصلية ادناه.
+
+The commands below install official upstream OpenCode, not this fork-specific internal distribution.
+
+This fork currently preserves upstream compatibility and develops an additional internal layer on top. If Cor-Incorporated publishes its own install path or renamed distribution, that should be documented separately from the upstream install instructions below.
+
 
 ```bash
 # YOLO
@@ -123,7 +163,21 @@ XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 ### البناء فوق OpenCode
 
 اذا كنت تعمل على مشروع مرتبط بـ OpenCode ويستخدم "opencode" كجزء من اسمه (مثل "opencode-dashboard" او "opencode-mobile")، يرجى اضافة ملاحظة في README توضح انه ليس مبنيا بواسطة فريق OpenCode ولا يرتبط بنا بأي شكل.
+بالنسبة لهذا الـ fork تحديدا، الصياغة الصحيحة هي:
 
+- fork من OpenCode
+- يحافظ على التوافق مع النسخة الاصلية حيثما كان ذلك عمليا
+- يمدده الى اداة داخلية خاصة بـ Cor-Incorporated عبر طبقة guardrail منفصلة
+- لا ينبغي تقديمه على انه اصدار رسمي من OpenCode
+
+
+
+For this fork specifically, the correct framing is:
+
+- forked from OpenCode
+- keeps upstream compatibility where practical
+- extends it into a Cor-Incorporated internal tool through a separate guardrail layer
+- should not be presented as an official upstream OpenCode release
 ### FAQ
 
 #### ما الفرق عن Claude Code؟

--- a/README.bn.md
+++ b/README.bn.md
@@ -43,7 +43,27 @@
 
 ---
 
+### About This Fork
+
+This repository is the Cor-Incorporated fork of OpenCode.
+
+- It tracks upstream OpenCode and keeps compatibility where practical.
+- It adds a thin internal distribution layer rather than a deep rewrite.
+- Internal product work lives under `docs/ai-guardrails/` and `packages/guardrails/`.
+- It is not an official OpenCode team repository or release channel.
+
+If you are reading this fork for internal implementation work, start here:
+
+- Plan and ADRs: `docs/ai-guardrails/README.md`
+- Migration inventory: `docs/ai-guardrails/migration/claude-code-skills-inventory.md`
+- Thin distribution package: `packages/guardrails/`
+- GitHub tracker: `Cor-Incorporated/opencode` issues `#1` to `#7`
+
 ### ইনস্টলেশন (Installation)
+
+The commands below install official upstream OpenCode, not this fork-specific internal distribution.
+
+This fork currently preserves upstream compatibility and develops an additional internal layer on top. If Cor-Incorporated publishes its own install path or renamed distribution, that should be documented separately from the upstream install instructions below.
 
 ```bash
 # YOLO
@@ -121,6 +141,13 @@ OpenCode এ দুটি বিল্ট-ইন এজেন্ট রয়ে
 আপনি যদি OpenCode এ অবদান রাখতে চান, অনুগ্রহ করে একটি পুল রিকোয়েস্ট সাবমিট করার আগে আমাদের [কন্ট্রিবিউটিং ডকস](./CONTRIBUTING.md) পড়ে নিন।
 
 ### OpenCode এর উপর বিল্ডিং (Building on OpenCode)
+
+For this fork specifically, the correct framing is:
+
+- forked from OpenCode
+- keeps upstream compatibility where practical
+- extends it into a Cor-Incorporated internal tool through a separate guardrail layer
+- should not be presented as an official upstream OpenCode release
 
 আপনি যদি এমন প্রজেক্টে কাজ করেন যা OpenCode এর সাথে সম্পর্কিত এবং প্রজেক্টের নামের অংশ হিসেবে "opencode" ব্যবহার করেন, উদাহরণস্বরূপ "opencode-dashboard" বা "opencode-mobile", তবে দয়া করে আপনার README তে একটি নোট যোগ করে স্পষ্ট করুন যে এই প্রজেক্টটি OpenCode দল দ্বারা তৈরি হয়নি এবং আমাদের সাথে এর কোনো সরাসরি সম্পর্ক নেই।
 

--- a/README.br.md
+++ b/README.br.md
@@ -43,7 +43,27 @@
 
 ---
 
+### About This Fork
+
+This repository is the Cor-Incorporated fork of OpenCode.
+
+- It tracks upstream OpenCode and keeps compatibility where practical.
+- It adds a thin internal distribution layer rather than a deep rewrite.
+- Internal product work lives under `docs/ai-guardrails/` and `packages/guardrails/`.
+- It is not an official OpenCode team repository or release channel.
+
+If you are reading this fork for internal implementation work, start here:
+
+- Plan and ADRs: `docs/ai-guardrails/README.md`
+- Migration inventory: `docs/ai-guardrails/migration/claude-code-skills-inventory.md`
+- Thin distribution package: `packages/guardrails/`
+- GitHub tracker: `Cor-Incorporated/opencode` issues `#1` to `#7`
+
 ### Instalação
+
+The commands below install official upstream OpenCode, not this fork-specific internal distribution.
+
+This fork currently preserves upstream compatibility and develops an additional internal layer on top. If Cor-Incorporated publishes its own install path or renamed distribution, that should be documented separately from the upstream install instructions below.
 
 ```bash
 # YOLO
@@ -121,6 +141,13 @@ Para mais informações sobre como configurar o OpenCode, [**veja nossa document
 Se você tem interesse em contribuir com o OpenCode, leia os [contributing docs](./CONTRIBUTING.md) antes de enviar um pull request.
 
 ### Construindo com OpenCode
+
+For this fork specifically, the correct framing is:
+
+- forked from OpenCode
+- keeps upstream compatibility where practical
+- extends it into a Cor-Incorporated internal tool through a separate guardrail layer
+- should not be presented as an official upstream OpenCode release
 
 Se você estiver trabalhando em um projeto relacionado ao OpenCode e estiver usando "opencode" como parte do nome (por exemplo, "opencode-dashboard" ou "opencode-mobile"), adicione uma nota no README para deixar claro que não foi construído pela equipe do OpenCode e não é afiliado a nós de nenhuma forma.
 

--- a/README.bs.md
+++ b/README.bs.md
@@ -43,7 +43,27 @@
 
 ---
 
+### About This Fork
+
+This repository is the Cor-Incorporated fork of OpenCode.
+
+- It tracks upstream OpenCode and keeps compatibility where practical.
+- It adds a thin internal distribution layer rather than a deep rewrite.
+- Internal product work lives under `docs/ai-guardrails/` and `packages/guardrails/`.
+- It is not an official OpenCode team repository or release channel.
+
+If you are reading this fork for internal implementation work, start here:
+
+- Plan and ADRs: `docs/ai-guardrails/README.md`
+- Migration inventory: `docs/ai-guardrails/migration/claude-code-skills-inventory.md`
+- Thin distribution package: `packages/guardrails/`
+- GitHub tracker: `Cor-Incorporated/opencode` issues `#1` to `#7`
+
 ### Instalacija
+
+The commands below install official upstream OpenCode, not this fork-specific internal distribution.
+
+This fork currently preserves upstream compatibility and develops an additional internal layer on top. If Cor-Incorporated publishes its own install path or renamed distribution, that should be documented separately from the upstream install instructions below.
 
 ```bash
 # YOLO
@@ -121,6 +141,13 @@ Za više informacija o konfiguraciji OpenCode-a, [**pogledaj dokumentaciju**](ht
 Ako želiš doprinositi OpenCode-u, pročitaj [upute za doprinošenje](./CONTRIBUTING.md) prije slanja pull requesta.
 
 ### Gradnja na OpenCode-u
+
+For this fork specifically, the correct framing is:
+
+- forked from OpenCode
+- keeps upstream compatibility where practical
+- extends it into a Cor-Incorporated internal tool through a separate guardrail layer
+- should not be presented as an official upstream OpenCode release
 
 Ako radiš na projektu koji je povezan s OpenCode-om i koristi "opencode" kao dio naziva, npr. "opencode-dashboard" ili "opencode-mobile", dodaj napomenu u svoj README da projekat nije napravio OpenCode tim i da nije povezan s nama.
 

--- a/README.da.md
+++ b/README.da.md
@@ -43,7 +43,27 @@
 
 ---
 
+### About This Fork
+
+This repository is the Cor-Incorporated fork of OpenCode.
+
+- It tracks upstream OpenCode and keeps compatibility where practical.
+- It adds a thin internal distribution layer rather than a deep rewrite.
+- Internal product work lives under `docs/ai-guardrails/` and `packages/guardrails/`.
+- It is not an official OpenCode team repository or release channel.
+
+If you are reading this fork for internal implementation work, start here:
+
+- Plan and ADRs: `docs/ai-guardrails/README.md`
+- Migration inventory: `docs/ai-guardrails/migration/claude-code-skills-inventory.md`
+- Thin distribution package: `packages/guardrails/`
+- GitHub tracker: `Cor-Incorporated/opencode` issues `#1` to `#7`
+
 ### Installation
+
+The commands below install official upstream OpenCode, not this fork-specific internal distribution.
+
+This fork currently preserves upstream compatibility and develops an additional internal layer on top. If Cor-Incorporated publishes its own install path or renamed distribution, that should be documented separately from the upstream install instructions below.
 
 ```bash
 # YOLO
@@ -121,6 +141,13 @@ For mere info om konfiguration af OpenCode, [**se vores docs**](https://opencode
 Hvis du vil bidrage til OpenCode, så læs vores [contributing docs](./CONTRIBUTING.md) før du sender en pull request.
 
 ### Bygget på OpenCode
+
+For this fork specifically, the correct framing is:
+
+- forked from OpenCode
+- keeps upstream compatibility where practical
+- extends it into a Cor-Incorporated internal tool through a separate guardrail layer
+- should not be presented as an official upstream OpenCode release
 
 Hvis du arbejder på et projekt der er relateret til OpenCode og bruger "opencode" som en del af navnet; f.eks. "opencode-dashboard" eller "opencode-mobile", så tilføj en note i din README, der tydeliggør at projektet ikke er bygget af OpenCode-teamet og ikke er tilknyttet os på nogen måde.
 

--- a/README.de.md
+++ b/README.de.md
@@ -43,7 +43,27 @@
 
 ---
 
+### About This Fork
+
+This repository is the Cor-Incorporated fork of OpenCode.
+
+- It tracks upstream OpenCode and keeps compatibility where practical.
+- It adds a thin internal distribution layer rather than a deep rewrite.
+- Internal product work lives under `docs/ai-guardrails/` and `packages/guardrails/`.
+- It is not an official OpenCode team repository or release channel.
+
+If you are reading this fork for internal implementation work, start here:
+
+- Plan and ADRs: `docs/ai-guardrails/README.md`
+- Migration inventory: `docs/ai-guardrails/migration/claude-code-skills-inventory.md`
+- Thin distribution package: `packages/guardrails/`
+- GitHub tracker: `Cor-Incorporated/opencode` issues `#1` to `#7`
+
 ### Installation
+
+The commands below install official upstream OpenCode, not this fork-specific internal distribution.
+
+This fork currently preserves upstream compatibility and develops an additional internal layer on top. If Cor-Incorporated publishes its own install path or renamed distribution, that should be documented separately from the upstream install instructions below.
 
 ```bash
 # YOLO
@@ -121,6 +141,13 @@ Mehr Infos zur Konfiguration von OpenCode findest du in unseren [**Docs**](https
 Wenn du zu OpenCode beitragen möchtest, lies bitte unsere [Contributing Docs](./CONTRIBUTING.md), bevor du einen Pull Request einreichst.
 
 ### Auf OpenCode aufbauen
+
+For this fork specifically, the correct framing is:
+
+- forked from OpenCode
+- keeps upstream compatibility where practical
+- extends it into a Cor-Incorporated internal tool through a separate guardrail layer
+- should not be presented as an official upstream OpenCode release
 
 Wenn du an einem Projekt arbeitest, das mit OpenCode zusammenhängt und "opencode" als Teil seines Namens verwendet (z.B. "opencode-dashboard" oder "opencode-mobile"), füge bitte einen Hinweis in deine README ein, dass es nicht vom OpenCode-Team gebaut wird und nicht in irgendeiner Weise mit uns verbunden ist.
 

--- a/README.es.md
+++ b/README.es.md
@@ -43,7 +43,27 @@
 
 ---
 
+### About This Fork
+
+This repository is the Cor-Incorporated fork of OpenCode.
+
+- It tracks upstream OpenCode and keeps compatibility where practical.
+- It adds a thin internal distribution layer rather than a deep rewrite.
+- Internal product work lives under `docs/ai-guardrails/` and `packages/guardrails/`.
+- It is not an official OpenCode team repository or release channel.
+
+If you are reading this fork for internal implementation work, start here:
+
+- Plan and ADRs: `docs/ai-guardrails/README.md`
+- Migration inventory: `docs/ai-guardrails/migration/claude-code-skills-inventory.md`
+- Thin distribution package: `packages/guardrails/`
+- GitHub tracker: `Cor-Incorporated/opencode` issues `#1` to `#7`
+
 ### Instalación
+
+The commands below install official upstream OpenCode, not this fork-specific internal distribution.
+
+This fork currently preserves upstream compatibility and develops an additional internal layer on top. If Cor-Incorporated publishes its own install path or renamed distribution, that should be documented separately from the upstream install instructions below.
 
 ```bash
 # YOLO
@@ -121,6 +141,13 @@ Para más información sobre cómo configurar OpenCode, [**ve a nuestra document
 Si te interesa contribuir a OpenCode, lee nuestras [docs de contribución](./CONTRIBUTING.md) antes de enviar un pull request.
 
 ### Construyendo sobre OpenCode
+
+For this fork specifically, the correct framing is:
+
+- forked from OpenCode
+- keeps upstream compatibility where practical
+- extends it into a Cor-Incorporated internal tool through a separate guardrail layer
+- should not be presented as an official upstream OpenCode release
 
 Si estás trabajando en un proyecto relacionado con OpenCode y usas "opencode" como parte del nombre; por ejemplo, "opencode-dashboard" u "opencode-mobile", agrega una nota en tu README para aclarar que no está construido por el equipo de OpenCode y que no está afiliado con nosotros de ninguna manera.
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -43,7 +43,27 @@
 
 ---
 
+### About This Fork
+
+This repository is the Cor-Incorporated fork of OpenCode.
+
+- It tracks upstream OpenCode and keeps compatibility where practical.
+- It adds a thin internal distribution layer rather than a deep rewrite.
+- Internal product work lives under `docs/ai-guardrails/` and `packages/guardrails/`.
+- It is not an official OpenCode team repository or release channel.
+
+If you are reading this fork for internal implementation work, start here:
+
+- Plan and ADRs: `docs/ai-guardrails/README.md`
+- Migration inventory: `docs/ai-guardrails/migration/claude-code-skills-inventory.md`
+- Thin distribution package: `packages/guardrails/`
+- GitHub tracker: `Cor-Incorporated/opencode` issues `#1` to `#7`
+
 ### Installation
+
+The commands below install official upstream OpenCode, not this fork-specific internal distribution.
+
+This fork currently preserves upstream compatibility and develops an additional internal layer on top. If Cor-Incorporated publishes its own install path or renamed distribution, that should be documented separately from the upstream install instructions below.
 
 ```bash
 # YOLO
@@ -121,6 +141,13 @@ Pour plus d'informations sur la configuration d'OpenCode, [**consultez notre doc
 Si vous souhaitez contribuer à OpenCode, lisez nos [docs de contribution](./CONTRIBUTING.md) avant de soumettre une pull request.
 
 ### Construire avec OpenCode
+
+For this fork specifically, the correct framing is:
+
+- forked from OpenCode
+- keeps upstream compatibility where practical
+- extends it into a Cor-Incorporated internal tool through a separate guardrail layer
+- should not be presented as an official upstream OpenCode release
 
 Si vous travaillez sur un projet lié à OpenCode et que vous utilisez "opencode" dans le nom du projet (par exemple, "opencode-dashboard" ou "opencode-mobile"), ajoutez une note dans votre README pour préciser qu'il n'est pas construit par l'équipe OpenCode et qu'il n'est pas affilié à nous.
 

--- a/README.gr.md
+++ b/README.gr.md
@@ -43,7 +43,27 @@
 
 ---
 
+### About This Fork
+
+This repository is the Cor-Incorporated fork of OpenCode.
+
+- It tracks upstream OpenCode and keeps compatibility where practical.
+- It adds a thin internal distribution layer rather than a deep rewrite.
+- Internal product work lives under `docs/ai-guardrails/` and `packages/guardrails/`.
+- It is not an official OpenCode team repository or release channel.
+
+If you are reading this fork for internal implementation work, start here:
+
+- Plan and ADRs: `docs/ai-guardrails/README.md`
+- Migration inventory: `docs/ai-guardrails/migration/claude-code-skills-inventory.md`
+- Thin distribution package: `packages/guardrails/`
+- GitHub tracker: `Cor-Incorporated/opencode` issues `#1` to `#7`
+
 ### Εγκατάσταση
+
+The commands below install official upstream OpenCode, not this fork-specific internal distribution.
+
+This fork currently preserves upstream compatibility and develops an additional internal layer on top. If Cor-Incorporated publishes its own install path or renamed distribution, that should be documented separately from the upstream install instructions below.
 
 ```bash
 # YOLO
@@ -121,6 +141,13 @@ XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 Εάν ενδιαφέρεσαι να συνεισφέρεις στο OpenCode, διαβάστε τα [οδηγό χρήσης συνεισφοράς](./CONTRIBUTING.md) πριν υποβάλεις ένα pull request.
 
 ### Δημιουργία πάνω στο OpenCode
+
+For this fork specifically, the correct framing is:
+
+- forked from OpenCode
+- keeps upstream compatibility where practical
+- extends it into a Cor-Incorporated internal tool through a separate guardrail layer
+- should not be presented as an official upstream OpenCode release
 
 Εάν εργάζεσαι σε ένα έργο σχετικό με το OpenCode και χρησιμοποιείτε το "opencode" ως μέρος του ονόματός του, για παράδειγμα "opencode-dashboard" ή "opencode-mobile", πρόσθεσε μια σημείωση στο README σας για να διευκρινίσεις ότι δεν είναι κατασκευασμένο από την ομάδα του OpenCode και δεν έχει καμία σχέση με εμάς.
 

--- a/README.it.md
+++ b/README.it.md
@@ -43,7 +43,27 @@
 
 ---
 
+### About This Fork
+
+This repository is the Cor-Incorporated fork of OpenCode.
+
+- It tracks upstream OpenCode and keeps compatibility where practical.
+- It adds a thin internal distribution layer rather than a deep rewrite.
+- Internal product work lives under `docs/ai-guardrails/` and `packages/guardrails/`.
+- It is not an official OpenCode team repository or release channel.
+
+If you are reading this fork for internal implementation work, start here:
+
+- Plan and ADRs: `docs/ai-guardrails/README.md`
+- Migration inventory: `docs/ai-guardrails/migration/claude-code-skills-inventory.md`
+- Thin distribution package: `packages/guardrails/`
+- GitHub tracker: `Cor-Incorporated/opencode` issues `#1` to `#7`
+
 ### Installazione
+
+The commands below install official upstream OpenCode, not this fork-specific internal distribution.
+
+This fork currently preserves upstream compatibility and develops an additional internal layer on top. If Cor-Incorporated publishes its own install path or renamed distribution, that should be documented separately from the upstream install instructions below.
 
 ```bash
 # YOLO
@@ -121,6 +141,13 @@ Per maggiori informazioni su come configurare OpenCode, [**consulta la nostra do
 Se sei interessato a contribuire a OpenCode, leggi la nostra [guida alla contribuzione](./CONTRIBUTING.md) prima di inviare una pull request.
 
 ### Costruire su OpenCode
+
+For this fork specifically, the correct framing is:
+
+- forked from OpenCode
+- keeps upstream compatibility where practical
+- extends it into a Cor-Incorporated internal tool through a separate guardrail layer
+- should not be presented as an official upstream OpenCode release
 
 Se stai lavorando a un progetto correlato a OpenCode e che utilizza “opencode” come parte del nome (ad esempio “opencode-dashboard” o “opencode-mobile”), aggiungi una nota nel tuo README per chiarire che non è sviluppato dal team OpenCode e che non è affiliato in alcun modo con noi.
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -43,7 +43,27 @@
 
 ---
 
+### About This Fork
+
+This repository is the Cor-Incorporated fork of OpenCode.
+
+- It tracks upstream OpenCode and keeps compatibility where practical.
+- It adds a thin internal distribution layer rather than a deep rewrite.
+- Internal product work lives under `docs/ai-guardrails/` and `packages/guardrails/`.
+- It is not an official OpenCode team repository or release channel.
+
+If you are reading this fork for internal implementation work, start here:
+
+- Plan and ADRs: `docs/ai-guardrails/README.md`
+- Migration inventory: `docs/ai-guardrails/migration/claude-code-skills-inventory.md`
+- Thin distribution package: `packages/guardrails/`
+- GitHub tracker: `Cor-Incorporated/opencode` issues `#1` to `#7`
+
 ### インストール
+
+The commands below install official upstream OpenCode, not this fork-specific internal distribution.
+
+This fork currently preserves upstream compatibility and develops an additional internal layer on top. If Cor-Incorporated publishes its own install path or renamed distribution, that should be documented separately from the upstream install instructions below.
 
 ```bash
 # YOLO
@@ -121,6 +141,13 @@ OpenCode の設定については [**ドキュメント**](https://opencode.ai/d
 OpenCode に貢献したい場合は、Pull Request を送る前に [contributing docs](./CONTRIBUTING.md) を読んでください。
 
 ### OpenCode の上に構築する
+
+For this fork specifically, the correct framing is:
+
+- forked from OpenCode
+- keeps upstream compatibility where practical
+- extends it into a Cor-Incorporated internal tool through a separate guardrail layer
+- should not be presented as an official upstream OpenCode release
 
 OpenCode に関連するプロジェクトで、名前に "opencode"（例: "opencode-dashboard" や "opencode-mobile"）を含める場合は、そのプロジェクトが OpenCode チームによって作られたものではなく、いかなる形でも関係がないことを README に明記してください。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -43,7 +43,27 @@
 
 ---
 
+### About This Fork
+
+This repository is the Cor-Incorporated fork of OpenCode.
+
+- It tracks upstream OpenCode and keeps compatibility where practical.
+- It adds a thin internal distribution layer rather than a deep rewrite.
+- Internal product work lives under `docs/ai-guardrails/` and `packages/guardrails/`.
+- It is not an official OpenCode team repository or release channel.
+
+If you are reading this fork for internal implementation work, start here:
+
+- Plan and ADRs: `docs/ai-guardrails/README.md`
+- Migration inventory: `docs/ai-guardrails/migration/claude-code-skills-inventory.md`
+- Thin distribution package: `packages/guardrails/`
+- GitHub tracker: `Cor-Incorporated/opencode` issues `#1` to `#7`
+
 ### 설치
+
+The commands below install official upstream OpenCode, not this fork-specific internal distribution.
+
+This fork currently preserves upstream compatibility and develops an additional internal layer on top. If Cor-Incorporated publishes its own install path or renamed distribution, that should be documented separately from the upstream install instructions below.
 
 ```bash
 # YOLO
@@ -121,6 +141,13 @@ OpenCode 설정에 대한 자세한 내용은 [**문서**](https://opencode.ai/d
 OpenCode 에 기여하고 싶다면, Pull Request 를 제출하기 전에 [contributing docs](./CONTRIBUTING.md) 를 읽어주세요.
 
 ### OpenCode 기반으로 만들기
+
+For this fork specifically, the correct framing is:
+
+- forked from OpenCode
+- keeps upstream compatibility where practical
+- extends it into a Cor-Incorporated internal tool through a separate guardrail layer
+- should not be presented as an official upstream OpenCode release
 
 OpenCode 와 관련된 프로젝트를 진행하면서 이름에 "opencode"(예: "opencode-dashboard" 또는 "opencode-mobile") 를 포함한다면, README 에 해당 프로젝트가 OpenCode 팀이 만든 것이 아니며 어떤 방식으로도 우리와 제휴되어 있지 않다는 점을 명시해 주세요.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,31 @@
 
 ---
 
-### Installation
+### About This Fork
+
+This repository is the Cor-Incorporated fork of OpenCode.
+
+- It tracks upstream OpenCode and aims to keep compatibility wherever practical.
+- It adds an internal thin distribution layer rather than turning the fork into a deep rewrite.
+- Its current internal product work lives under `docs/ai-guardrails/` and `packages/guardrails/`.
+- It is not an official OpenCode team repository or release channel.
+
+The intended positioning is:
+
+> OpenCode-compatible foundation, evolved into a Cor-Incorporated internal tool through managed config, plugins, commands, permissions, and workflow policy.
+
+If you are reading this fork for internal implementation work, start here:
+
+- Plan and ADRs: `docs/ai-guardrails/README.md`
+- Migration inventory: `docs/ai-guardrails/migration/claude-code-skills-inventory.md`
+- Thin distribution package: `packages/guardrails/`
+- GitHub tracker: `Cor-Incorporated/opencode` issues `#1` to `#7`
+
+### Upstream Installation
+
+The commands below install official upstream OpenCode, not this fork-specific internal distribution.
+
+This fork currently preserves upstream compatibility and develops an additional internal layer on top. If and when Cor-Incorporated publishes its own install path or renamed distribution, that should be documented separately from the upstream install instructions below.
 
 ```bash
 # YOLO
@@ -134,6 +158,13 @@ If you're interested in contributing to OpenCode, please read our [contributing 
 ### Building on OpenCode
 
 If you are working on a project that's related to OpenCode and is using "opencode" as part of its name, for example "opencode-dashboard" or "opencode-mobile", please add a note to your README to clarify that it is not built by the OpenCode team and is not affiliated with us in any way.
+
+For this fork specifically, the right framing is:
+
+- forked from OpenCode
+- maintains compatibility with upstream where possible
+- extends it into a Cor-Incorporated internal tool through a separate guardrail layer
+- should not be presented as an official upstream OpenCode release
 
 ### FAQ
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,17 @@ Learn more about [agents](https://opencode.ai/docs/agents).
 
 For more info on how to configure OpenCode, [**head over to our docs**](https://opencode.ai/docs).
 
+### Internal Guardrails
+
+The Cor-Incorporated fork is building an internal thin distribution on top of upstream OpenCode rather than a deep product fork.
+
+- Plan and ADRs: `docs/ai-guardrails/README.md`
+- Claude asset migration inventory: `docs/ai-guardrails/migration/claude-code-skills-inventory.md`
+- Packaged distribution layer: `packages/guardrails/`
+- GitHub tracker: epic `#1` and workstreams `#2` to `#7` on `Cor-Incorporated/opencode`
+
+The operating model follows the same philosophy captured in `claude-code-skills` epic `#130`: mechanism-first guardrails, fast feedback, pointer-based instructions, and system-level verification instead of assuming that code presence means runtime correctness.
+
 ### Contributing
 
 If you're interested in contributing to OpenCode, please read our [contributing docs](./CONTRIBUTING.md) before submitting a pull request.

--- a/README.no.md
+++ b/README.no.md
@@ -43,7 +43,27 @@
 
 ---
 
+### About This Fork
+
+This repository is the Cor-Incorporated fork of OpenCode.
+
+- It tracks upstream OpenCode and keeps compatibility where practical.
+- It adds a thin internal distribution layer rather than a deep rewrite.
+- Internal product work lives under `docs/ai-guardrails/` and `packages/guardrails/`.
+- It is not an official OpenCode team repository or release channel.
+
+If you are reading this fork for internal implementation work, start here:
+
+- Plan and ADRs: `docs/ai-guardrails/README.md`
+- Migration inventory: `docs/ai-guardrails/migration/claude-code-skills-inventory.md`
+- Thin distribution package: `packages/guardrails/`
+- GitHub tracker: `Cor-Incorporated/opencode` issues `#1` to `#7`
+
 ### Installasjon
+
+The commands below install official upstream OpenCode, not this fork-specific internal distribution.
+
+This fork currently preserves upstream compatibility and develops an additional internal layer on top. If Cor-Incorporated publishes its own install path or renamed distribution, that should be documented separately from the upstream install instructions below.
 
 ```bash
 # YOLO
@@ -121,6 +141,13 @@ For mer info om hvordan du konfigurerer OpenCode, [**se dokumentasjonen**](https
 Hvis du vil bidra til OpenCode, les [contributing docs](./CONTRIBUTING.md) før du sender en pull request.
 
 ### Bygge på OpenCode
+
+For this fork specifically, the correct framing is:
+
+- forked from OpenCode
+- keeps upstream compatibility where practical
+- extends it into a Cor-Incorporated internal tool through a separate guardrail layer
+- should not be presented as an official upstream OpenCode release
 
 Hvis du jobber med et prosjekt som er relatert til OpenCode og bruker "opencode" som en del av navnet; for eksempel "opencode-dashboard" eller "opencode-mobile", legg inn en merknad i README som presiserer at det ikke er bygget av OpenCode-teamet og ikke er tilknyttet oss på noen måte.
 

--- a/README.pl.md
+++ b/README.pl.md
@@ -43,7 +43,27 @@
 
 ---
 
+### About This Fork
+
+This repository is the Cor-Incorporated fork of OpenCode.
+
+- It tracks upstream OpenCode and keeps compatibility where practical.
+- It adds a thin internal distribution layer rather than a deep rewrite.
+- Internal product work lives under `docs/ai-guardrails/` and `packages/guardrails/`.
+- It is not an official OpenCode team repository or release channel.
+
+If you are reading this fork for internal implementation work, start here:
+
+- Plan and ADRs: `docs/ai-guardrails/README.md`
+- Migration inventory: `docs/ai-guardrails/migration/claude-code-skills-inventory.md`
+- Thin distribution package: `packages/guardrails/`
+- GitHub tracker: `Cor-Incorporated/opencode` issues `#1` to `#7`
+
 ### Instalacja
+
+The commands below install official upstream OpenCode, not this fork-specific internal distribution.
+
+This fork currently preserves upstream compatibility and develops an additional internal layer on top. If Cor-Incorporated publishes its own install path or renamed distribution, that should be documented separately from the upstream install instructions below.
 
 ```bash
 # YOLO
@@ -121,6 +141,13 @@ Więcej informacji o konfiguracji OpenCode znajdziesz w [**dokumentacji**](https
 Jeśli chcesz współtworzyć OpenCode, przeczytaj [contributing docs](./CONTRIBUTING.md) przed wysłaniem pull requesta.
 
 ### Budowanie na OpenCode
+
+For this fork specifically, the correct framing is:
+
+- forked from OpenCode
+- keeps upstream compatibility where practical
+- extends it into a Cor-Incorporated internal tool through a separate guardrail layer
+- should not be presented as an official upstream OpenCode release
 
 Jeśli pracujesz nad projektem związanym z OpenCode i używasz "opencode" jako części nazwy (na przykład "opencode-dashboard" lub "opencode-mobile"), dodaj proszę notatkę do swojego README, aby wyjaśnić, że projekt nie jest tworzony przez zespół OpenCode i nie jest z nami w żaden sposób powiązany.
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -43,7 +43,27 @@
 
 ---
 
+### About This Fork
+
+This repository is the Cor-Incorporated fork of OpenCode.
+
+- It tracks upstream OpenCode and keeps compatibility where practical.
+- It adds a thin internal distribution layer rather than a deep rewrite.
+- Internal product work lives under `docs/ai-guardrails/` and `packages/guardrails/`.
+- It is not an official OpenCode team repository or release channel.
+
+If you are reading this fork for internal implementation work, start here:
+
+- Plan and ADRs: `docs/ai-guardrails/README.md`
+- Migration inventory: `docs/ai-guardrails/migration/claude-code-skills-inventory.md`
+- Thin distribution package: `packages/guardrails/`
+- GitHub tracker: `Cor-Incorporated/opencode` issues `#1` to `#7`
+
 ### Установка
+
+The commands below install official upstream OpenCode, not this fork-specific internal distribution.
+
+This fork currently preserves upstream compatibility and develops an additional internal layer on top. If Cor-Incorporated publishes its own install path or renamed distribution, that should be documented separately from the upstream install instructions below.
 
 ```bash
 # YOLO
@@ -121,6 +141,13 @@ XDG_BIN_DIR=$HOME/.local/bin curl -fsSL https://opencode.ai/install | bash
 Если вы хотите внести вклад в OpenCode, прочитайте [contributing docs](./CONTRIBUTING.md) перед тем, как отправлять pull request.
 
 ### Разработка на базе OpenCode
+
+For this fork specifically, the correct framing is:
+
+- forked from OpenCode
+- keeps upstream compatibility where practical
+- extends it into a Cor-Incorporated internal tool through a separate guardrail layer
+- should not be presented as an official upstream OpenCode release
 
 Если вы делаете проект, связанный с OpenCode, и используете "opencode" как часть имени (например, "opencode-dashboard" или "opencode-mobile"), добавьте примечание в README, чтобы уточнить, что проект не создан командой OpenCode и не аффилирован с нами.
 

--- a/README.th.md
+++ b/README.th.md
@@ -43,7 +43,27 @@
 
 ---
 
+### About This Fork
+
+This repository is the Cor-Incorporated fork of OpenCode.
+
+- It tracks upstream OpenCode and keeps compatibility where practical.
+- It adds a thin internal distribution layer rather than a deep rewrite.
+- Internal product work lives under `docs/ai-guardrails/` and `packages/guardrails/`.
+- It is not an official OpenCode team repository or release channel.
+
+If you are reading this fork for internal implementation work, start here:
+
+- Plan and ADRs: `docs/ai-guardrails/README.md`
+- Migration inventory: `docs/ai-guardrails/migration/claude-code-skills-inventory.md`
+- Thin distribution package: `packages/guardrails/`
+- GitHub tracker: `Cor-Incorporated/opencode` issues `#1` to `#7`
+
 ### การติดตั้ง
+
+The commands below install official upstream OpenCode, not this fork-specific internal distribution.
+
+This fork currently preserves upstream compatibility and develops an additional internal layer on top. If Cor-Incorporated publishes its own install path or renamed distribution, that should be documented separately from the upstream install instructions below.
 
 ```bash
 # YOLO
@@ -121,6 +141,13 @@ OpenCode รวมเอเจนต์ในตัวสองตัวที�
 หากคุณสนใจที่จะมีส่วนร่วมใน OpenCode โปรดอ่าน [เอกสารการมีส่วนร่วม](./CONTRIBUTING.md) ก่อนส่ง Pull Request
 
 ### การสร้างบน OpenCode
+
+For this fork specifically, the correct framing is:
+
+- forked from OpenCode
+- keeps upstream compatibility where practical
+- extends it into a Cor-Incorporated internal tool through a separate guardrail layer
+- should not be presented as an official upstream OpenCode release
 
 หากคุณทำงานในโปรเจกต์ที่เกี่ยวข้องกับ OpenCode และใช้ "opencode" เป็นส่วนหนึ่งของชื่อ เช่น "opencode-dashboard" หรือ "opencode-mobile" โปรดเพิ่มหมายเหตุใน README ของคุณเพื่อชี้แจงว่าไม่ได้สร้างโดยทีม OpenCode และไม่ได้เกี่ยวข้องกับเราในทางใด
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -43,7 +43,27 @@
 
 ---
 
+### About This Fork
+
+This repository is the Cor-Incorporated fork of OpenCode.
+
+- It tracks upstream OpenCode and keeps compatibility where practical.
+- It adds a thin internal distribution layer rather than a deep rewrite.
+- Internal product work lives under `docs/ai-guardrails/` and `packages/guardrails/`.
+- It is not an official OpenCode team repository or release channel.
+
+If you are reading this fork for internal implementation work, start here:
+
+- Plan and ADRs: `docs/ai-guardrails/README.md`
+- Migration inventory: `docs/ai-guardrails/migration/claude-code-skills-inventory.md`
+- Thin distribution package: `packages/guardrails/`
+- GitHub tracker: `Cor-Incorporated/opencode` issues `#1` to `#7`
+
 ### Kurulum
+
+The commands below install official upstream OpenCode, not this fork-specific internal distribution.
+
+This fork currently preserves upstream compatibility and develops an additional internal layer on top. If Cor-Incorporated publishes its own install path or renamed distribution, that should be documented separately from the upstream install instructions below.
 
 ```bash
 # YOLO
@@ -121,6 +141,13 @@ OpenCode'u nasıl yapılandıracağınız hakkında daha fazla bilgi için [**do
 OpenCode'a katkıda bulunmak istiyorsanız, lütfen bir pull request göndermeden önce [katkıda bulunma dokümanlarımızı](./CONTRIBUTING.md) okuyun.
 
 ### OpenCode Üzerine Geliştirme
+
+For this fork specifically, the correct framing is:
+
+- forked from OpenCode
+- keeps upstream compatibility where practical
+- extends it into a Cor-Incorporated internal tool through a separate guardrail layer
+- should not be presented as an official upstream OpenCode release
 
 OpenCode ile ilgili bir proje üzerinde çalışıyorsanız ve projenizin adının bir parçası olarak "opencode" kullanıyorsanız (örneğin, "opencode-dashboard" veya "opencode-mobile"), lütfen README dosyanıza projenin OpenCode ekibi tarafından geliştirilmediğini ve bizimle hiçbir şekilde bağlantılı olmadığını belirten bir not ekleyin.
 

--- a/README.uk.md
+++ b/README.uk.md
@@ -43,7 +43,27 @@
 
 ---
 
+### About This Fork
+
+This repository is the Cor-Incorporated fork of OpenCode.
+
+- It tracks upstream OpenCode and keeps compatibility where practical.
+- It adds a thin internal distribution layer rather than a deep rewrite.
+- Internal product work lives under `docs/ai-guardrails/` and `packages/guardrails/`.
+- It is not an official OpenCode team repository or release channel.
+
+If you are reading this fork for internal implementation work, start here:
+
+- Plan and ADRs: `docs/ai-guardrails/README.md`
+- Migration inventory: `docs/ai-guardrails/migration/claude-code-skills-inventory.md`
+- Thin distribution package: `packages/guardrails/`
+- GitHub tracker: `Cor-Incorporated/opencode` issues `#1` to `#7`
+
 ### Встановлення
+
+The commands below install official upstream OpenCode, not this fork-specific internal distribution.
+
+This fork currently preserves upstream compatibility and develops an additional internal layer on top. If Cor-Incorporated publishes its own install path or renamed distribution, that should be documented separately from the upstream install instructions below.
 
 ```bash
 # YOLO
@@ -121,6 +141,13 @@ OpenCode містить два вбудовані агенти, між яким�
 Якщо ви хочете зробити внесок в OpenCode, будь ласка, прочитайте нашу [документацію для контриб'юторів](./CONTRIBUTING.md) перед надсиланням pull request.
 
 ### Проєкти на базі OpenCode
+
+For this fork specifically, the correct framing is:
+
+- forked from OpenCode
+- keeps upstream compatibility where practical
+- extends it into a Cor-Incorporated internal tool through a separate guardrail layer
+- should not be presented as an official upstream OpenCode release
 
 Якщо ви працюєте над проєктом, пов'язаним з OpenCode, і використовуєте "opencode" у назві, наприклад "opencode-dashboard" або "opencode-mobile", додайте примітку до свого README.
 Уточніть, що цей проєкт не створений командою OpenCode і жодним чином не афілійований із нами.

--- a/README.vi.md
+++ b/README.vi.md
@@ -43,7 +43,27 @@
 
 ---
 
+### About This Fork
+
+This repository is the Cor-Incorporated fork of OpenCode.
+
+- It tracks upstream OpenCode and keeps compatibility where practical.
+- It adds a thin internal distribution layer rather than a deep rewrite.
+- Internal product work lives under `docs/ai-guardrails/` and `packages/guardrails/`.
+- It is not an official OpenCode team repository or release channel.
+
+If you are reading this fork for internal implementation work, start here:
+
+- Plan and ADRs: `docs/ai-guardrails/README.md`
+- Migration inventory: `docs/ai-guardrails/migration/claude-code-skills-inventory.md`
+- Thin distribution package: `packages/guardrails/`
+- GitHub tracker: `Cor-Incorporated/opencode` issues `#1` to `#7`
+
 ### Cài đặt
+
+The commands below install official upstream OpenCode, not this fork-specific internal distribution.
+
+This fork currently preserves upstream compatibility and develops an additional internal layer on top. If Cor-Incorporated publishes its own install path or renamed distribution, that should be documented separately from the upstream install instructions below.
 
 ```bash
 # YOLO
@@ -121,6 +141,13 @@ Tìm hiểu thêm về [agents](https://opencode.ai/docs/agents).
 Nếu bạn muốn đóng góp cho OpenCode, vui lòng đọc [tài liệu hướng dẫn đóng góp](./CONTRIBUTING.md) trước khi gửi pull request.
 
 ### Xây dựng trên nền tảng OpenCode
+
+For this fork specifically, the correct framing is:
+
+- forked from OpenCode
+- keeps upstream compatibility where practical
+- extends it into a Cor-Incorporated internal tool through a separate guardrail layer
+- should not be presented as an official upstream OpenCode release
 
 Nếu bạn đang làm việc trên một dự án liên quan đến OpenCode và sử dụng "opencode" như một phần của tên dự án, ví dụ "opencode-dashboard" hoặc "opencode-mobile", vui lòng thêm một ghi chú vào README của bạn để làm rõ rằng dự án đó không được xây dựng bởi đội ngũ OpenCode và không liên kết với chúng tôi dưới bất kỳ hình thức nào.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -43,7 +43,27 @@
 
 ---
 
+### About This Fork
+
+This repository is the Cor-Incorporated fork of OpenCode.
+
+- It tracks upstream OpenCode and keeps compatibility where practical.
+- It adds a thin internal distribution layer rather than a deep rewrite.
+- Internal product work lives under `docs/ai-guardrails/` and `packages/guardrails/`.
+- It is not an official OpenCode team repository or release channel.
+
+If you are reading this fork for internal implementation work, start here:
+
+- Plan and ADRs: `docs/ai-guardrails/README.md`
+- Migration inventory: `docs/ai-guardrails/migration/claude-code-skills-inventory.md`
+- Thin distribution package: `packages/guardrails/`
+- GitHub tracker: `Cor-Incorporated/opencode` issues `#1` to `#7`
+
 ### 安装
+
+The commands below install official upstream OpenCode, not this fork-specific internal distribution.
+
+This fork currently preserves upstream compatibility and develops an additional internal layer on top. If Cor-Incorporated publishes its own install path or renamed distribution, that should be documented separately from the upstream install instructions below.
 
 ```bash
 # 直接安装 (YOLO)
@@ -120,6 +140,13 @@ OpenCode 内置两种 Agent，可用 `Tab` 键快速切换：
 如有兴趣贡献代码，请在提交 PR 前阅读 [贡献指南 (Contributing Docs)](./CONTRIBUTING.md)。
 
 ### 基于 OpenCode 进行开发
+
+For this fork specifically, the correct framing is:
+
+- forked from OpenCode
+- keeps upstream compatibility where practical
+- extends it into a Cor-Incorporated internal tool through a separate guardrail layer
+- should not be presented as an official upstream OpenCode release
 
 如果你在项目名中使用了 “opencode”（如 “opencode-dashboard” 或 “opencode-mobile”），请在 README 里注明该项目不是 OpenCode 团队官方开发，且不存在隶属关系。
 

--- a/README.zht.md
+++ b/README.zht.md
@@ -43,7 +43,27 @@
 
 ---
 
+### About This Fork
+
+This repository is the Cor-Incorporated fork of OpenCode.
+
+- It tracks upstream OpenCode and keeps compatibility where practical.
+- It adds a thin internal distribution layer rather than a deep rewrite.
+- Internal product work lives under `docs/ai-guardrails/` and `packages/guardrails/`.
+- It is not an official OpenCode team repository or release channel.
+
+If you are reading this fork for internal implementation work, start here:
+
+- Plan and ADRs: `docs/ai-guardrails/README.md`
+- Migration inventory: `docs/ai-guardrails/migration/claude-code-skills-inventory.md`
+- Thin distribution package: `packages/guardrails/`
+- GitHub tracker: `Cor-Incorporated/opencode` issues `#1` to `#7`
+
 ### 安裝
+
+The commands below install official upstream OpenCode, not this fork-specific internal distribution.
+
+This fork currently preserves upstream compatibility and develops an additional internal layer on top. If Cor-Incorporated publishes its own install path or renamed distribution, that should be documented separately from the upstream install instructions below.
 
 ```bash
 # 直接安裝 (YOLO)
@@ -120,6 +140,13 @@ OpenCode 內建了兩種 Agent，您可以使用 `Tab` 鍵快速切換。
 如果您有興趣參與 OpenCode 的開發，請在提交 Pull Request 前先閱讀我們的 [貢獻指南 (Contributing Docs)](./CONTRIBUTING.md)。
 
 ### 基於 OpenCode 進行開發
+
+For this fork specifically, the correct framing is:
+
+- forked from OpenCode
+- keeps upstream compatibility where practical
+- extends it into a Cor-Incorporated internal tool through a separate guardrail layer
+- should not be presented as an official upstream OpenCode release
 
 如果您正在開發與 OpenCode 相關的專案，並在名稱中使用了 "opencode"（例如 "opencode-dashboard" 或 "opencode-mobile"），請在您的 README 中加入聲明，說明該專案並非由 OpenCode 團隊開發，且與我們沒有任何隸屬關係。
 

--- a/bun.lock
+++ b/bun.lock
@@ -297,6 +297,16 @@
         "typescript": "catalog:",
       },
     },
+    "packages/guardrails": {
+      "name": "@opencode-ai/guardrails",
+      "version": "1.3.13",
+      "bin": {
+        "opencode-guardrails": "./bin/opencode-guardrails",
+      },
+      "dependencies": {
+        "opencode": "1.3.13",
+      },
+    },
     "packages/opencode": {
       "name": "opencode",
       "version": "1.3.13",
@@ -1477,6 +1487,8 @@
     "@opencode-ai/enterprise": ["@opencode-ai/enterprise@workspace:packages/enterprise"],
 
     "@opencode-ai/function": ["@opencode-ai/function@workspace:packages/function"],
+
+    "@opencode-ai/guardrails": ["@opencode-ai/guardrails@workspace:packages/guardrails"],
 
     "@opencode-ai/plugin": ["@opencode-ai/plugin@workspace:packages/plugin"],
 

--- a/docs/ai-guardrails/README.md
+++ b/docs/ai-guardrails/README.md
@@ -2,6 +2,19 @@
 
 This document defines the production plan for building an internal AI coding environment on top of OpenCode without turning the repo into a long-lived fork.
 
+## Product framing
+
+The target product should be described consistently across README, issues, and future docs as:
+
+- a Cor-Incorporated fork of OpenCode
+- intentionally upstream-compatible where practical
+- extended through a thin internal distribution layer
+- not an official upstream OpenCode release channel
+
+The migration goal is not to hide the upstream lineage. It is to make the fork legible:
+
+> forked from OpenCode, kept compatible where possible, and evolved into a Cor-Incorporated internal tool through managed config, plugins, commands, permissions, and workflow policy.
+
 ## Operating principles
 
 This plan inherits the key philosophy from `claude-code-skills` epic `#130`, its README, and its ADRs:
@@ -118,6 +131,16 @@ When continuing this work in future sessions:
 - preserve upstream compatibility unless a missing extension point proves otherwise
 - update docs and tests in the same change set when guardrail behavior changes
 - do not mark work complete unless runtime behavior is verified, not just implemented
+
+## Naming note
+
+Renaming the GitHub repository or any published package should be treated as a separate branding/distribution decision, not as part of the guardrail runtime work.
+
+Until that decision is made, the safer default is:
+
+- keep the repository technically close to upstream naming for compatibility
+- update README and planning docs so users understand this is a Cor-Incorporated fork
+- only introduce a new distribution name once install paths, package names, and release ownership are ready together
 
 ## Artifact map
 

--- a/docs/ai-guardrails/README.md
+++ b/docs/ai-guardrails/README.md
@@ -1,0 +1,144 @@
+# OpenCode Internal Guardrails Plan
+
+This document defines the production plan for building an internal AI coding environment on top of OpenCode without turning the repo into a long-lived fork.
+
+## Operating principles
+
+This plan inherits the key philosophy from `claude-code-skills` epic `#130`, its README, and its ADRs:
+
+- enforce quality and safety through mechanism before prose
+- push checks to the fastest reliable layer first
+- keep always-loaded instructions pointer-based and short
+- treat deployment/runtime verification as a separate requirement from code review
+- prefer explicit workflow gates for review, CI, and release-sensitive operations
+
+That means the migration target is not "copy Claude hooks as-is." It is "preserve the operating model using OpenCode-native config, plugins, commands, permissions, and CI."
+
+## Goal
+
+Build a thin internal distribution that keeps OpenCode upstream-friendly while adding:
+
+- managed configuration for enterprise control
+- provider admission policies
+- Claude-compatible skill and rule migration
+- plugin- and command-based guardrails
+- scenario tests that pin critical safety behavior
+
+## Non-goals
+
+- a deep rewrite of OpenCode core
+- default use of preview or free third-party models for confidential code
+- direct AI-driven push, merge, or release without explicit workflow gates
+- always-on remote config, remote instructions, or unbounded MCP expansion
+
+## Baseline facts
+
+- OpenCode already supports `AGENTS.md`, `instructions`, managed config, plugins, commands, permissions, and provider allowlisting.
+- OpenCode already supports Claude-compatible fallbacks for `CLAUDE.md` and `.claude/skills/*/SKILL.md`.
+- OpenCode already supports OpenAI via `/connect`, including ChatGPT Plus/Pro browser auth, and OpenRouter as a first-class provider.
+- OpenRouter exposes routing controls such as provider order, fallback control, data collection policy, and ZDR filtering.
+- Z.AI pricing currently lists GLM-5-Code and related models with a Coding API price sheet.
+
+## Product requirements
+
+### Architecture
+
+- Keep OpenCode as the upstream engine.
+- Add a wrapper distribution, not a deep fork.
+- Store organization defaults in managed config and project config, not in scattered local scripts.
+- Default server exposure to localhost-only and default sharing to disabled.
+
+### Provider policy
+
+- Use Z.AI as the default daily lane.
+- Use OpenAI as the high-confidence escalation lane.
+- Use OpenRouter as an explicit evaluation lane.
+- Gate provider access through `enabled_providers`, `disabled_providers`, managed config, and repo policy.
+- Treat preview, free, or data-collecting models as opt-in only for non-confidential evaluation work.
+
+### Claude asset migration
+
+- Reuse `SKILL.md` assets directly where possible.
+- Move long-lived repo rules into `AGENTS.md` plus `instructions`.
+- Rebuild Claude hooks as OpenCode plugins, commands, or workflow gates.
+- Preserve only organization-specific controls; do not re-implement platform behavior that OpenCode already has.
+
+### Guardrails
+
+- Default to explicit permission policies for `bash`, `edit`, `task`, `webfetch`, and external directories.
+- Block secret reads and unsafe shell patterns through plugin hooks.
+- Move completion gates such as review, CI, and release checks into slash commands and CI policies.
+- Make scenario tests the contract for managed config precedence, Claude-compatible discovery, and plugin hook behavior.
+
+## Delivery phases
+
+1. Freeze architecture decisions in ADRs.
+2. Create issue-sized implementation slices with acceptance criteria.
+3. Lock critical behavior with scenario tests before adding internal product code.
+4. Build the thin distribution pieces:
+   - wrapper CLI
+   - managed config profile
+   - guardrail plugin
+   - safe agents and commands
+   - provider admission policy
+5. Add replay and scenario harness coverage for future regressions.
+
+## Cor-Incorporated roadmap
+
+GitHub tracking lives in the fork, not only in local docs.
+
+- Epic: [#1](https://github.com/Cor-Incorporated/opencode/issues/1) `internal AI guardrails thin distribution for Cor-Incorporated`
+- [#2](https://github.com/Cor-Incorporated/opencode/issues/2) Bootstrap thin distribution
+- [#3](https://github.com/Cor-Incorporated/opencode/issues/3) Claude asset inventory and import
+- [#4](https://github.com/Cor-Incorporated/opencode/issues/4) Guardrail plugin MVP for policy enforcement
+- [#5](https://github.com/Cor-Incorporated/opencode/issues/5) Safe agents and workflow commands
+- [#6](https://github.com/Cor-Incorporated/opencode/issues/6) Provider admission policy
+- [#7](https://github.com/Cor-Incorporated/opencode/issues/7) Scenario and replay harness
+
+## Current status
+
+Done:
+
+- ADRs fixed for architecture, provider lanes, Claude asset migration, and scenario-first delivery
+- scenario coverage added for managed config precedence, Claude-compatible skill discovery, plugin env injection, and compaction context
+- thin distribution package added under `packages/guardrails/`
+- initial migration inventory created from `/Users/teradakousuke/Developer/claude-code-skills`
+
+Next:
+
+- implement issue `#4` using the inventory's `plugin` bucket as the source map
+- then implement issue `#5` for explicit safe workflows instead of relying on ad hoc shell paths
+- keep replay and provider-policy work linked to issues `#6` and `#7`
+
+## Session rule
+
+When continuing this work in future sessions:
+
+- start from the GitHub epic and the linked issue, not from memory
+- preserve upstream compatibility unless a missing extension point proves otherwise
+- update docs and tests in the same change set when guardrail behavior changes
+- do not mark work complete unless runtime behavior is verified, not just implemented
+
+## Artifact map
+
+- ADRs: `docs/ai-guardrails/adr/`
+- Issue briefs: `docs/ai-guardrails/issues/`
+- Migration inventory: `docs/ai-guardrails/migration/`
+- Scenario tests: `packages/opencode/test/scenario/`
+- Thin distribution package: `packages/guardrails/`
+
+## Primary references
+
+- OpenCode config: https://opencode.ai/docs/config
+- OpenCode providers: https://opencode.ai/docs/providers
+- OpenCode plugins: https://opencode.ai/docs/plugins
+- OpenCode rules: https://opencode.ai/docs/rules
+- OpenCode skills: https://opencode.ai/docs/skills
+- OpenCode commands: https://opencode.ai/docs/commands
+- OpenCode agents: https://opencode.ai/docs/agents
+- OpenCode server: https://opencode.ai/docs/server
+- OpenRouter quickstart: https://openrouter.ai/docs/quickstart
+- OpenRouter provider routing: https://openrouter.ai/docs/guides/routing/provider-selection
+- OpenAI Codex web: https://developers.openai.com/codex/cloud
+- ChatGPT pricing: https://chatgpt.com/pricing
+- Z.AI pricing: https://docs.z.ai/guides/overview/pricing

--- a/docs/ai-guardrails/adr/001-thin-distribution-over-deep-fork.md
+++ b/docs/ai-guardrails/adr/001-thin-distribution-over-deep-fork.md
@@ -1,0 +1,38 @@
+# ADR 001: Thin Distribution Over Deep Fork
+
+- Status: Accepted
+- Date: 2026-04-03
+
+## Context
+
+The internal product needs enterprise guardrails, provider policy, and Claude asset migration. OpenCode already exposes the primitives needed to do this through config layering, managed settings, plugins, commands, agents, and server APIs.
+
+A deep fork would create a permanent rebase tax, make upstream updates harder, and encourage product logic to drift into core files that are not unique to the internal distribution.
+
+## Decision
+
+Build the internal product as a thin distribution:
+
+- keep upstream OpenCode pinned and trackable
+- prefer wrapper CLI, managed config, project config, `.opencode` assets, and plugins
+- treat core patches as exceptions that must be justified by a missing extension point
+
+## Consequences
+
+### Positive
+
+- lower upstream merge cost
+- easier security and version upgrades
+- clearer separation between platform behavior and organization policy
+- easier scenario testing because policy lives at the edges
+
+### Negative
+
+- some existing Claude hooks must be redesigned instead of copied 1:1
+- workflow control depends on configuration discipline and tests
+
+## Evidence
+
+- OpenCode config precedence and managed config support: https://opencode.ai/docs/config
+- OpenCode plugins and hook surface: https://opencode.ai/docs/plugins
+- OpenCode commands and agents: https://opencode.ai/docs/commands and https://opencode.ai/docs/agents

--- a/docs/ai-guardrails/adr/002-provider-admission-lanes.md
+++ b/docs/ai-guardrails/adr/002-provider-admission-lanes.md
@@ -1,0 +1,50 @@
+# ADR 002: Provider Admission Lanes
+
+- Status: Accepted
+- Date: 2026-04-03
+
+## Context
+
+The internal tool needs multiple provider lanes:
+
+- a cost-efficient default lane
+- a high-confidence escalation lane
+- an evaluation lane for model exploration
+
+OpenCode supports provider allowlisting and per-provider model config. OpenRouter supports provider routing controls including fallback policy, data collection policy, and ZDR routing.
+
+## Decision
+
+Adopt three provider lanes:
+
+- `zai`: default development lane
+- `openai`: escalation lane for high-confidence or higher-stakes work
+- `openrouter`: evaluation lane only
+
+Admission rules:
+
+- use `enabled_providers` and `disabled_providers` as the first coarse gate
+- keep default sharing disabled and server localhost-only in managed config
+- allow OpenRouter only when the repo policy explicitly permits it
+- do not standardize preview, free, or data-collecting models for confidential repos
+- require evaluation results before promoting any OpenRouter-backed model into a wider lane
+
+## Consequences
+
+### Positive
+
+- clean separation between cost, confidence, and experimentation
+- safer future model churn because policy targets lanes, not one named model
+- lower risk of standardizing unstable preview offerings
+
+### Negative
+
+- additional evaluation work is required before model promotion
+- some teams may want a faster path than the policy allows
+
+## Evidence
+
+- OpenCode provider config and provider allowlists: https://opencode.ai/docs/providers and https://opencode.ai/docs/config
+- OpenAI Codex availability in ChatGPT plans: https://developers.openai.com/codex/cloud and https://chatgpt.com/pricing
+- OpenRouter unified API and routing controls: https://openrouter.ai/docs/quickstart and https://openrouter.ai/docs/guides/routing/provider-selection
+- Z.AI pricing reference: https://docs.z.ai/guides/overview/pricing

--- a/docs/ai-guardrails/adr/003-claude-assets-migrate-by-role.md
+++ b/docs/ai-guardrails/adr/003-claude-assets-migrate-by-role.md
@@ -1,0 +1,45 @@
+# ADR 003: Claude Assets Migrate By Role
+
+- Status: Accepted
+- Date: 2026-04-03
+
+## Context
+
+The source Claude harness contains skills, rules, hooks, and scripts. OpenCode can already read Claude-compatible rule and skill locations, but it does not offer a one-to-one clone of Claude hook semantics.
+
+Trying to copy every hook as-is would create brittle behavior and duplicate platform capabilities that OpenCode already provides.
+
+## Decision
+
+Migrate Claude assets by role:
+
+- skills: reuse directly through `.claude/skills/*/SKILL.md` and `.opencode/skills/*/SKILL.md`
+- rules: move to `AGENTS.md` plus `instructions`
+- hooks: redesign as plugins, commands, or CI workflow gates
+- scripts: keep only when they remain the simplest implementation unit
+
+Hook classes should be triaged into four buckets:
+
+- direct keep
+- plugin rewrite
+- command rewrite
+- drop because OpenCode already covers it
+
+## Consequences
+
+### Positive
+
+- high reuse for skill assets
+- lower migration risk for repo instructions
+- clearer ownership of runtime guardrails
+
+### Negative
+
+- hook inventory and mapping work becomes a dedicated migration task
+- some Claude-only lifecycle semantics need workflow redesign
+
+## Evidence
+
+- OpenCode rules and Claude compatibility: https://opencode.ai/docs/rules
+- OpenCode skills and Claude-compatible discovery: https://opencode.ai/docs/skills
+- OpenCode plugins and commands: https://opencode.ai/docs/plugins and https://opencode.ai/docs/commands

--- a/docs/ai-guardrails/adr/004-scenario-tests-before-productization.md
+++ b/docs/ai-guardrails/adr/004-scenario-tests-before-productization.md
@@ -1,0 +1,38 @@
+# ADR 004: Scenario Tests Before Productization
+
+- Status: Accepted
+- Date: 2026-04-03
+
+## Context
+
+The internal distribution will add policy, not just features. Policy breaks quietly when config precedence, plugin hooks, or compatibility discovery shifts under upstream changes.
+
+Unit tests are necessary but not sufficient. The contract that matters is scenario behavior across config, discovery, and plugin wiring.
+
+## Decision
+
+Add scenario tests before product code for these contracts:
+
+- managed config overrides weaker config layers for enterprise restrictions
+- Claude-compatible skills remain discoverable during migration
+- plugin hooks can inject environment and observe session lifecycle events
+
+Future work should extend this suite with replay tests for release gates, provider admission, and share/server restrictions.
+
+## Consequences
+
+### Positive
+
+- safer upstream upgrades
+- easier AI-driven implementation because expected behavior is executable
+- faster detection of regressions in config precedence and plugin surfaces
+
+### Negative
+
+- test fixtures must stay aligned with evolving config semantics
+
+## Evidence
+
+- OpenCode config precedence and managed settings: https://opencode.ai/docs/config
+- OpenCode plugin events: https://opencode.ai/docs/plugins
+- OpenCode skills and commands: https://opencode.ai/docs/skills and https://opencode.ai/docs/commands

--- a/docs/ai-guardrails/issues/001-bootstrap-thin-distribution.md
+++ b/docs/ai-guardrails/issues/001-bootstrap-thin-distribution.md
@@ -1,0 +1,29 @@
+# Issue 001: Bootstrap Thin Distribution
+
+## Problem
+
+The repo needs a first internal distribution layer that can enforce organization defaults without forking core behavior into unrelated files.
+
+## Deliverables
+
+- wrapper entrypoint for the internal distribution
+- pinned OpenCode version strategy
+- managed config profile for enterprise defaults
+- localhost-only server default
+- default `share: "disabled"`
+
+## Acceptance
+
+- internal launcher resolves to a pinned OpenCode build
+- managed config overrides weaker config layers in tests
+- project config can still add project-local commands, skills, and agents
+
+## Dependencies
+
+- ADR 001
+- ADR 004
+
+## Sources
+
+- https://opencode.ai/docs/config
+- https://opencode.ai/docs/server

--- a/docs/ai-guardrails/issues/002-claude-asset-inventory-and-import.md
+++ b/docs/ai-guardrails/issues/002-claude-asset-inventory-and-import.md
@@ -1,0 +1,38 @@
+# Issue 002: Claude Asset Inventory And Import
+
+## Problem
+
+The Claude harness contains reusable assets, but they are not yet classified by what OpenCode can consume directly versus what must be redesigned.
+
+## Deliverables
+
+- migration inventory for skills, rules, hooks, and scripts
+- direct-import path for Claude-compatible skills
+- `AGENTS.md` plus `instructions` layout for long-form rules
+- hook mapping table with target implementation type:
+  - plugin
+  - command
+  - CI gate
+  - drop
+
+## Acceptance
+
+- the inventory names each hook and assigns a migration bucket
+- at least one representative `.claude/skills/*/SKILL.md` fixture is exercised by scenario tests
+- repo guidance explains when to keep assets in `.claude` versus move them into `.opencode`
+
+## Current artifact
+
+- `docs/ai-guardrails/migration/claude-code-skills-inventory.md`
+
+## Dependencies
+
+- ADR 003
+- Issue 001
+
+## Sources
+
+- https://opencode.ai/docs/rules
+- https://opencode.ai/docs/skills
+- https://opencode.ai/docs/commands
+- https://opencode.ai/docs/plugins

--- a/docs/ai-guardrails/issues/003-guardrail-plugin-mvp.md
+++ b/docs/ai-guardrails/issues/003-guardrail-plugin-mvp.md
@@ -1,0 +1,31 @@
+# Issue 003: Guardrail Plugin MVP
+
+## Problem
+
+Claude hooks that enforced guardrails do not transfer directly. OpenCode plugins are the primary runtime surface for secret blocking, shell environment injection, and lifecycle observation.
+
+## Deliverables
+
+- local or packaged guardrail plugin skeleton
+- secret read blocklist
+- shell environment injection for policy mode
+- lifecycle logging for session and permission events
+- compaction hook stub for future context preservation
+
+## Acceptance
+
+- plugin loads from project config
+- plugin can inject environment through `shell.env`
+- plugin can observe `session.created`
+- plugin tests do not require a deep core patch
+
+## Dependencies
+
+- ADR 001
+- ADR 003
+- ADR 004
+
+## Sources
+
+- https://opencode.ai/docs/plugins
+- https://opencode.ai/docs/permissions

--- a/docs/ai-guardrails/issues/004-safe-agents-and-commands.md
+++ b/docs/ai-guardrails/issues/004-safe-agents-and-commands.md
@@ -1,0 +1,29 @@
+# Issue 004: Safe Agents And Commands
+
+## Problem
+
+Raw built-in agents are too permissive for an internal product. The repo needs a safer default operating model for implementation, review, and release workflows.
+
+## Deliverables
+
+- hardened default primary agent
+- review-oriented subagent
+- slash commands for `/implement`, `/review`, `/ship`, and `/handoff`
+- explicit permission policy for dangerous shell patterns and write operations
+
+## Acceptance
+
+- default agent is not an unrestricted build clone
+- review workflow can run without edit access
+- release workflow cannot bypass explicit gates
+
+## Dependencies
+
+- Issue 001
+- Issue 003
+
+## Sources
+
+- https://opencode.ai/docs/agents
+- https://opencode.ai/docs/commands
+- https://opencode.ai/docs/permissions

--- a/docs/ai-guardrails/issues/005-provider-admission-policy.md
+++ b/docs/ai-guardrails/issues/005-provider-admission-policy.md
@@ -1,0 +1,32 @@
+# Issue 005: Provider Admission Policy
+
+## Problem
+
+The internal distribution needs a stable provider strategy that does not tie product decisions to one transient model name.
+
+## Deliverables
+
+- lane policy for `zai`, `openai`, and `openrouter`
+- provider allowlist and denylist defaults
+- evaluation checklist for OpenRouter-backed candidates
+- confidential-repo restrictions for preview, free, or data-collecting models
+
+## Acceptance
+
+- provider defaults are expressed in config, not only in prose
+- evaluation lane is separate from standard defaults
+- policy references official routing and data controls, not assumptions
+
+## Dependencies
+
+- ADR 002
+- Issue 001
+
+## Sources
+
+- https://opencode.ai/docs/providers
+- https://opencode.ai/docs/config
+- https://openrouter.ai/docs/guides/routing/provider-selection
+- https://developers.openai.com/codex/cloud
+- https://chatgpt.com/pricing
+- https://docs.z.ai/guides/overview/pricing

--- a/docs/ai-guardrails/issues/006-scenario-and-replay-harness.md
+++ b/docs/ai-guardrails/issues/006-scenario-and-replay-harness.md
@@ -1,0 +1,31 @@
+# Issue 006: Scenario And Replay Harness
+
+## Problem
+
+Guardrails are only credible if config precedence, plugin behavior, and migration compatibility are exercised automatically.
+
+## Deliverables
+
+- scenario tests for managed config precedence
+- scenario tests for Claude-compatible skill discovery
+- scenario tests for plugin shell environment injection and lifecycle hooks
+- follow-up plan for replaying release-gate and provider-admission scenarios
+
+## Acceptance
+
+- scenario suite runs under `packages/opencode`
+- the tests are stable on local development machines and CI
+- future guardrail issues can link to specific scenario coverage
+
+## Dependencies
+
+- ADR 004
+- Issue 001
+- Issue 002
+- Issue 003
+
+## Sources
+
+- https://opencode.ai/docs/config
+- https://opencode.ai/docs/plugins
+- https://opencode.ai/docs/skills

--- a/docs/ai-guardrails/issues/README.md
+++ b/docs/ai-guardrails/issues/README.md
@@ -1,0 +1,20 @@
+# AI Guardrails Issue Pack
+
+These issue briefs are intentionally written as implementation slices that can be handed to humans or agents.
+
+## Order
+
+1. `001-bootstrap-thin-distribution.md`
+2. `002-claude-asset-inventory-and-import.md`
+3. `003-guardrail-plugin-mvp.md`
+4. `004-safe-agents-and-commands.md`
+5. `005-provider-admission-policy.md`
+6. `006-scenario-and-replay-harness.md`
+
+## Working rule
+
+No issue is complete unless:
+
+- acceptance criteria are met
+- linked scenario tests are green
+- any required ADR updates are committed in the same change set

--- a/docs/ai-guardrails/migration/claude-code-skills-inventory.md
+++ b/docs/ai-guardrails/migration/claude-code-skills-inventory.md
@@ -1,0 +1,209 @@
+# Claude Asset Inventory
+
+This document maps the source assets in `/Users/teradakousuke/Developer/claude-code-skills` into the thin-distribution plan for OpenCode.
+
+It is intentionally philosophy-first. The migration is not "copy Claude hooks into a new runtime." The goal is to preserve the operating model while moving enforcement onto OpenCode-native extension points.
+
+## Source Philosophy To Preserve
+
+The migration must preserve these non-negotiable ideas from `claude-code-skills` README, epic `#130`, and the source ADRs:
+
+- deterministic quality gates via mechanism, not prompt prose
+- feedback speed hierarchy: fastest possible layer first
+- pointer-based instructions: keep always-loaded instructions short and move detail to ADRs/docs
+- "implemented" is not "working": deployment/runtime integrity must be verified as a system
+- Codex and heavyweight automation are for bounded, mechanical, long-running work
+- GitHub and release gates must not rely on agent goodwill alone
+
+## Migration Rules
+
+### Keep In `.claude`
+
+- third-party Claude-only frameworks that OpenCode does not consume directly
+- source-of-truth migration fixtures during the transition
+- local reference assets used to compare behavior against the original harness
+
+### Move To `.opencode`
+
+- organization-owned `SKILL.md` assets that OpenCode can discover directly
+- project-local commands, agents, and plugins
+- runtime guardrails that belong in the OpenCode config/profile layer
+
+### Move To `AGENTS.md` And `instructions`
+
+- short routing rules
+- prohibitions that point to plugins, commands, CI, or ADRs
+- numeric thresholds and workflow entrypoints
+
+### Move To CI Or Git Provider Policy
+
+- merge gates
+- review freshness requirements
+- branch protection
+- post-merge automations
+- deployment verification that must remain authoritative outside the local client
+
+### Drop
+
+- Claude-specific hook deployment integrity logic
+- settings-local hook override protection that exists only because of Claude's hook model
+- features already covered by OpenCode runtime behavior or by the thin-distribution packaging model
+
+## Skills
+
+These skills are direct-reuse candidates. OpenCode already discovers `.claude/skills/*/SKILL.md`, so the first migration step is to keep them intact and only move them into `.opencode/skills/` when ownership, naming, and packaging are stable.
+
+| Asset | Target | Notes |
+|---|---|---|
+| `adk-engineer` | direct keep | OpenCode-compatible `SKILL.md` asset. |
+| `agent-orchestrator` | direct keep | High-value source for future safe-agent orchestration. |
+| `brainstorming` | direct keep | Pure prompt asset. |
+| `bugfix` | direct keep | Pure prompt asset. |
+| `changelog-generator` | direct keep | Pure prompt asset. |
+| `classify-review` | direct keep | Pure prompt asset; may later pair with GitHub command. |
+| `code-reviewer` | direct keep | Core review asset. |
+| `codex-review` | direct keep | Review asset that may later pair with wrapper commands. |
+| `context7-skills` | direct keep | Prompt asset; tool wiring is separate. |
+| `developer-growth-analysis` | direct keep | Prompt asset. |
+| `file-organizer` | direct keep | Prompt asset. |
+| `gcp-deploy-guardian` | direct keep | Prompt asset; runtime enforcement is separate. |
+| `git-commit-helper` | direct keep | Prompt asset; commit gate remains outside skill. |
+| `gws-workspace` | direct keep | Prompt asset. |
+| `modern-architecture` | direct keep | Prompt asset. |
+| `review-loop` | direct keep | Prompt asset; may later call OpenCode commands. |
+| `security-review` | direct keep | Prompt asset. |
+| `senior-architect` | direct keep | Prompt asset. |
+| `senior-backend` | direct keep | Prompt asset. |
+| `senior-frontend` | direct keep | Prompt asset. |
+| `senior-fullstack` | direct keep | Prompt asset. |
+| `skill-creator` | direct keep | Prompt asset. |
+| `supabase-nextjs-debugger` | direct keep | Prompt asset. |
+| `tdd-workflow` | direct keep | Prompt asset; gate logic moves elsewhere. |
+| `test-falsify` | direct keep | Prompt asset. |
+| `ui-design-system` | direct keep | Prompt asset. |
+| `ui-skills` | direct keep | Prompt asset. |
+| `ux-researcher-designer` | direct keep | Prompt asset. |
+
+## Rules
+
+Rules should not be copied verbatim into always-loaded OpenCode instructions. They should be compressed into pointers, with enforcement moved into plugins, commands, or CI.
+
+| Asset | Target | Notes |
+|---|---|---|
+| `rules/coding-style.md` | `AGENTS.md` + plugin pointers | Keep short style constraints and point to plugin/CI for enforcement. |
+| `rules/delegation.md` | `AGENTS.md` + commands | Turn routing into `/implement`, `/review`, `/handoff`, and safe-agent defaults. |
+| `rules/git-workflow.md` | `AGENTS.md` + CI | Keep branch/PR policy as pointers; enforce in CI/provider policy. |
+| `rules/hook-deployment.md` | ADR + tests | Keep the lesson from epic `#130`; do not recreate Claude deployment mechanics. |
+| `rules/quality.md` | `AGENTS.md` + plugin + CI | Keep completion definition and fact-check rules as pointers. |
+| `rules/testing.md` | `AGENTS.md` + commands + CI | Keep test doctrine short; enforce through `/ship` and CI. |
+
+## Hooks
+
+Bucket definitions:
+
+- `plugin`: rewrite onto OpenCode plugin hooks, permissions, or session lifecycle
+- `command`: rewrite as explicit slash-command or wrapper workflow
+- `CI gate`: move to GitHub Actions / branch protection / server-side workflow gate
+- `drop`: do not port directly; either Claude-specific or replaced by packaging/native behavior
+
+| Hook | Target | Why |
+|---|---|---|
+| `audit-docker-build-args.sh` | plugin | Fast local shell policy check before risky docker commands. |
+| `auto-init-permissions.sh` | drop | Replaced by managed config and packaged profile defaults. |
+| `block-codex-mcp.sh` | drop | Codex-MCP-specific policy is not part of the target OpenCode runtime. |
+| `block-local-hooks-write.sh` | plugin | Protect OpenCode config/profile files from unsafe local override edits. |
+| `block-manual-merge-ops.sh` | command | Replace raw merge-path blocking with explicit `/ship` workflow. |
+| `block-merge-without-ci.sh` | CI gate | Branch protection / Actions should remain authoritative. |
+| `block-merge-without-review.sh` | CI gate | Review freshness belongs in GitHub policy, not local shell heuristics alone. |
+| `block-state-file-tampering-bash.sh` | plugin | Direct safety block on shell writes to guardrail state. |
+| `block-state-file-tampering.sh` | plugin | Direct safety block on edit/write access to guardrail state. |
+| `block-version-downgrade.sh` | plugin | Fast local block before weakening runtime/package baselines. |
+| `codex-task-gate.sh` | command | External Codex delegation should go through wrapper commands, not ad hoc shell. |
+| `codex-task-release.sh` | command | Companion state transition for command-mediated Codex delegation. |
+| `context-budget-agent-gate.sh` | plugin | Runtime decision at tool-call time. |
+| `context-budget-edit-write-gate.sh` | plugin | Runtime decision at tool-call time. |
+| `context-budget-read-gate.sh` | plugin | Runtime decision at tool-call time. |
+| `context-budget-reset.sh` | plugin | Session lifecycle state reset belongs in plugin state. |
+| `context-budget-write-gate.sh` | plugin | Runtime decision at tool-call time. |
+| `enforce-architecture-layers.sh` | plugin | Fast local structural reminder after edits. |
+| `enforce-branch-workflow.sh` | CI gate | Branch naming/protection should be authoritative in provider policy. |
+| `enforce-codex-delegation.sh` | plugin | Advisory routing is best decided at runtime before agent/tool use. |
+| `enforce-codex-for-impl.sh` | command | Use explicit `/implement` or delegation workflow instead of shell hooking. |
+| `enforce-deploy-verify-on-pr.sh` | CI gate | Deployment verification should be server-side and reviewable. |
+| `enforce-develop-base.sh` | CI gate | PR base enforcement belongs in provider workflow policy. |
+| `enforce-doc-update-scope.sh` | plugin | Fast local reminder tied to changed files. |
+| `enforce-domain-naming.sh` | plugin | Fast local reminder tied to edited paths. |
+| `enforce-endpoint-dataflow.sh` | plugin | Immediate structural reminder after endpoint edits. |
+| `enforce-factcheck-before-edit.sh` | plugin | Runtime guard before risky edits. |
+| `enforce-factcheck-before-user-request.sh` | plugin | Runtime guard before requesting manual user actions. |
+| `enforce-factcheck-github-ops.sh` | plugin | Runtime guard before GitHub write operations. |
+| `enforce-follow-up-limit.sh` | CI gate | PR lineage policy should be authoritative in Git workflow automation. |
+| `enforce-git-freshness.sh` | plugin | Session-start/runtime reminder in the local client. |
+| `enforce-hook-deploy-after-merge.sh` | drop | Claude hook deployment concern disappears in packaged OpenCode profile model. |
+| `enforce-hook-deploy-integrity.sh` | drop | Claude hook deployment concern disappears in packaged OpenCode profile model. |
+| `enforce-issue-close-verification.sh` | command | Explicit close/ship workflow should require evidence-based acceptance checks. |
+| `enforce-memory-update-on-commit.sh` | command | Commit workflow should carry this check explicitly. |
+| `enforce-post-merge-validation.sh` | CI gate | Post-merge operational checks should survive local client differences. |
+| `enforce-review-reading.sh` | plugin | Fast local reminder/block before risky merge-like operations. |
+| `enforce-seed-data-verification.sh` | CI gate | Data-safety verification belongs in shared automation. |
+| `enforce-soak-time.sh` | CI gate | Release timing policy belongs in server-side merge policy. |
+| `git-commit-guard.sh` | command | Commit path should go through explicit workflow command. |
+| `git-push-guard.sh` | CI gate | Push/branch enforcement should not rely on local hook presence. |
+| `inject-claude-review-helper.py` | command | Keep as helper logic only if needed behind OpenCode review commands. |
+| `inject-claude-review-on-checks.sh` | command | Rewrite as OpenCode/GitHub review workflow command. |
+| `mark-factcheck-done.sh` | plugin | Runtime state transition after successful verification actions. |
+| `post-deploy-verify.sh` | CI gate | Deployment verification must remain shared, visible automation. |
+| `post-lint-format.sh` | plugin | Preserve fastest feedback layer with OpenCode-native hooks. |
+| `post-merge-close-issues.sh` | CI gate | Post-merge GitHub automation belongs in Actions/app workflow. |
+| `post-pr-create-review-trigger.sh` | CI gate | PR lifecycle automation belongs in Actions/app workflow. |
+| `pr-ci-review-gate.sh` | CI gate | Central PR gate should move to GitHub workflow plus optional local preflight command. |
+| `pr-guard.sh` | command | Local preflight belongs in explicit PR/ship command. |
+| `pr-merge-claude-review-gate.sh` | CI gate | Merge gating belongs in provider workflow policy. |
+| `pre-compact-context-save.sh` | plugin | OpenCode already exposes compaction hooks. |
+| `protect-branches.sh` | CI gate | Branch protection should be authoritative in provider policy. |
+| `protect-linter-config.sh` | plugin | Fast local block before config weakening edits. |
+| `record-code-review.sh` | plugin | Runtime state recording after review agents complete. |
+| `record-codex-review.sh` | plugin | Runtime state recording after delegated review completes. |
+| `reset-factcheck.sh` | plugin | Session lifecycle reset belongs in plugin state. |
+| `stop-test-gate.sh` | command | Rewrite as explicit completion/ship verification command. |
+| `task-completion-gate.sh` | command | Rewrite as explicit completion/ship verification command. |
+| `tool-failure-recovery.sh` | plugin | Runtime recovery assistance belongs in plugin lifecycle. |
+| `track-agent-team.sh` | plugin | Runtime state tracking belongs in plugin lifecycle. |
+| `validate-hook-deployment.sh` | drop | Claude hook deployment concern disappears in packaged OpenCode profile model. |
+| `validate-no-local-hooks.sh` | drop | Claude settings-local hook override concern does not carry over directly. |
+| `verify-agent-output.sh` | plugin | Runtime post-execution verification fits OpenCode plugin hooks. |
+| `verify-codex-output.sh` | plugin | Runtime post-execution verification fits OpenCode plugin hooks. |
+| `verify-state-file-integrity.sh` | plugin | Runtime post-execution verification fits OpenCode plugin hooks. |
+| `verify-test-falsifiability.sh` | plugin | Fast local reminder after test file changes. |
+| `workflow-sync-guard.sh` | CI gate | Workflow consistency is best enforced in shared CI. |
+
+## Utility Scripts
+
+| Asset | Target | Notes |
+|---|---|---|
+| `scripts/check-pr-reviews.sh` | CI gate | Server-side review freshness is more trustworthy. |
+| `scripts/codex-orchestrate.sh` | command | Candidate backend for explicit delegation workflows. |
+| `scripts/codex-parallel.sh` | command | Candidate backend for explicit delegation workflows. |
+| `scripts/context-monitor.py` | drop | Useful as reference, not required for MVP OpenCode migration. |
+| `scripts/delivery_score.py` | CI gate | Better as reporting/analytics than local runtime guard. |
+| `scripts/verify-pr-review.sh` | CI gate | Server-side review verification should remain authoritative. |
+
+## Immediate Implications For This Repo
+
+- `Issue 001` should stay thin: wrapper, managed config, packaged profile.
+- `Issue 002` is complete only when this inventory remains current and scenario coverage for `.claude/skills` stays green.
+- `Issue 003` should focus on plugin rewrites that preserve fast feedback and system-level verifiability.
+- `Issue 004` should turn command-bucket items into explicit safe workflows like `/implement`, `/review`, `/ship`, and `/handoff`.
+- `Issue 005` should keep provider policy declarative and independent from one transient model brand.
+
+## What Success Looks Like
+
+Success is not "we copied most files."
+
+Success is:
+
+- OpenCode core remains close to upstream
+- organization policy lives in profile/plugin/command/CI layers
+- direct-reuse skills still work during migration
+- important gates are verifiable in tests or CI
+- no critical workflow depends on a hidden local hook deployment step

--- a/packages/guardrails/README.md
+++ b/packages/guardrails/README.md
@@ -45,6 +45,8 @@ Current contents focus on the first thin-distribution slice:
 - managed enterprise defaults
 - packaged custom config dir profile
 - initial guardrail plugin for shell env injection, secret-path blocking, and compaction context
+- guarded default implementation agent
+- packaged workflow commands for `implement`, `review`, `ship`, and `handoff`
 
 Planned next slices are tracked in the fork:
 

--- a/packages/guardrails/README.md
+++ b/packages/guardrails/README.md
@@ -1,0 +1,63 @@
+# Guardrails Distribution
+
+This package is the thin internal distribution layer for the guardrails plan.
+
+It keeps upstream OpenCode as the runtime and adds organization policy at the edges:
+
+- `bin/opencode-guardrails` sets `OPENCODE_CONFIG_DIR` to the packaged profile and then delegates to the pinned `opencode` dependency
+- `managed/opencode.json` is the admin-managed profile for system deployment
+- `profile/` contains custom-dir assets such as `AGENTS.md`, commands, agents, and plugins
+
+## Design intent
+
+This package exists to preserve the operating model imported from `claude-code-skills` without turning OpenCode into a deep fork.
+
+- mechanism-first guardrails
+- fast feedback before slower workflow gates
+- pointer-based instructions instead of bloated always-loaded prompts
+- runtime verifiability over "the code exists, so it must work"
+
+Those principles come from `claude-code-skills` epic `#130` and are tracked in this fork under `docs/ai-guardrails/`.
+
+## Upstream strategy
+
+- Keep this package version aligned with `packages/opencode/package.json`
+- Upgrade upstream first, then update this package only where the extension surface changed
+- Prefer `managed/` and `profile/` assets over core patches
+
+## Current scope
+
+Current contents focus on the first thin-distribution slice:
+
+- packaged wrapper entrypoint
+- managed enterprise defaults
+- packaged custom config dir profile
+- initial guardrail plugin for shell env injection, secret-path blocking, and compaction context
+
+Planned next slices are tracked in the fork:
+
+- epic [#1](https://github.com/Cor-Incorporated/opencode/issues/1)
+- plugin MVP [#4](https://github.com/Cor-Incorporated/opencode/issues/4)
+- safe agents and commands [#5](https://github.com/Cor-Incorporated/opencode/issues/5)
+- provider policy [#6](https://github.com/Cor-Incorporated/opencode/issues/6)
+- scenario/replay harness [#7](https://github.com/Cor-Incorporated/opencode/issues/7)
+
+## Usage
+
+Run the wrapper directly:
+
+```sh
+opencode-guardrails
+```
+
+It respects an existing `OPENCODE_CONFIG_DIR` so project- or environment-specific overrides can still replace the packaged profile when needed.
+
+## Managed deployment
+
+Copy [managed/opencode.json](/Users/teradakousuke/Developer/opencode/packages/guardrails/managed/opencode.json) into the system managed config directory:
+
+- macOS: `/Library/Application Support/opencode/opencode.json`
+- Linux: `/etc/opencode/opencode.json`
+- Windows: `%ProgramData%\\opencode\\opencode.json`
+
+For macOS MDM deployments, use the same keys in the `ai.opencode.managed` payload that OpenCode already reads through managed preferences.

--- a/packages/guardrails/README.md
+++ b/packages/guardrails/README.md
@@ -2,6 +2,8 @@
 
 This package is the thin internal distribution layer for the guardrails plan.
 
+It should be understood as the Cor-Incorporated-specific layer that sits on top of upstream-compatible OpenCode, not as a separate reimplementation of the core runtime.
+
 It keeps upstream OpenCode as the runtime and adds organization policy at the edges:
 
 - `bin/opencode-guardrails` sets `OPENCODE_CONFIG_DIR` to the packaged profile and then delegates to the pinned `opencode` dependency
@@ -18,6 +20,16 @@ This package exists to preserve the operating model imported from `claude-code-s
 - runtime verifiability over "the code exists, so it must work"
 
 Those principles come from `claude-code-skills` epic `#130` and are tracked in this fork under `docs/ai-guardrails/`.
+
+## Positioning
+
+When describing this package or this fork externally, use wording close to:
+
+- forked from OpenCode
+- compatibility with upstream preserved where practical
+- Cor-Incorporated-specific policy and workflow layer added in `packages/guardrails`
+
+Avoid wording that implies this package replaces OpenCode itself. The intended architecture is still upstream engine plus thin internal distribution.
 
 ## Upstream strategy
 

--- a/packages/guardrails/bin/opencode-guardrails
+++ b/packages/guardrails/bin/opencode-guardrails
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+const child = require("child_process")
+const fs = require("fs")
+const path = require("path")
+
+function fail(msg) {
+  console.error(msg)
+  process.exit(1)
+}
+
+function bin() {
+  const file = require.resolve("opencode/package.json")
+  const root = path.dirname(file)
+  const json = JSON.parse(fs.readFileSync(file, "utf8"))
+  const rel = typeof json.bin === "string" ? json.bin : json.bin?.opencode
+  if (!rel) fail("Failed to resolve opencode bin from dependency")
+  return path.resolve(root, rel)
+}
+
+const dir = path.resolve(__dirname, "..", "profile")
+process.env.OPENCODE_CONFIG_DIR ||= dir
+
+const out = child.spawnSync(bin(), process.argv.slice(2), {
+  stdio: "inherit",
+  env: process.env,
+})
+
+if (out.error) fail(out.error.message)
+process.exit(typeof out.status === "number" ? out.status : 1)

--- a/packages/guardrails/managed/opencode.json
+++ b/packages/guardrails/managed/opencode.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "share": "disabled",
+  "server": {
+    "hostname": "127.0.0.1",
+    "mdns": false
+  },
+  "permission": {
+    "edit": "ask",
+    "task": "ask",
+    "webfetch": "ask",
+    "external_directory": "ask",
+    "bash": {
+      "*": "ask",
+      "rm -rf *": "deny",
+      "sudo *": "deny",
+      "curl * | sh*": "deny",
+      "wget * | sh*": "deny"
+    },
+    "read": {
+      "*": "allow",
+      "*.env": "deny",
+      "*.env.*": "deny",
+      "*.env.example": "allow",
+      "*id_rsa*": "deny",
+      "*id_ed25519*": "deny",
+      "*.pem": "deny",
+      "*.key": "deny",
+      "*.p12": "deny",
+      "*.pfx": "deny",
+      "*.cer": "deny",
+      "*.crt": "deny",
+      "*.der": "deny",
+      "*.kdbx": "deny",
+      "*credentials*": "deny"
+    }
+  }
+}

--- a/packages/guardrails/package.json
+++ b/packages/guardrails/package.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/package.json",
+  "name": "@opencode-ai/guardrails",
+  "version": "1.3.13",
+  "private": true,
+  "type": "module",
+  "license": "MIT",
+  "bin": {
+    "opencode-guardrails": "./bin/opencode-guardrails"
+  },
+  "files": [
+    "bin",
+    "managed",
+    "profile",
+    "README.md"
+  ],
+  "dependencies": {
+    "opencode": "1.3.13"
+  }
+}

--- a/packages/guardrails/profile/AGENTS.md
+++ b/packages/guardrails/profile/AGENTS.md
@@ -1,0 +1,9 @@
+# Guardrail Profile
+
+- Treat this profile as a thin distribution over upstream OpenCode.
+- Prefer config, commands, agents, and plugins over core runtime patches.
+- Prefer mechanism over prose: enforce with plugins, commands, permissions, and CI before adding more instruction text.
+- Keep always-loaded instructions short and pointer-based; move detailed rationale into ADRs and docs.
+- Push checks to the fastest reliable layer first, then fall back to command workflows and CI for authoritative gates.
+- Keep project-local `.opencode` assets working; use them for repo-specific workflows instead of editing this profile unless the rule is organization-wide.
+- Default to review and explicit workflow gates before shipping changes.

--- a/packages/guardrails/profile/AGENTS.md
+++ b/packages/guardrails/profile/AGENTS.md
@@ -6,4 +6,5 @@
 - Keep always-loaded instructions short and pointer-based; move detailed rationale into ADRs and docs.
 - Push checks to the fastest reliable layer first, then fall back to command workflows and CI for authoritative gates.
 - Keep project-local `.opencode` assets working; use them for repo-specific workflows instead of editing this profile unless the rule is organization-wide.
-- Default to review and explicit workflow gates before shipping changes.
+- Default to the guarded `implement` agent instead of raw `build`.
+- Use `/review`, `/ship`, and `/handoff` as explicit workflow gates before shipping changes.

--- a/packages/guardrails/profile/agents/implement.md
+++ b/packages/guardrails/profile/agents/implement.md
@@ -1,0 +1,25 @@
+---
+description: Default guarded implementation agent for internal development workflows.
+mode: primary
+permission:
+  question: allow
+  plan_enter: allow
+  bash:
+    "git checkout -- *": deny
+    "git merge *": deny
+    "git push --force*": deny
+    "git push * --force*": deny
+    "git reset --hard*": deny
+    "gh pr merge *": deny
+---
+
+Implement changes in bounded increments.
+
+Use `/review`, `/ship`, and `/handoff` as explicit workflow gates instead of improvising release steps.
+
+Before claiming completion:
+
+- keep the change aligned to the requested scope
+- prefer profile, plugin, command, and config layers over core runtime patches
+- run the smallest relevant verification that proves the change works
+- call out remaining approvals, CI gates, and release blockers explicitly

--- a/packages/guardrails/profile/agents/review.md
+++ b/packages/guardrails/profile/agents/review.md
@@ -1,0 +1,23 @@
+---
+description: Review changes, risks, and missing checks without editing files.
+mode: subagent
+permission:
+  "*": deny
+  read: allow
+  grep: allow
+  glob: allow
+  list: allow
+  lsp: allow
+  skill: allow
+  webfetch: ask
+  bash:
+    "*": deny
+    "git diff *": allow
+    "git status *": allow
+    "git show *": allow
+    "git log *": allow
+---
+
+Review for regressions, missing validation, and missing verification.
+
+Prefer file-backed findings with concrete evidence. Do not edit files. Call out missing tests and workflow gates when they matter to the change.

--- a/packages/guardrails/profile/commands/handoff.md
+++ b/packages/guardrails/profile/commands/handoff.md
@@ -1,0 +1,19 @@
+---
+description: Produce a structured handoff with guardrail state and pending gates.
+agent: review
+subtask: true
+---
+
+Prepare a handoff for the current work.
+
+Required sections:
+
+- Goal
+- Constraints
+- Guardrail state
+- Files changed
+- Verification
+- Open risks
+- Next steps
+
+Include any pending approvals, denied operations, provider restrictions, or release gates that still block completion.

--- a/packages/guardrails/profile/commands/implement.md
+++ b/packages/guardrails/profile/commands/implement.md
@@ -1,0 +1,15 @@
+---
+description: Implement a bounded change with the guarded primary agent.
+agent: implement
+---
+
+Implement the requested change under the guardrail profile.
+
+Requirements:
+
+- keep the scope bounded to the stated goal
+- prefer upstream-compatible extension points over core runtime patches
+- run the smallest relevant verification before claiming completion
+- if review, ship, or handoff gates are needed, use `/review`, `/ship`, or `/handoff`
+
+$ARGUMENTS

--- a/packages/guardrails/profile/commands/review.md
+++ b/packages/guardrails/profile/commands/review.md
@@ -1,0 +1,16 @@
+---
+description: Review current work with the read-only guardrail review agent.
+agent: review
+subtask: true
+---
+
+Review the current work for correctness, regressions, missing tests, and missing workflow gates.
+
+Required sections:
+
+- Findings
+- Verification
+- Open risks
+- Recommended next step
+
+Default scope is the current uncommitted work unless `$ARGUMENTS` narrows it.

--- a/packages/guardrails/profile/commands/ship.md
+++ b/packages/guardrails/profile/commands/ship.md
@@ -1,0 +1,23 @@
+---
+description: Run a release-readiness gate without edit access.
+agent: review
+subtask: true
+---
+
+Run a release-readiness check for the current work.
+
+Required gates:
+
+- the scope still matches the requested goal
+- relevant verification has been run and cited
+- risky shell or write operations did not bypass policy
+- remaining approvals, CI, provider, or review gates are listed explicitly
+
+Output:
+
+- Ready or Not ready
+- Evidence
+- Blocking gates
+- Next action
+
+Default scope is the current uncommitted work unless `$ARGUMENTS` narrows it.

--- a/packages/guardrails/profile/opencode.json
+++ b/packages/guardrails/profile/opencode.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
+  "default_agent": "implement",
   "share": "disabled",
   "server": {
     "hostname": "127.0.0.1",
@@ -14,6 +15,12 @@
       "*": "ask",
       "rm -rf *": "deny",
       "sudo *": "deny",
+      "git checkout -- *": "deny",
+      "git merge *": "deny",
+      "git push --force*": "deny",
+      "git push * --force*": "deny",
+      "git reset --hard*": "deny",
+      "gh pr merge *": "deny",
       "curl * | sh*": "deny",
       "wget * | sh*": "deny"
     },

--- a/packages/guardrails/profile/opencode.json
+++ b/packages/guardrails/profile/opencode.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "share": "disabled",
+  "server": {
+    "hostname": "127.0.0.1",
+    "mdns": false
+  },
+  "permission": {
+    "edit": "ask",
+    "task": "ask",
+    "webfetch": "ask",
+    "external_directory": "ask",
+    "bash": {
+      "*": "ask",
+      "rm -rf *": "deny",
+      "sudo *": "deny",
+      "curl * | sh*": "deny",
+      "wget * | sh*": "deny"
+    },
+    "read": {
+      "*": "allow",
+      "*.env": "deny",
+      "*.env.*": "deny",
+      "*.env.example": "allow",
+      "*id_rsa*": "deny",
+      "*id_ed25519*": "deny",
+      "*.pem": "deny",
+      "*.key": "deny",
+      "*.p12": "deny",
+      "*.pfx": "deny",
+      "*.cer": "deny",
+      "*.crt": "deny",
+      "*.der": "deny",
+      "*.kdbx": "deny",
+      "*credentials*": "deny"
+    }
+  }
+}

--- a/packages/guardrails/profile/plugins/guardrail.ts
+++ b/packages/guardrails/profile/plugins/guardrail.ts
@@ -1,0 +1,79 @@
+import { appendFile } from "fs/promises"
+import type { Plugin } from "@opencode-ai/plugin"
+
+const mode = process.env.GUARDRAIL_MODE ?? "strict"
+const deny = [
+  ".env",
+  ".env.",
+  "/.ssh/",
+  "/.aws/credentials",
+  "/credentials",
+  "id_rsa",
+  "id_ed25519",
+  ".pem",
+  ".key",
+  ".p12",
+  ".pfx",
+  ".cer",
+  ".crt",
+  ".der",
+  ".kdbx",
+]
+
+function norm(input: string) {
+  return input.replaceAll("\\", "/").toLowerCase()
+}
+
+function pick(tool: string, args: Record<string, unknown>) {
+  if (tool === "read" || tool === "edit" || tool === "write") {
+    return typeof args.filePath === "string" ? [args.filePath] : []
+  }
+
+  if (tool === "list") {
+    return typeof args.path === "string" ? [args.path] : []
+  }
+
+  if (tool === "glob") {
+    return [args.path, args.pattern].filter((item): item is string => typeof item === "string")
+  }
+
+  if (tool === "grep") {
+    return typeof args.path === "string" ? [args.path] : []
+  }
+
+  return []
+}
+
+function hit(tool: string, args: Record<string, unknown>) {
+  const vals = pick(tool, args).map(norm)
+  return vals.find((item) => deny.some((part) => item.includes(part)))
+}
+
+function note(event: string, data: unknown) {
+  const file = process.env.GUARDRAIL_LOG_FILE
+  if (!file) return Promise.resolve()
+  const line = JSON.stringify({ time: Date.now(), event, data }) + "\n"
+  return appendFile(file, line).catch(() => undefined)
+}
+
+const plugin: Plugin = async () => ({
+  event: async ({ event }) => {
+    if (event.type !== "session.created" && event.type !== "permission.asked" && event.type !== "permission.replied") {
+      return
+    }
+    await note(event.type, event.properties)
+  },
+  "shell.env": async (_input, output) => {
+    output.env.GUARDRAIL_MODE = mode
+  },
+  "tool.execute.before": async (input, output) => {
+    const bad = hit(input.tool, output.args as Record<string, unknown>)
+    if (!bad) return
+    throw new Error(`guardrail blocked ${input.tool} access to sensitive path: ${bad}`)
+  },
+  "experimental.session.compacting": async (_input, output) => {
+    output.context.push("Preserve guardrail approvals, denials, and policy mode before compaction.")
+  },
+})
+
+export default plugin

--- a/packages/opencode/test/scenario/guardrails.test.ts
+++ b/packages/opencode/test/scenario/guardrails.test.ts
@@ -1,0 +1,323 @@
+import { afterAll, afterEach, expect, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { pathToFileURL } from "url"
+import { Agent } from "../../src/agent/agent"
+import { Command } from "../../src/command"
+import { Config } from "../../src/config/config"
+import { Instance } from "../../src/project/instance"
+import { Session } from "../../src/session"
+import { Skill } from "../../src/skill"
+import { Filesystem } from "../../src/util/filesystem"
+import { SessionID } from "../../src/session/schema"
+import { tmpdir } from "../fixture/fixture"
+
+const disable = process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS
+process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS = "1"
+
+const { Plugin } = await import("../../src/plugin")
+
+const managed = process.env.OPENCODE_TEST_MANAGED_CONFIG_DIR!
+const profile = path.resolve(import.meta.dir, "../../../guardrails/profile")
+
+afterEach(async () => {
+  await Instance.disposeAll()
+  await fs.rm(managed, { force: true, recursive: true }).catch(() => {})
+  await Config.invalidate(true)
+})
+
+afterAll(() => {
+  if (disable === undefined) {
+    delete process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS
+    return
+  }
+  process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS = disable
+})
+
+async function write(dir: string, file: string, data: object) {
+  await Filesystem.write(path.join(dir, file), JSON.stringify(data, null, 2))
+}
+
+async function managedConfig(data: object) {
+  await fs.mkdir(managed, { recursive: true })
+  await write(managed, "opencode.json", data)
+}
+
+async function pluginProject(dir: string, source: string) {
+  const file = path.join(dir, "guardrail-plugin.ts")
+  await Bun.write(file, source)
+  await write(dir, "opencode.json", {
+    $schema: "https://opencode.ai/config.json",
+    plugin: [pathToFileURL(file).href],
+  })
+  return file
+}
+
+test("managed config overrides project provider and share defaults", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      await write(dir, "opencode.json", {
+        $schema: "https://opencode.ai/config.json",
+        share: "auto",
+        enabled_providers: ["openrouter", "openai"],
+      })
+    },
+  })
+
+  await managedConfig({
+    $schema: "https://opencode.ai/config.json",
+    share: "disabled",
+    enabled_providers: ["zai", "openai"],
+    disabled_providers: ["openrouter"],
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const cfg = await Config.get()
+      expect(cfg.share).toBe("disabled")
+      expect(cfg.enabled_providers).toEqual(["zai", "openai"])
+      expect(cfg.disabled_providers).toEqual(["openrouter"])
+    },
+  })
+})
+
+test("claude-compatible skills remain discoverable and command-addressable", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      await Bun.write(
+        path.join(dir, ".claude", "skills", "review-loop", "SKILL.md"),
+        `---
+name: review-loop
+description: Review loop from Claude-compatible assets.
+---
+
+# Review Loop
+`,
+      )
+      await Bun.write(
+        path.join(dir, ".opencode", "skills", "ship-gate", "SKILL.md"),
+        `---
+name: ship-gate
+description: Internal ship gate skill.
+---
+
+# Ship Gate
+`,
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      const skills = await Skill.all()
+      const cmds = await Command.list()
+
+      expect(skills.map((item) => item.name).sort()).toEqual(["review-loop", "ship-gate"])
+      expect(cmds.some((item) => item.name === "review-loop" && item.source === "skill")).toBe(true)
+      expect(cmds.some((item) => item.name === "ship-gate" && item.source === "skill")).toBe(true)
+    },
+  })
+})
+
+test("project plugin can inject shell environment for policy mode", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      await pluginProject(
+        dir,
+        [
+          "export default async () => ({",
+          '  "shell.env": async (_input, output) => {',
+          '    output.env.GUARDRAIL_MODE = "strict"',
+          "  },",
+          "})",
+          "",
+        ].join("\n"),
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      await Plugin.init()
+      const out = await Plugin.trigger("shell.env", { cwd: tmp.path }, { env: {} as Record<string, string> })
+      expect(out.env.GUARDRAIL_MODE).toBe("strict")
+    },
+  })
+})
+
+test("project plugin can extend compaction context for state handoff", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      await pluginProject(
+        dir,
+        [
+          "export default async () => ({",
+          '  "experimental.session.compacting": async (_input, output) => {',
+          '    output.context.push("Preserve guardrail lock state before compaction.")',
+          '    output.prompt = "Resume with guardrail state restored."',
+          "  },",
+          "})",
+          "",
+        ].join("\n"),
+      )
+    },
+  })
+
+  await Instance.provide({
+    directory: tmp.path,
+    fn: async () => {
+      await Plugin.init()
+      const out = await Plugin.trigger(
+        "experimental.session.compacting",
+        { sessionID: SessionID.make("ses_guardrail") },
+        { context: [] as string[], prompt: undefined as string | undefined },
+      )
+      expect(out.context).toEqual(["Preserve guardrail lock state before compaction."])
+      expect(out.prompt).toBe("Resume with guardrail state restored.")
+    },
+  })
+})
+
+test("guardrail profile keeps internal assets while allowing project-local additions", async () => {
+  const prev = process.env.OPENCODE_CONFIG_DIR
+  process.env.OPENCODE_CONFIG_DIR = profile
+
+  try {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await write(dir, "opencode.json", {
+          $schema: "https://opencode.ai/config.json",
+          share: "auto",
+        })
+        await Bun.write(
+          path.join(dir, ".opencode", "commands", "project-local.md"),
+          `---
+description: Project-local workflow.
+---
+
+Use the project-local command.
+`,
+        )
+        await Bun.write(
+          path.join(dir, ".opencode", "agents", "project-review.md"),
+          `---
+description: Project-local review helper.
+mode: subagent
+permission:
+  "*": deny
+  read: allow
+---
+
+Review local project context only.
+`,
+        )
+        await Bun.write(
+          path.join(dir, ".opencode", "skills", "project-skill", "SKILL.md"),
+          `---
+name: project-skill
+description: Project-local skill.
+---
+
+# Project Skill
+`,
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const cfg = await Config.get()
+        const cmds = await Command.list()
+        const skills = await Skill.all()
+        const agents = await Agent.list()
+
+        expect(cfg.share).toBe("disabled")
+        expect(cfg.server?.hostname).toBe("127.0.0.1")
+        expect(cmds.some((item) => item.name === "handoff")).toBe(true)
+        expect(cmds.some((item) => item.name === "project-local")).toBe(true)
+        expect(skills.some((item) => item.name === "project-skill")).toBe(true)
+        expect(agents.some((item) => item.name === "review")).toBe(true)
+        expect(agents.some((item) => item.name === "project-review")).toBe(true)
+      },
+    })
+  } finally {
+    if (prev === undefined) delete process.env.OPENCODE_CONFIG_DIR
+    else process.env.OPENCODE_CONFIG_DIR = prev
+  }
+})
+
+test("guardrail profile plugin injects env, blocks secret reads, and logs session lifecycle", async () => {
+  const prevDir = process.env.OPENCODE_CONFIG_DIR
+  const prevLog = process.env.GUARDRAIL_LOG_FILE
+  process.env.OPENCODE_CONFIG_DIR = profile
+
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      await Bun.write(path.join(dir, ".env"), "SECRET=1\n")
+    },
+  })
+
+  process.env.GUARDRAIL_LOG_FILE = path.join(tmp.path, "guardrail.jsonl")
+
+  try {
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Plugin.init()
+
+        const env = await Plugin.trigger("shell.env", { cwd: tmp.path }, { env: {} as Record<string, string> })
+        expect(env.env.GUARDRAIL_MODE).toBe("strict")
+
+        await expect(
+          Plugin.trigger(
+            "tool.execute.before",
+            { tool: "read", sessionID: SessionID.make("ses_guardrail_plugin"), callID: "call_guardrail_plugin" },
+            { args: { filePath: path.join(tmp.path, ".env") } },
+          ),
+        ).rejects.toThrow("guardrail blocked read access")
+
+        const session = await Session.create({})
+        const out = await Plugin.trigger(
+          "experimental.session.compacting",
+          { sessionID: session.id },
+          { context: [] as string[], prompt: undefined as string | undefined },
+        )
+        const hooks = await Plugin.list()
+
+        expect(out.context).toContain("Preserve guardrail approvals, denials, and policy mode before compaction.")
+
+        await Promise.all(
+          hooks.map((hook) =>
+            hook.event?.({
+              event: {
+                type: "session.created",
+                properties: {
+                  sessionID: session.id,
+                  info: session,
+                },
+              } as never,
+            }),
+          ),
+        )
+
+        const log = await Bun.file(process.env.GUARDRAIL_LOG_FILE!).text()
+        expect(log).toContain('"event":"session.created"')
+      },
+    })
+  } finally {
+    if (prevDir === undefined) delete process.env.OPENCODE_CONFIG_DIR
+    else process.env.OPENCODE_CONFIG_DIR = prevDir
+    if (prevLog === undefined) delete process.env.GUARDRAIL_LOG_FILE
+    else process.env.GUARDRAIL_LOG_FILE = prevLog
+  }
+})

--- a/packages/opencode/test/scenario/guardrails.test.ts
+++ b/packages/opencode/test/scenario/guardrails.test.ts
@@ -10,6 +10,7 @@ import { Session } from "../../src/session"
 import { Skill } from "../../src/skill"
 import { Filesystem } from "../../src/util/filesystem"
 import { SessionID } from "../../src/session/schema"
+import { Permission } from "../../src/permission"
 import { tmpdir } from "../fixture/fixture"
 
 const disable = process.env.OPENCODE_DISABLE_DEFAULT_PLUGINS
@@ -239,11 +240,26 @@ description: Project-local skill.
         const cmds = await Command.list()
         const skills = await Skill.all()
         const agents = await Agent.list()
+        const name = await Agent.defaultAgent()
+        const implement = await Agent.get("implement")
+        const review = await Agent.get("review")
 
+        expect(cfg.default_agent).toBe("implement")
         expect(cfg.share).toBe("disabled")
         expect(cfg.server?.hostname).toBe("127.0.0.1")
+        expect(name).toBe("implement")
+        expect(implement?.mode).toBe("primary")
+        expect(Permission.evaluate("question", "*", implement?.permission).action).toBe("allow")
+        expect(Permission.evaluate("bash", "git push --force-with-lease origin head", implement?.permission).action).toBe(
+          "deny",
+        )
+        expect(Permission.evaluate("edit", "*", review?.permission).action).toBe("deny")
+        expect(cmds.some((item) => item.name === "implement" && item.agent === "implement")).toBe(true)
+        expect(cmds.some((item) => item.name === "review" && item.agent === "review" && item.subtask)).toBe(true)
+        expect(cmds.some((item) => item.name === "ship" && item.agent === "review" && item.subtask)).toBe(true)
         expect(cmds.some((item) => item.name === "handoff")).toBe(true)
         expect(cmds.some((item) => item.name === "project-local")).toBe(true)
+        expect(agents.some((item) => item.name === "implement")).toBe(true)
         expect(skills.some((item) => item.name === "project-skill")).toBe(true)
         expect(agents.some((item) => item.name === "review")).toBe(true)
         expect(agents.some((item) => item.name === "project-review")).toBe(true)


### PR DESCRIPTION
## Summary
- add the initial `docs/ai-guardrails` plan, ADRs, issue pack, and migration inventory
- add the thin distribution package under `packages/guardrails`
- add scenario coverage for managed config, Claude-compatible skills, plugin env injection, and compaction context
- add fork-specific roadmap links in the root README and guardrails package docs

## GitHub tracker
- closes #2
- references #1, #3, #4, #5, #6, #7

## Philosophy preserved
This PR follows the same principles established in `claude-code-skills` epic #130:

- mechanism-first guardrails
- fast feedback before slower gates
- pointer-based instructions
- runtime/system verification instead of treating code presence as completion

## Verification
- `bun test test/scenario/guardrails.test.ts` in `packages/opencode`
- `bun typecheck` in `packages/opencode`
- `git push` pre-push hook ran `bun turbo typecheck`
