### PR TITLE
feat: align permission defaults with Claude Code

### DIFF
--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -112,6 +112,8 @@
     "lsp": "allow",
     "task": "allow",
     "skill": "allow",
+    "question": "allow",
+    "todowrite": "allow",
     // External directory access: ask (security boundary)
     "external_directory": "ask",
   },

--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -34,19 +34,34 @@
     // Bash: pattern-based control mirroring Claude Code's Bash whitelist
     "bash": {
       "*": "ask",
-      // Dev toolchain (Claude Code allows: node, npm, pnpm, bun, python, pip)
+      // JS/TS toolchain
       "node *": "allow",
       "npm *": "allow",
+      "npx *": "allow",
       "pnpm *": "allow",
       "bun *": "allow",
+      "bunx *": "allow",
+      "yarn *": "allow",
+      "turbo *": "allow",
+      "tsc *": "allow",
+      // Python toolchain
       "python *": "allow",
       "python3 *": "allow",
       "pip *": "allow",
       "pip3 install *": "allow",
-      // Git operations (Claude Code allows: git, gh)
+      "uv *": "allow",
+      // Linters/formatters
+      "eslint *": "allow",
+      "prettier *": "allow",
+      "biome *": "allow",
+      // Test runners
+      "jest *": "allow",
+      "vitest *": "allow",
+      "playwright *": "allow",
+      // Git operations
       "git *": "allow",
       "gh *": "allow",
-      // System utilities (Claude Code allows: ls, wc, lsof, test, set, dig, etc.)
+      // System utilities
       "ls *": "allow",
       "wc *": "allow",
       "lsof *": "allow",
@@ -60,21 +75,34 @@
       "mkdir *": "allow",
       "cp *": "allow",
       "mv *": "allow",
+      "touch *": "allow",
+      "chmod *": "allow",
       "which *": "allow",
       "echo *": "allow",
-      // Network (Claude Code allows: curl, openssl)
+      "pwd": "allow",
+      "env *": "allow",
+      "sort *": "allow",
+      "uniq *": "allow",
+      "diff *": "allow",
+      "grep *": "allow",
+      "find *": "allow",
+      "sed *": "allow",
+      "awk *": "allow",
+      "xargs *": "allow",
+      // Network
       "curl *": "allow",
       "openssl *": "allow",
-      // Container (Claude Code allows: docker)
+      // Container/Cloud
       "docker *": "allow",
-      // Cloud CLI
       "vercel *": "allow",
       "supabase *": "allow",
-      // Dangerous operations: deny (Claude Code denies: rm -rf, sudo, force-push)
+      // Dangerous operations: deny
       "rm -rf *": "deny",
       "sudo *": "deny",
       "git push --force*": "deny",
+      "git push -f *": "deny",
       "curl * | sh*": "deny",
+      "curl * | bash*": "deny",
     },
     // Web operations: allow (Claude Code allows WebSearch, WebFetch)
     "websearch": "allow",

--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -6,9 +6,86 @@
     },
   },
   "permission": {
-    "edit": {
-      "packages/opencode/migration/*": "deny",
+    // Read operations: allow by default, deny sensitive files
+    // Mirrors Claude Code's Read allow + .env/.secrets deny
+    "read": {
+      "*": "allow",
+      ".env": "deny",
+      ".env.*": "deny",
+      "**/.env": "deny",
+      "**/.env.*": "deny",
+      "secrets/**": "deny",
+      "**/secrets/**": "deny",
     },
+    // Edit operations: allow by default (Claude Code's acceptEdits mode)
+    // Deny migration files and sensitive configs
+    "edit": {
+      "*": "allow",
+      "packages/opencode/migration/*": "deny",
+      ".env": "deny",
+      ".env.*": "deny",
+      "**/.env": "deny",
+      "**/.env.*": "deny",
+    },
+    // File search: always allow (Claude Code allows Glob/Grep unconditionally)
+    "glob": "allow",
+    "grep": "allow",
+    "list": "allow",
+    // Bash: pattern-based control mirroring Claude Code's Bash whitelist
+    "bash": {
+      "*": "ask",
+      // Dev toolchain (Claude Code allows: node, npm, pnpm, bun, python, pip)
+      "node *": "allow",
+      "npm *": "allow",
+      "pnpm *": "allow",
+      "bun *": "allow",
+      "python *": "allow",
+      "python3 *": "allow",
+      "pip *": "allow",
+      "pip3 install *": "allow",
+      // Git operations (Claude Code allows: git, gh)
+      "git *": "allow",
+      "gh *": "allow",
+      // System utilities (Claude Code allows: ls, wc, lsof, test, set, dig, etc.)
+      "ls *": "allow",
+      "wc *": "allow",
+      "lsof *": "allow",
+      "test *": "allow",
+      "set *": "allow",
+      "dig *": "allow",
+      "nslookup *": "allow",
+      "cat *": "allow",
+      "head *": "allow",
+      "tail *": "allow",
+      "mkdir *": "allow",
+      "cp *": "allow",
+      "mv *": "allow",
+      "which *": "allow",
+      "echo *": "allow",
+      // Network (Claude Code allows: curl, openssl)
+      "curl *": "allow",
+      "openssl *": "allow",
+      // Container (Claude Code allows: docker)
+      "docker *": "allow",
+      // Cloud CLI
+      "vercel *": "allow",
+      "supabase *": "allow",
+      // Dangerous operations: deny (Claude Code denies: rm -rf, sudo, force-push)
+      "rm -rf *": "deny",
+      "sudo *": "deny",
+      "git push --force*": "deny",
+      "curl * | sh*": "deny",
+    },
+    // Web operations: allow (Claude Code allows WebSearch, WebFetch)
+    "websearch": "allow",
+    "webfetch": "allow",
+    "codesearch": "allow",
+    // Tool integrations: allow
+    "lsp": "allow",
+    "task": "allow",
+    "skill": "allow",
+    // External directory access: ask (security boundary)
+    "external_directory": "ask",
   },
   "mcp": {},
   "tools": {


### PR DESCRIPTION
## Summary
- Expands `.opencode/opencode.jsonc` permission config to mirror Claude Code's `acceptEdits` + allow-list model
- Adds pattern-based bash whitelist for common dev tools (git, gh, node, npm, bun, python, curl, docker, etc.)
- Adds explicit deny rules for dangerous operations (rm -rf, sudo, force-push, curl-pipe-sh)
- Adds .env/secrets deny rules for read and edit operations
- Sets glob/grep/list/websearch/webfetch/codesearch/lsp/task/skill to "allow"

## Motivation
OpenCode's default permission config only specifies one deny rule (`packages/opencode/migration/*`), causing all other tool operations to fall through to `"ask"`. This results in significantly more approval prompts compared to Claude Code, which has a broad allow-list and `acceptEdits` mode.

Closes #28

## Test plan
- [ ] Start OpenCode TUI with updated config
- [ ] Verify read/edit/glob/grep operations proceed without prompts
- [ ] Verify bash commands (git, npm, bun, ls) auto-approve
- [ ] Verify dangerous commands (rm -rf, sudo) are blocked
- [ ] Verify .env file access is denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)