### PR TITLE
feat: add provider admission policy

### DIFF
--- a/docs/ai-guardrails/adr/002-provider-admission-lanes.md
+++ b/docs/ai-guardrails/adr/002-provider-admission-lanes.md
@@ -1,0 +1,104 @@
+# ADR 002: Provider Admission Lanes
+
+## Status
+
+Accepted
+
+## Context
+
+The internal product needs a stable answer for confidential-code routing before it can honestly be called an MVP.
+
+OpenCode already exposes the needed primitives in config, provider metadata, commands, agents, and plugins. The missing piece is not another fork-level provider abstraction. It is a thin-distribution policy that:
+
+- admits a small provider set intentionally
+- keeps standard work separate from evaluation traffic
+- blocks free, preview, or otherwise non-approved models for confidential repositories
+- stays declarative in config and verifiable at runtime
+
+This follows the same philosophy imported from `claude-code-skills` epic `#130` and the harness-engineering references:
+
+- mechanism before prose
+- fastest reliable layer first
+- pointer-based instructions
+- runtime proof instead of "the code exists"
+
+## Decision
+
+Adopt three admission lanes:
+
+1. `zai` and `openai` are the standard confidential-code lane.
+2. `openrouter` is admitted only as a separate evaluation lane.
+3. OpenRouter-backed evaluation stays on an explicit `provider-eval` agent and command instead of widening the default implementation lane.
+
+The policy is implemented in two layers:
+
+- config expresses admitted providers and model allowlists
+- the guardrail plugin enforces lane usage at runtime through `chat.params`
+
+## Policy
+
+### Standard lane
+
+- admitted providers: `zai`, `openai`
+- admitted models are pinned through provider allowlists
+- preview, free, and non-approved variants are excluded by default
+
+### Evaluation lane
+
+- admitted provider: `openrouter`
+- admitted models are a narrow allowlist of approved evaluation candidates
+- the lane is entered only through the packaged `provider-eval` workflow
+
+### Confidential-repo rule
+
+For confidential repositories:
+
+- do not use free models
+- do not use preview, alpha, beta, or experimental models
+- do not use OpenRouter outside the explicit evaluation lane
+- do not expand the admitted model set without a docs-backed review of routing and data controls
+
+## Rationale
+
+This keeps the runtime upstream-compatible while still answering the real policy question:
+
+- standard work has a stable provider set
+- evaluation traffic is explicit instead of accidental
+- adding a new OpenRouter candidate requires a deliberate config change
+- plugin enforcement means project-local config cannot silently widen the lane
+
+## Consequences
+
+### Positive
+
+- provider policy is declarative and testable
+- the default lane is smaller and easier to reason about
+- evaluation traffic is visible in workflow and logs
+- future provider additions become explicit admission decisions, not casual model switches
+
+### Negative
+
+- the policy duplicates some intent across config and plugin checks
+- OpenRouter evaluation remains intentionally narrower than raw upstream capability
+- new model admissions require docs and allowlist maintenance
+
+## Verification
+
+Issue `#6` must prove:
+
+- admitted providers and model allowlists load from config
+- OpenRouter-backed models are available only in the explicit evaluation lane
+- blocked provider misuse throws at runtime through the guardrail plugin
+
+## Sources
+
+- `claude-code-skills` epic `#130`
+- `claude-code-skills` README
+- `claude-code-skills/docs/references/harness-engineering-best-practices-2026.md`
+- Anthropic `The Complete Guide to Building Skills for Claude`
+- OpenCode config docs: `https://opencode.ai/docs/config`
+- OpenRouter provider routing docs: `https://openrouter.ai/docs/guides/routing/provider-selection`
+- OpenAI pricing: `https://openai.com/api/pricing/`
+- OpenAI data controls: `https://developers.openai.com/api/docs/guides/your-data`
+- Z.AI pricing: `https://docs.z.ai/guides/overview/pricing`
+- Z.AI OpenCode guide: `https://docs.z.ai/devpack/tool/opencode`

