### PR TITLE
chore(ci): limit heavy checks to branch pushes

### DIFF
--- a/.github/workflows/nix-eval.yml
+++ b/.github/workflows/nix-eval.yml
@@ -2,9 +2,7 @@ name: nix-eval
 
 on:
   push:
-    branches: [dev]
-  pull_request:
-    branches: [dev]
+    branches: [dev, fix/guardrails-bootstrap-and-openrouter]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - dev
-  pull_request:
+      - fix/guardrails-bootstrap-and-openrouter
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -2,9 +2,7 @@ name: typecheck
 
 on:
   push:
-    branches: [dev]
-  pull_request:
-    branches: [dev]
+    branches: [dev, fix/guardrails-bootstrap-and-openrouter]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- stop running heavy test/typecheck/nix workflows on every pull request in the internal fork
- keep those workflows on push to `dev` and `fix/guardrails-bootstrap-and-openrouter`, plus manual dispatch
- preserve lightweight PR checks such as `pr-standards` and `pr-management`

## Verification
- bunx prettier --check .github/workflows/test.yml .github/workflows/typecheck.yml .github/workflows/nix-eval.yml
- /review (no blockers)