### PR TITLE
fix(ci): use pull_request_target for fork runner compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - dev
-  pull_request:
+  pull_request_target:
   workflow_dispatch:
 
 concurrency:
@@ -25,6 +25,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Bun
@@ -76,6 +77,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Bun

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -3,7 +3,7 @@ name: typecheck
 on:
   push:
     branches: [dev]
-  pull_request:
+  pull_request_target:
     branches: [dev]
   workflow_dispatch:
 
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Bun
         uses: ./.github/actions/setup-bun


### PR DESCRIPTION
## Summary
- Change test.yml and typecheck.yml from pull_request to pull_request_target
- Explicitly checkout PR head SHA to test correct code
- Fixes GitHub-hosted runner allocation issue on forked repos

Closes #62