### PR TITLE
merge upstream notification support into guardrails fork

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,6 +75,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: unit-${{ matrix.settings.name }}-${{ github.run_attempt }}
+          include-hidden-files: true
           if-no-files-found: ignore
           retention-days: 7
           path: packages/*/.artifacts/unit/junit.xml

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -15,7 +15,7 @@
     "build": "vite build",
     "serve": "vite preview",
     "test": "bun run test:unit",
-    "test:ci": "bun test --preload ./happydom.ts ./src --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml",
+    "test:ci": "mkdir -p .artifacts/unit && bun test --preload ./happydom.ts ./src --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml",
     "test:unit": "bun test --preload ./happydom.ts ./src",
     "test:unit:watch": "bun test --watch --preload ./happydom.ts ./src",
     "test:e2e": "playwright test",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -9,7 +9,7 @@
     "prepare": "effect-language-service patch || true",
     "typecheck": "tsgo --noEmit",
     "test": "bun test --timeout 30000",
-    "test:ci": "bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml",
+    "test:ci": "mkdir -p .artifacts/unit && bun test --timeout 30000 --reporter=junit --reporter-outfile=.artifacts/unit/junit.xml",
     "build": "bun run script/build.ts",
     "upgrade-opentui": "bun run script/upgrade-opentui.ts",
     "dev": "bun run --conditions=browser ./src/index.ts",

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -822,10 +822,8 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     const focused = await Notification.terminalIsFocused().catch(() => false)
     if (focused) return
 
-    const sessionID = evt.properties.info?.id
-    const session = sessionID ? sync.data.session?.[sessionID] : undefined
-    const title = session?.title ?? sessionID ?? "Session"
-    Notification.show("opencode", `${title} completed`).catch(() => {})
+    const sessionID = evt.properties.sessionID
+    Notification.show("opencode", `${sessionID} completed`).catch(() => {})
   })
 
   sdk.event.on("session.error", (evt) => {

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -825,7 +825,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     const sessionID = evt.properties.info?.id
     const session = sessionID ? sync.data.session?.[sessionID] : undefined
     const title = session?.title ?? sessionID ?? "Session"
-    Notification.show("opencode", `${title} completed`)
+    Notification.show("opencode", `${title} completed`).catch(() => {})
   })
 
   sdk.event.on("session.error", (evt) => {

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -59,6 +59,7 @@ import { TuiConfigProvider, useTuiConfig } from "./context/tui-config"
 import { TuiConfig } from "@/config/tui"
 import { createTuiApi, TuiPluginRuntime, type RouteMap } from "./plugin"
 import { FormatError, FormatUnknownError } from "@/cli/error"
+import { Notification } from "@/notification"
 
 async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {
   // can't set raw mode if not a TTY
@@ -816,6 +817,17 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     }
   })
 
+  sdk.event.on("session.idle", async (evt) => {
+    if (tuiConfig.notifications === false) return
+    const focused = await Notification.terminalIsFocused().catch(() => false)
+    if (focused) return
+
+    const sessionID = evt.properties.info?.id
+    const session = sessionID ? sync.data.session?.[sessionID] : undefined
+    const title = session?.title ?? sessionID ?? "Session"
+    Notification.show("opencode", `${title} completed`)
+  })
+
   sdk.event.on("session.error", (evt) => {
     const error = evt.properties.error
     if (error && typeof error === "object" && error.name === "MessageAbortedError") return
@@ -825,6 +837,12 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       variant: "error",
       message,
       duration: 5000,
+    })
+
+    void Notification.terminalIsFocused().then((focused) => {
+      if (focused) return
+      if (tuiConfig.notifications === false) return
+      Notification.show("opencode", `Error: ${message}`)
     })
   })
 

--- a/packages/opencode/src/cli/cmd/tui/feature-plugins/home/tips-view.tsx
+++ b/packages/opencode/src/cli/cmd/tui/feature-plugins/home/tips-view.tsx
@@ -103,7 +103,7 @@ const TIPS = [
   "Create {highlight}.ts{/highlight} files in {highlight}.opencode/tools/{/highlight} to define new LLM tools",
   "Tool definitions can invoke scripts written in Python, Go, etc",
   "Add {highlight}.ts{/highlight} files to {highlight}.opencode/plugin/{/highlight} for event hooks",
-  "Use plugins to send OS notifications when sessions complete",
+  'Use built-in {highlight}"notifications": true{/highlight} in {highlight}tui.json{/highlight} for session-complete alerts',
   "Create a plugin to prevent OpenCode from reading sensitive files",
   "Use {highlight}opencode run{/highlight} for non-interactive scripting",
   "Use {highlight}opencode --continue{/highlight} to resume the last session",

--- a/packages/opencode/src/cli/cmd/tui/ui/toast.tsx
+++ b/packages/opencode/src/cli/cmd/tui/ui/toast.tsx
@@ -1,18 +1,34 @@
-import { createContext, useContext, type ParentProps, Show } from "solid-js"
+import { createContext, useContext, type ParentProps, Show, createMemo } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useTheme } from "@tui/context/theme"
 import { useTerminalDimensions } from "@opentui/solid"
-import { SplitBorder } from "../component/border"
 import { TextAttributes } from "@opentui/core"
 import z from "zod"
 import { TuiEvent } from "../event"
 
 export type ToastOptions = z.infer<typeof TuiEvent.ToastShow.properties>
 
+const VARIANT_ICONS: Record<string, string> = {
+  error: "✗",
+  success: "✓",
+  info: "ℹ",
+  warning: "⚠",
+}
+
 export function Toast() {
   const toast = useToast()
   const { theme } = useTheme()
   const dimensions = useTerminalDimensions()
+
+  const icon = createMemo(() => {
+    if (!toast.currentToast) return ""
+    return VARIANT_ICONS[toast.currentToast.variant] ?? "●"
+  })
+
+  const iconColor = createMemo(() => {
+    if (!toast.currentToast) return theme.text
+    return theme[toast.currentToast.variant] ?? theme.text
+  })
 
   return (
     <Show when={toast.currentToast}>
@@ -30,14 +46,18 @@ export function Toast() {
           paddingBottom={1}
           backgroundColor={theme.backgroundPanel}
           borderColor={theme[current().variant]}
-          border={["left", "right"]}
-          customBorderChars={SplitBorder.customBorderChars}
+          border={["top", "bottom", "left", "right"]}
         >
-          <Show when={current().title}>
-            <text attributes={TextAttributes.BOLD} marginBottom={1} fg={theme.text}>
-              {current().title}
+          <box flexDirection="row" gap={1} marginBottom={1}>
+            <text fg={iconColor()} attributes={TextAttributes.BOLD}>
+              {icon()}
             </text>
-          </Show>
+            <Show when={current().title}>
+              <text attributes={TextAttributes.BOLD} fg={theme.text}>
+                {current().title}
+              </text>
+            </Show>
+          </box>
           <text fg={theme.text} wrapMode="word" width="100%">
             {current().message}
           </text>
@@ -64,7 +84,7 @@ function init() {
         setStore("currentToast", null)
       }, duration).unref()
     },
-    error: (err: any) => {
+    error: (err: unknown) => {
       if (err instanceof Error)
         return toast.show({
           variant: "error",

--- a/packages/opencode/src/config/tui-schema.ts
+++ b/packages/opencode/src/config/tui-schema.ts
@@ -22,6 +22,11 @@ export const TuiOptions = z.object({
     .enum(["auto", "stacked"])
     .optional()
     .describe("Control diff rendering style: 'auto' adapts to terminal width, 'stacked' always shows single column"),
+  notifications: z
+    .boolean()
+    .default(true)
+    .optional()
+    .describe("Show system notifications when sessions complete or error. Requires terminal focus-loss detection."),
 })
 
 export const TuiInfo = z

--- a/packages/opencode/src/notification/index.ts
+++ b/packages/opencode/src/notification/index.ts
@@ -16,7 +16,13 @@ const TERMINAL_APPS = [
   "wave",
   "tmux",
   "zellij",
+  "vscode",
+  "code",
 ]
+
+function escapeForOsascript(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
+}
 
 export namespace Notification {
   export async function terminalIsFocused(): Promise<boolean> {
@@ -38,8 +44,8 @@ export namespace Notification {
     const os = platform()
 
     if (os === "darwin") {
-      const escaped = message.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/'/g, "'\"'\"'")
-      const titleEscaped = title.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/'/g, "'\"'\"'")
+      const escaped = escapeForOsascript(message)
+      const titleEscaped = escapeForOsascript(title)
       await Process.run(
         [
           "osascript",

--- a/packages/opencode/src/notification/index.ts
+++ b/packages/opencode/src/notification/index.ts
@@ -1,0 +1,89 @@
+import { platform } from "os"
+import { Process } from "@/util/process"
+import { which } from "@/util/which"
+
+const TERMINAL_APPS = [
+  "terminal",
+  "iterm",
+  "iterm2",
+  "warp",
+  "alacritty",
+  "kitty",
+  "ghostty",
+  "wezterm",
+  "hyper",
+  "tabby",
+  "wave",
+  "tmux",
+  "zellij",
+]
+
+export namespace Notification {
+  export async function terminalIsFocused(): Promise<boolean> {
+    if (platform() !== "darwin") return false
+
+    const result = await Process.text(
+      [
+        "osascript",
+        "-e",
+        'tell application "System Events" to get name of first application process whose frontmost is true',
+      ],
+      { nothrow: true },
+    )
+    const frontmost = result.text.trim().toLowerCase()
+    return TERMINAL_APPS.some((app) => frontmost.includes(app))
+  }
+
+  export async function show(title: string, message: string): Promise<void> {
+    const os = platform()
+
+    if (os === "darwin") {
+      const escaped = message.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/'/g, "'\"'\"'")
+      const titleEscaped = title.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/'/g, "'\"'\"'")
+      await Process.run(
+        [
+          "osascript",
+          "-e",
+          `tell application "Terminal" to display notification "${escaped}" with title "${titleEscaped}"`,
+        ],
+        { nothrow: true },
+      )
+      return
+    }
+
+    if (os === "linux") {
+      if (which("notify-send")) {
+        await Process.run(["notify-send", "--app-name=opencode", title, message], { nothrow: true })
+        return
+      }
+      if (which("notify")) {
+        await Process.run(["notify", title, message], { nothrow: true })
+        return
+      }
+      return
+    }
+
+    if (os === "win32") {
+      const script = [
+        "[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null",
+        "[Windows.Data.Xml.Dom.XmlDocument, Windows.Data.Xml.Dom.XmlDocument, ContentType = WindowsRuntime] | Out-Null",
+        `$template = "<toast><visual><binding template='ToastText02'><text id='1'>${escapeXml(title)}</text><text id='2'>${escapeXml(message)}</text></binding></visual></toast>"`,
+        "$xml = New-Object Windows.Data.Xml.Dom.XmlDocument",
+        "$xml.LoadXml($template)",
+        "$toast = [Windows.UI.Notifications.ToastNotification]::new($xml)",
+        '[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier("opencode").Show($toast)',
+      ].join("; ")
+      await Process.run(["powershell.exe", "-NonInteractive", "-NoProfile", "-Command", script], { nothrow: true })
+      return
+    }
+  }
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;")
+}

--- a/packages/opencode/src/notification/index.ts
+++ b/packages/opencode/src/notification/index.ts
@@ -2,8 +2,9 @@ import { platform } from "os"
 import { Process } from "@/util/process"
 import { which } from "@/util/which"
 
-const TERMINAL_APPS = [
+const APPS = new Set([
   "terminal",
+  "terminalapp",
   "iterm",
   "iterm2",
   "warp",
@@ -16,12 +17,29 @@ const TERMINAL_APPS = [
   "wave",
   "tmux",
   "zellij",
-  "vscode",
+  "visualstudiocode",
+  "visualstudiocodeinsiders",
   "code",
-]
+  "codeinsiders",
+  "cursor",
+  "vscodium",
+  "windsurf",
+])
+
+function norm(s: string) {
+  return s.toLowerCase().replace(/[^a-z0-9]/g, "")
+}
 
 function escapeForOsascript(s: string): string {
   return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')
+}
+
+export function terminal(name: string) {
+  return APPS.has(norm(name))
+}
+
+export function xml(title: string, message: string) {
+  return `<toast><visual><binding template='ToastText02'><text id='1'>${escapeXml(title)}</text><text id='2'>${escapeXml(message)}</text></binding></visual></toast>`
 }
 
 export namespace Notification {
@@ -36,8 +54,7 @@ export namespace Notification {
       ],
       { nothrow: true },
     )
-    const frontmost = result.text.trim().toLowerCase()
-    return TERMINAL_APPS.some((app) => frontmost.includes(app))
+    return terminal(result.text.trim())
   }
 
   export async function show(title: string, message: string): Promise<void> {
@@ -70,16 +87,32 @@ export namespace Notification {
     }
 
     if (os === "win32") {
-      const script = [
-        "[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null",
-        "[Windows.Data.Xml.Dom.XmlDocument, Windows.Data.Xml.Dom.XmlDocument, ContentType = WindowsRuntime] | Out-Null",
-        `$template = "<toast><visual><binding template='ToastText02'><text id='1'>${escapeXml(title)}</text><text id='2'>${escapeXml(message)}</text></binding></visual></toast>"`,
-        "$xml = New-Object Windows.Data.Xml.Dom.XmlDocument",
-        "$xml.LoadXml($template)",
-        "$toast = [Windows.UI.Notifications.ToastNotification]::new($xml)",
-        '[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier("opencode").Show($toast)',
-      ].join("; ")
-      await Process.run(["powershell.exe", "-NonInteractive", "-NoProfile", "-Command", script], { nothrow: true })
+      const proc = Process.spawn(
+        [
+          "powershell.exe",
+          "-NonInteractive",
+          "-NoProfile",
+          "-Command",
+          [
+            "[Console]::InputEncoding = [System.Text.Encoding]::UTF8",
+            "[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null",
+            "[Windows.Data.Xml.Dom.XmlDocument, Windows.Data.Xml.Dom.XmlDocument, ContentType = WindowsRuntime] | Out-Null",
+            "$xml = New-Object Windows.Data.Xml.Dom.XmlDocument",
+            "$xml.LoadXml([Console]::In.ReadToEnd())",
+            "$toast = [Windows.UI.Notifications.ToastNotification]::new($xml)",
+            '[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier("opencode").Show($toast)',
+          ].join("; "),
+        ],
+        {
+          stdin: "pipe",
+          stdout: "ignore",
+          stderr: "ignore",
+        },
+      )
+      if (!proc.stdin) return
+      proc.stdin.write(xml(title, message))
+      proc.stdin.end()
+      await proc.exited.catch(() => {})
       return
     }
   }

--- a/packages/opencode/test/notification.test.ts
+++ b/packages/opencode/test/notification.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test"
+import { terminal, xml } from "../src/notification"
+
+describe("notification", () => {
+  test("matches known terminal apps exactly after normalization", () => {
+    expect(terminal("Terminal")).toBe(true)
+    expect(terminal("Visual Studio Code")).toBe(true)
+    expect(terminal("Visual Studio Code - Insiders")).toBe(true)
+    expect(terminal("Xcode")).toBe(false)
+  })
+
+  test("escapes xml payload for windows toasts", () => {
+    expect(xml('A&B "title"', "<tag> & 'quote'")).toContain(
+      "<text id='1'>A&amp;B &quot;title&quot;</text><text id='2'>&lt;tag&gt; &amp; &apos;quote&apos;</text>",
+    )
+  })
+})

--- a/packages/web/src/content/docs/ar/plugins.mdx
+++ b/packages/web/src/content/docs/ar/plugins.mdx
@@ -225,7 +225,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/bs/plugins.mdx
+++ b/packages/web/src/content/docs/bs/plugins.mdx
@@ -216,7 +216,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/da/plugins.mdx
+++ b/packages/web/src/content/docs/da/plugins.mdx
@@ -225,7 +225,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/de/plugins.mdx
+++ b/packages/web/src/content/docs/de/plugins.mdx
@@ -224,7 +224,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/es/plugins.mdx
+++ b/packages/web/src/content/docs/es/plugins.mdx
@@ -225,7 +225,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/fr/plugins.mdx
+++ b/packages/web/src/content/docs/fr/plugins.mdx
@@ -224,7 +224,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/it/plugins.mdx
+++ b/packages/web/src/content/docs/it/plugins.mdx
@@ -224,7 +224,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/ja/plugins.mdx
+++ b/packages/web/src/content/docs/ja/plugins.mdx
@@ -225,7 +225,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/ko/plugins.mdx
+++ b/packages/web/src/content/docs/ko/plugins.mdx
@@ -224,7 +224,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/nb/plugins.mdx
+++ b/packages/web/src/content/docs/nb/plugins.mdx
@@ -225,7 +225,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/pl/plugins.mdx
+++ b/packages/web/src/content/docs/pl/plugins.mdx
@@ -225,7 +225,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -225,14 +225,14 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }
 }
 ```
 
-We are using `osascript` to run AppleScript on macOS. Here we are using it to send notifications.
+We are using `osascript` to run AppleScript on macOS. Here we are using it to send notifications. If you want this without a plugin, OpenCode's TUI also has built-in system notifications via `"notifications": true` in `tui.json`.
 
 :::note
 If you’re using the OpenCode desktop app, it can send system notifications automatically when a response is ready or when a session errors.

--- a/packages/web/src/content/docs/pt-br/plugins.mdx
+++ b/packages/web/src/content/docs/pt-br/plugins.mdx
@@ -224,7 +224,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/ru/plugins.mdx
+++ b/packages/web/src/content/docs/ru/plugins.mdx
@@ -225,7 +225,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/th/plugins.mdx
+++ b/packages/web/src/content/docs/th/plugins.mdx
@@ -225,7 +225,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/tr/plugins.mdx
+++ b/packages/web/src/content/docs/tr/plugins.mdx
@@ -224,7 +224,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/zh-cn/plugins.mdx
+++ b/packages/web/src/content/docs/zh-cn/plugins.mdx
@@ -224,7 +224,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }

--- a/packages/web/src/content/docs/zh-tw/plugins.mdx
+++ b/packages/web/src/content/docs/zh-tw/plugins.mdx
@@ -224,7 +224,7 @@ export const NotificationPlugin = async ({ project, client, $, directory, worktr
     event: async ({ event }) => {
       // Send notification on session completion
       if (event.type === "session.idle") {
-        await $`osascript -e 'display notification "Session completed!" with title "opencode"'`
+        await $`osascript -e 'tell application "Terminal" to display notification "Session completed!" with title "opencode"'`
       }
     },
   }


### PR DESCRIPTION
## Summary
- bring in upstream PR #20963 for built-in TUI system notifications, toast polish, and the new `tui.json` notification toggle
- add follow-up hardening so macOS focus detection uses normalized exact matches and Windows toast payloads flow through stdin instead of PowerShell interpolation
- sync the latest upstream dev CI fix needed to keep JUnit output directories created during tests

## Verification
- bun test test/notification.test.ts
- bun typecheck