### PR TITLE
feat: add safe agents and workflow commands

### DIFF
--- a/packages/guardrails/README.md
+++ b/packages/guardrails/README.md
@@ -46,7 +46,8 @@ Current contents focus on the first thin-distribution slice:
 - managed enterprise defaults
 - packaged custom config dir profile
 - packaged plugin for runtime guardrail hooks
-- scenario coverage for managed config precedence, project-local asset compatibility, and plugin behavior
+- guarded `implement` and `review` agents plus packaged `/implement`, `/review`, `/ship`, and `/handoff` workflow commands
+- scenario coverage for managed config precedence, project-local asset compatibility, plugin behavior, and workflow safety defaults
 
 Planned next slices are tracked in the fork:
 
@@ -68,6 +69,8 @@ opencode-guardrails
 ```
 
 It respects an existing `OPENCODE_CONFIG_DIR` so project- or environment-specific overrides can still replace the packaged profile when needed.
+
+The packaged profile defaults to the `implement` agent. Review and release-readiness work should run through the packaged `/review`, `/ship`, and `/handoff` commands so the workflow stays read-only at the gate layer.
 
 ## Managed deployment
 

--- a/packages/guardrails/profile/AGENTS.md
+++ b/packages/guardrails/profile/AGENTS.md
@@ -8,3 +8,5 @@
 - Push checks to the fastest reliable layer first, then fall back to command workflows and CI for authoritative gates.
 - Keep project-local `.opencode` assets working; use them for repo-specific workflows instead of editing this profile unless the rule is organization-wide.
 - Treat `.opencode/guardrails/` as plugin-owned runtime state, not a manual editing surface.
+- Use `implement` as the guarded default primary agent. Route review, ship, and handoff work through the packaged `/review`, `/ship`, and `/handoff` commands instead of freeform release flows.
+- Keep review paths read-only. If a workflow needs edits, return to `implement` or a project-local implementation agent instead of widening the review agent.

--- a/packages/guardrails/profile/agents/implement.md
+++ b/packages/guardrails/profile/agents/implement.md
@@ -1,0 +1,25 @@
+---
+description: Default guarded implementation agent for internal development workflows.
+mode: primary
+permission:
+  question: allow
+  plan_enter: allow
+  bash:
+    "git checkout -- *": deny
+    "git merge *": deny
+    "git push --force*": deny
+    "git push * --force*": deny
+    "git reset --hard*": deny
+    "gh pr merge *": deny
+---
+
+Implement changes in bounded increments.
+
+Use `/review`, `/ship`, and `/handoff` as explicit workflow gates instead of improvising release steps.
+
+Before claiming completion:
+
+- keep the change aligned to the requested scope
+- prefer profile, plugin, command, and config layers over core runtime patches
+- run the smallest relevant verification that proves the change works
+- call out remaining approvals, CI gates, and release blockers explicitly

--- a/packages/guardrails/profile/agents/review.md
+++ b/packages/guardrails/profile/agents/review.md
@@ -1,0 +1,23 @@
+---
+description: Review changes, risks, and missing checks without editing files.
+mode: subagent
+permission:
+  "*": deny
+  read: allow
+  grep: allow
+  glob: allow
+  list: allow
+  lsp: allow
+  skill: allow
+  webfetch: ask
+  bash:
+    "*": deny
+    "git diff *": allow
+    "git status *": allow
+    "git show *": allow
+    "git log *": allow
+---
+
+Review for regressions, missing validation, and missing verification.
+
+Prefer file-backed findings with concrete evidence. Do not edit files. Call out missing tests and workflow gates when they matter to the change.

--- a/packages/guardrails/profile/commands/handoff.md
+++ b/packages/guardrails/profile/commands/handoff.md
@@ -1,0 +1,19 @@
+---
+description: Produce a structured handoff with guardrail state and pending gates.
+agent: review
+subtask: true
+---
+
+Prepare a handoff for the current work.
+
+Required sections:
+
+- Goal
+- Constraints
+- Guardrail state
+- Files changed
+- Verification
+- Open risks
+- Next steps
+
+Include any pending approvals, denied operations, provider restrictions, or release gates that still block completion.

--- a/packages/guardrails/profile/commands/implement.md
+++ b/packages/guardrails/profile/commands/implement.md
@@ -1,0 +1,15 @@
+---
+description: Implement a bounded change with the guarded primary agent.
+agent: implement
+---
+
+Implement the requested change under the guardrail profile.
+
+Requirements:
+
+- keep the scope bounded to the stated goal
+- prefer upstream-compatible extension points over core runtime patches
+- run the smallest relevant verification before claiming completion
+- if review, ship, or handoff gates are needed, use `/review`, `/ship`, or `/handoff`
+
+$ARGUMENTS

--- a/packages/guardrails/profile/commands/review.md
+++ b/packages/guardrails/profile/commands/review.md
@@ -1,0 +1,16 @@
+---
+description: Review current work with the read-only guardrail review agent.
+agent: review
+subtask: true
+---
+
+Review the current work for correctness, regressions, missing tests, and missing workflow gates.
+
+Required sections:
+
+- Findings
+- Verification
+- Open risks
+- Recommended next step
+
+Default scope is the current uncommitted work unless `$ARGUMENTS` narrows it.

--- a/packages/guardrails/profile/commands/ship.md
+++ b/packages/guardrails/profile/commands/ship.md
@@ -1,0 +1,23 @@
+---
+description: Run a release-readiness gate without edit access.
+agent: review
+subtask: true
+---
+
+Run a release-readiness check for the current work.
+
+Required gates:
+
+- the scope still matches the requested goal
+- relevant verification has been run and cited
+- risky shell or write operations did not bypass policy
+- remaining approvals, CI, provider, or review gates are listed explicitly
+
+Output:
+
+- Ready or Not ready
+- Evidence
+- Blocking gates
+- Next action
+
+Default scope is the current uncommitted work unless `$ARGUMENTS` narrows it.

--- a/packages/guardrails/profile/opencode.json
+++ b/packages/guardrails/profile/opencode.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
+  "default_agent": "implement",
   "share": "disabled",
   "server": {
     "hostname": "127.0.0.1",
@@ -17,6 +18,12 @@
       "*": "ask",
       "rm -rf *": "deny",
       "sudo *": "deny",
+      "git checkout -- *": "deny",
+      "git merge *": "deny",
+      "git push --force*": "deny",
+      "git push * --force*": "deny",
+      "git reset --hard*": "deny",
+      "gh pr merge *": "deny",
       "curl * | sh*": "deny",
       "wget * | sh*": "deny"
     },

--- a/packages/opencode/test/scenario/guardrails.test.ts
+++ b/packages/opencode/test/scenario/guardrails.test.ts
@@ -4,6 +4,7 @@ import path from "path"
 import { Agent } from "../../src/agent/agent"
 import { Command } from "../../src/command"
 import { Config } from "../../src/config/config"
+import { Permission } from "../../src/permission"
 import { Plugin } from "../../src/plugin"
 import { Instance } from "../../src/project/instance"
 import { Skill } from "../../src/skill"
@@ -50,6 +51,11 @@ function guard(dir: string) {
 
 function wait(ms = 50) {
   return new Promise((done) => setTimeout(done, ms))
+}
+
+function perm(agent: Agent.Info | undefined, key: string, pattern = "*") {
+  if (!agent) return undefined
+  return Permission.evaluate(key, pattern, agent.permission).action
 }
 
 test("managed config overrides weaker project defaults", async () => {
@@ -192,6 +198,63 @@ description: Project-local skill.
         expect(cmds.some((item) => item.name === "project-local")).toBe(true)
         expect(skills.some((item) => item.name === "project-skill")).toBe(true)
         expect(agents.some((item) => item.name === "project-review")).toBe(true)
+      },
+    })
+  })
+})
+
+test("guardrail profile ships safe agents and workflow commands", async () => {
+  await withProfile(async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await write(dir, "opencode.json", {
+          $schema: "https://opencode.ai/config.json",
+          share: "auto",
+        })
+        await Bun.write(
+          path.join(dir, ".opencode", "commands", "project-local.md"),
+          `---
+description: Project-local workflow.
+---
+
+Use the project-local command.
+`,
+        )
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const cfg = await Config.get()
+        const cmds = await Command.list()
+        const impl = await Agent.get("implement")
+        const review = await Agent.get("review")
+
+        expect(cfg.default_agent).toBe("implement")
+        expect(await Agent.defaultAgent()).toBe("implement")
+        expect(impl?.mode).toBe("primary")
+        expect(review?.mode).toBe("subagent")
+        expect(perm(impl, "question")).toBe("allow")
+        expect(perm(impl, "plan_enter")).toBe("allow")
+        expect(perm(impl, "edit")).toBe("ask")
+        expect(perm(impl, "bash", "git reset --hard HEAD")).toBe("deny")
+        expect(perm(impl, "bash", "git push origin --force-with-lease")).toBe("deny")
+        expect(perm(review, "edit")).toBe("deny")
+        expect(perm(review, "read")).toBe("allow")
+        expect(perm(review, "bash", "git diff HEAD")).toBe("allow")
+        expect(perm(review, "bash", "bun test")).toBe("deny")
+
+        const map = Object.fromEntries(cmds.map((item) => [item.name, item]))
+        expect(map.implement?.agent).toBe("implement")
+        expect(map.review?.agent).toBe("review")
+        expect(map.review?.subtask).toBe(true)
+        expect(map.ship?.agent).toBe("review")
+        expect(map.ship?.subtask).toBe(true)
+        expect(map.handoff?.agent).toBe("review")
+        expect(map.handoff?.subtask).toBe(true)
+        expect(map["project-local"]?.name).toBe("project-local")
       },
     })
   })


### PR DESCRIPTION
## Summary
- add a guarded `implement` primary agent and read-only `review` subagent to the packaged guardrail profile
- add packaged `/implement`, `/review`, `/ship`, and `/handoff` commands so workflow gates stay explicit and read-only where intended
- extend guardrail scenario coverage for default-agent routing, command wiring, and permission policy

## Verification
- bun test test/scenario/guardrails.test.ts
- bun typecheck

Closes #5