--- a/packages/guardrails/README.md
+++ b/packages/guardrails/README.md
@@ -47,6 +47,7 @@ Current contents focus on the first thin-distribution slice:
 - packaged custom config dir profile
 - packaged plugin for runtime guardrail hooks
 - guarded `implement` and `review` agents plus packaged `/implement`, `/review`, `/ship`, and `/handoff` workflow commands
+- declarative provider admission policy for `zai`, `openai`, and the isolated OpenRouter evaluation lane
 - scenario coverage for managed config precedence, project-local asset compatibility, plugin behavior, and workflow safety defaults
 
 Planned next slices are tracked in the fork:
@@ -71,6 +72,8 @@ opencode-guardrails
 It respects an existing `OPENCODE_CONFIG_DIR` so project- or environment-specific overrides can still replace the packaged profile when needed.
 
 The packaged profile defaults to the `implement` agent. Review and release-readiness work should run through the packaged `/review`, `/ship`, and `/handoff` commands so the workflow stays read-only at the gate layer.
+
+Provider admission is also packaged here. Standard confidential-code work is admitted on the `zai` and `openai` lane. OpenRouter-backed candidates are available only through the dedicated `provider-eval` lane so evaluation traffic does not silently become the default implementation path.
 
 ## Managed deployment
 

--- a/packages/guardrails/managed/opencode.json
+++ b/packages/guardrails/managed/opencode.json
@@ -1,9 +1,39 @@
 {
   "$schema": "https://opencode.ai/config.json",
+  "enabled_providers": [
+    "zai",
+    "openai",
+    "openrouter"
+  ],
   "share": "disabled",
   "server": {
     "hostname": "127.0.0.1",
     "mdns": false
+  },
+  "provider": {
+    "zai": {
+      "whitelist": [
+        "glm-5",
+        "glm-4.5",
+        "glm-4.5-air"
+      ]
+    },
+    "openai": {
+      "whitelist": [
+        "gpt-5",
+        "gpt-5-mini",
+        "gpt-5-nano",
+        "gpt-4.1"
+      ]
+    },
+    "openrouter": {
+      "whitelist": [
+        "openai/gpt-5",
+        "openai/gpt-5-mini",
+        "anthropic/claude-sonnet-4.5",
+        "google/gemini-2.5-pro"
+      ]
+    }
   },
   "permission": {
     "edit": "ask",

--- a/packages/guardrails/profile/AGENTS.md
+++ b/packages/guardrails/profile/AGENTS.md
@@ -10,3 +10,4 @@
 - Treat `.opencode/guardrails/` as plugin-owned runtime state, not a manual editing surface.
 - Use `implement` as the guarded default primary agent. Route review, ship, and handoff work through the packaged `/review`, `/ship`, and `/handoff` commands instead of freeform release flows.
 - Keep review paths read-only. If a workflow needs edits, return to `implement` or a project-local implementation agent instead of widening the review agent.
+- Keep provider admission explicit. Standard confidential-code work stays on the admitted `zai` and `openai` lane; OpenRouter-backed evaluation belongs on `provider-eval` or `/provider-eval` only.

--- a/packages/guardrails/profile/agents/provider-eval.md
+++ b/packages/guardrails/profile/agents/provider-eval.md
@@ -1,0 +1,28 @@
+---
+description: Evaluate admitted OpenRouter-backed candidates without widening the default confidential-code lane.
+mode: subagent
+model: openrouter/openai/gpt-5-mini
+permission:
+  "*": deny
+  read: allow
+  grep: allow
+  glob: allow
+  list: allow
+  lsp: allow
+  skill: allow
+  webfetch: ask
+  bash:
+    "*": deny
+    "git diff *": allow
+    "git status *": allow
+    "git show *": allow
+    "git log *": allow
+---
+
+Use this lane only for provider admission work.
+
+Keep the output evidence-based:
+
+- cite the admitted model and provider choice explicitly
+- call out routing or data-policy assumptions that still need confirmation
+- do not widen the default implementation lane from this agent

--- a/packages/guardrails/profile/commands/provider-eval.md
+++ b/packages/guardrails/profile/commands/provider-eval.md
@@ -1,0 +1,17 @@
+---
+description: Evaluate admitted provider candidates in the isolated provider-eval lane.
+agent: provider-eval
+subtask: true
+---
+
+Evaluate the requested provider or model candidate using the dedicated provider-eval lane.
+
+Required sections:
+
+- Candidate
+- Evidence
+- Routing and data-policy notes
+- Recommendation
+- Follow-up config change
+
+Default scope is provider admission and confidential-code suitability, not general implementation work.

--- a/packages/guardrails/profile/opencode.json
+++ b/packages/guardrails/profile/opencode.json
@@ -1,14 +1,41 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "default_agent": "implement",
+  "enabled_providers": [
+    "zai",
+    "openai",
+    "openrouter"
+  ],
   "share": "disabled",
   "server": {
     "hostname": "127.0.0.1",
     "mdns": false
   },
-  "plugin": [
-    "./plugins/guardrail.ts"
-  ],
+  "provider": {
+    "zai": {
+      "whitelist": [
+        "glm-5",
+        "glm-4.5",
+        "glm-4.5-air"
+      ]
+    },
+    "openai": {
+      "whitelist": [
+        "gpt-5",
+        "gpt-5-mini",
+        "gpt-5-nano",
+        "gpt-4.1"
+      ]
+    },
+    "openrouter": {
+      "whitelist": [
+        "openai/gpt-5",
+        "openai/gpt-5-mini",
+        "anthropic/claude-sonnet-4.5",
+        "google/gemini-2.5-pro"
+      ]
+    }
+  },
   "permission": {
     "edit": "ask",
     "task": "ask",

--- a/packages/guardrails/profile/plugins/guardrail.ts
+++ b/packages/guardrails/profile/plugins/guardrail.ts
@@ -80,14 +80,48 @@ function bash(cmd: string) {
   return mut.some((item) => item.test(cmd))
 }
 
+function list(data: unknown) {
+  return Array.isArray(data) ? data.filter((item): item is string => typeof item === "string" && item !== "") : []
+}
+
+function free(data: {
+  cost?: {
+    input?: number
+    output?: number
+    cache?: { read?: number; write?: number }
+  }
+}) {
+  const inCost = data.cost?.input ?? 0
+  const outCost = data.cost?.output ?? 0
+  const readCost = data.cost?.cache?.read ?? 0
+  const writeCost = data.cost?.cache?.write ?? 0
+  return inCost === 0 && outCost === 0 && readCost === 0 && writeCost === 0
+}
+
+function preview(data: {
+  id?: unknown
+  status?: unknown
+}) {
+  const id = typeof data.id === "string" ? data.id : ""
+  const status = typeof data.status === "string" ? data.status : ""
+  if (status && status !== "active") return true
+  return /(preview|alpha|beta|exp|experimental|:free\b|\bfree\b)/i.test(id)
+}
+
 export default async function guardrail(input: {
   directory: string
   worktree: string
 }, opts?: Record<string, unknown>) {
   const mode = typeof opts?.mode === "string" ? opts.mode : "enforced"
+  const evals = new Set(["openrouter"])
+  const evalAgent = "provider-eval"
+  const conf = true
+  const denyFree = true
+  const denyPreview = true
   const root = path.join(input.directory, ".opencode", "guardrails")
   const log = path.join(root, "events.jsonl")
   const state = path.join(root, "state.json")
+  const allow: Record<string, Set<string>> = {}
 
   await mkdir(root, { recursive: true })
 
@@ -119,7 +153,52 @@ export default async function guardrail(input: {
     if (kind === "edit" && has(item, cfg)) return "linter or formatter configuration is policy-protected"
   }
 
+  function gate(data: {
+    agent?: string
+    model?: {
+      id?: unknown
+      providerID?: unknown
+      status?: unknown
+      cost?: {
+        input?: number
+        output?: number
+        cache?: { read?: number; write?: number }
+      }
+    }
+  }) {
+    const provider = typeof data.model?.providerID === "string" ? data.model.providerID : ""
+    const agent = typeof data.agent === "string" ? data.agent : ""
+    if (!provider) return
+
+    if (evals.has(provider) && agent !== evalAgent) {
+      return `${provider} is evaluation-only under confidential policy; use ${evalAgent}`
+    }
+    if (agent === evalAgent && !evals.has(provider)) {
+      return `${evalAgent} is reserved for evaluation-lane providers`
+    }
+
+    const ids = allow[provider]
+    const model = typeof data.model?.id === "string" ? data.model.id : ""
+    if (ids?.size && model && !ids.has(model)) {
+      return `${provider}/${model} is not admitted by provider policy`
+    }
+
+    if (!conf) return
+    if (denyFree && free(data.model ?? {})) return `${provider}/${model || "unknown"} is a free-tier model`
+    if (denyPreview && preview(data.model ?? {})) return `${provider}/${model || "unknown"} is preview-only`
+  }
+
   return {
+    config: async (cfg: {
+      provider?: Record<string, { whitelist?: string[] }>
+    }) => {
+      for (const key of Object.keys(allow)) delete allow[key]
+      for (const [key, val] of Object.entries(cfg.provider ?? {})) {
+        const ids = list(val.whitelist)
+        if (!ids.length) continue
+        allow[key] = new Set(ids)
+      }
+    },
     event: async ({ event }: { event: { type?: string; properties?: Record<string, unknown> } }) => {
       if (!event.type) return
       if (!["session.created", "permission.asked", "session.idle", "session.compacted"].includes(event.type)) return
@@ -173,6 +252,39 @@ export default async function guardrail(input: {
       out.env.OPENCODE_GUARDRAIL_MODE = mode
       out.env.OPENCODE_GUARDRAIL_ROOT = root
       out.env.OPENCODE_GUARDRAIL_STATE = state
+    },
+    "chat.params": async (
+      item: {
+        sessionID: string
+        agent: string
+        model: {
+          id: string
+          providerID: string
+          status: "alpha" | "beta" | "deprecated" | "active"
+          cost: {
+            input: number
+            output: number
+            cache: { read: number; write: number }
+          }
+        }
+      },
+      _out: {
+        temperature?: number
+        topP?: number
+        topK?: number
+        options: Record<string, unknown>
+      },
+    ) => {
+      const err = gate(item)
+      if (!err) return
+      await mark({
+        last_block: "chat.params",
+        last_provider: item.model.providerID,
+        last_model: item.model.id,
+        last_agent: item.agent,
+        last_reason: err,
+      })
+      throw new Error(text(err))
     },
     "experimental.session.compacting": async (
       _item: { sessionID: string },

--- a/packages/opencode/test/scenario/guardrails.test.ts
+++ b/packages/opencode/test/scenario/guardrails.test.ts
@@ -4,9 +4,12 @@ import path from "path"
 import { Agent } from "../../src/agent/agent"
 import { Command } from "../../src/command"
 import { Config } from "../../src/config/config"
+import { Env } from "../../src/env"
 import { Permission } from "../../src/permission"
 import { Plugin } from "../../src/plugin"
 import { Instance } from "../../src/project/instance"
+import { Provider } from "../../src/provider/provider"
+import { ProviderID } from "../../src/provider/schema"
 import { Skill } from "../../src/skill"
 import { Filesystem } from "../../src/util/filesystem"
 import { tmpdir } from "../fixture/fixture"
@@ -255,6 +258,115 @@ Use the project-local command.
         expect(map.handoff?.agent).toBe("review")
         expect(map.handoff?.subtask).toBe(true)
         expect(map["project-local"]?.name).toBe("project-local")
+      },
+    })
+  })
+})
+
+test("guardrail profile enforces provider admission lanes", async () => {
+  await withProfile(async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await write(dir, "opencode.json", {
+          $schema: "https://opencode.ai/config.json",
+          share: "auto",
+        })
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      init: async () => {
+        Env.set("ZHIPU_API_KEY", "test-zai-key")
+        Env.set("OPENAI_API_KEY", "test-openai-key")
+        Env.set("OPENROUTER_API_KEY", "test-openrouter-key")
+      },
+      fn: async () => {
+        const cfg = await Config.get()
+        const providers = await Provider.list()
+        const cmds = await Command.list()
+        const evalAgent = await Agent.get("provider-eval")
+        const openrouter = providers[ProviderID.openrouter]
+        const zai = providers[ProviderID.make("zai")]
+        const openai = providers[ProviderID.openai]
+
+        expect(cfg.enabled_providers).toEqual(["zai", "openai", "openrouter"])
+        expect(zai).toBeDefined()
+        expect(openai).toBeDefined()
+        expect(openrouter).toBeDefined()
+        expect(Object.keys(zai.models).sort()).toEqual(["glm-4.5", "glm-4.5-air", "glm-5"])
+        expect(Object.keys(openai.models).sort()).toEqual(["gpt-4.1", "gpt-5", "gpt-5-mini", "gpt-5-nano"])
+        expect(Object.keys(openrouter.models).sort()).toEqual([
+          "anthropic/claude-sonnet-4.5",
+          "google/gemini-2.5-pro",
+          "openai/gpt-5",
+          "openai/gpt-5-mini",
+        ])
+        expect(evalAgent?.mode).toBe("subagent")
+        expect(cmds.some((item) => item.name === "provider-eval" && item.agent === "provider-eval")).toBe(true)
+
+        const evalModel = openrouter.models["openai/gpt-5-mini"]
+
+        await expect(
+          Plugin.trigger(
+            "chat.params",
+            {
+              sessionID: "session_test",
+              agent: "implement",
+              model: evalModel,
+            },
+            { temperature: undefined, topP: undefined, topK: undefined, options: {} },
+          ),
+        ).rejects.toThrow("evaluation-only")
+
+        await expect(
+          Plugin.trigger(
+            "chat.params",
+            {
+              sessionID: "session_test",
+              agent: "provider-eval",
+              model: openai.models["gpt-5-mini"],
+            },
+            { temperature: undefined, topP: undefined, topK: undefined, options: {} },
+          ),
+        ).rejects.toThrow("reserved for evaluation-lane providers")
+
+        await expect(
+          Plugin.trigger(
+            "chat.params",
+            {
+              sessionID: "session_test",
+              agent: "provider-eval",
+              model: {
+                ...evalModel,
+                id: "deepseek/deepseek-r1:free" as typeof evalModel.id,
+                cost: {
+                  ...evalModel.cost,
+                  input: 0,
+                  output: 0,
+                  cache: {
+                    read: 0,
+                    write: 0,
+                  },
+                },
+              },
+            },
+            { temperature: undefined, topP: undefined, topK: undefined, options: {} },
+          ),
+        ).rejects.toThrow("not admitted")
+
+        await expect(
+          Plugin.trigger(
+            "chat.params",
+            {
+              sessionID: "session_test",
+              agent: "provider-eval",
+              model: evalModel,
+            },
+            { temperature: undefined, topP: undefined, topK: undefined, options: {} },
+          ),
+        ).resolves.toEqual({ temperature: undefined, topP: undefined, topK: undefined, options: {} })
       },
     })
   })


### PR DESCRIPTION
## Summary
- add ADR-002 for provider admission lanes and document the confidential-code routing policy from issue #6
- express admitted providers and model allowlists in the managed profile and packaged guardrails profile
- add a dedicated `provider-eval` lane plus runtime `chat.params` enforcement so OpenRouter stays evaluation-only under the confidential-code policy
- extend guardrail scenarios to prove provider allowlists and blocked provider misuse actually fire

## Verification
- bun test test/scenario/guardrails.test.ts
- bun typecheck
- bun turbo typecheck

## References
- https://opencode.ai/docs/config
- https://openrouter.ai/docs/guides/routing/provider-selection
- https://openai.com/api/pricing/
- https://developers.openai.com/api/docs/guides/your-data
- https://docs.z.ai/guides/overview/pricing
- https://docs.z.ai/devpack/tool/opencode

Closes #6