### PR TITLE
fix: parseFrontmatter型バリデーション + repetition共有util抽出

### DIFF
--- a/packages/opencode/src/memory/file.ts
+++ b/packages/opencode/src/memory/file.ts
@@ -1,7 +1,7 @@
 import path from "path"
 import { Instance } from "@/project/instance"
 import { Log } from "@/util/log"
-import type { Memory } from "./types"
+import { Memory } from "./types"
 
 const log = Log.create({ service: "memory.file" })
 
@@ -35,6 +35,8 @@ function parseFrontmatter(raw: string): { frontmatter: Memory.Frontmatter; conte
     fm[line.slice(0, idx).trim()] = line.slice(idx + 1).trim()
   }
   if (!fm.topic || !fm.type) return undefined
+  const validTypes: readonly string[] = Memory.TYPES
+  if (!validTypes.includes(fm.type)) return undefined
   return {
     frontmatter: {
       topic: fm.topic,

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -19,12 +19,10 @@ import { SessionStatus } from "./status"
 import { SessionSummary } from "./summary"
 import type { Provider } from "@/provider/provider"
 import { Question } from "@/question"
+import { detectRepetition, REPETITION_THRESHOLD } from "./repetition"
 
 export namespace SessionProcessor {
   const DOOM_LOOP_THRESHOLD = 3
-  // 50+ consecutive repeats of a 4-200 char pattern in the last 8KB indicates a model generation loop
-  const REPETITION_THRESHOLD = 50
-  const REPETITION_WINDOW = 8000
   const log = Log.create({ service: "session.processor" })
 
   class RepetitionError extends Error {
@@ -32,24 +30,6 @@ export namespace SessionProcessor {
       super(`Repetition loop detected: "${pattern.substring(0, 80)}..." repeated ${REPETITION_THRESHOLD}+ times. Aborting to prevent context exhaustion.`)
       this.name = "RepetitionError"
     }
-  }
-
-  function detectRepetition(text: string): boolean {
-    if (text.length < REPETITION_WINDOW) return false
-    const tail = text.slice(-REPETITION_WINDOW)
-    for (let len = 4; len <= 200; len++) {
-      const pattern = tail.slice(-len)
-      let count = 0
-      let pos = tail.length - len
-      while (pos >= 0) {
-        if (tail.slice(pos, pos + len) === pattern) {
-          count++
-          pos -= len
-        } else break
-      }
-      if (count >= REPETITION_THRESHOLD) return true
-    }
-    return false
   }
 
   export type Result = "compact" | "stop" | "continue"

--- a/packages/opencode/src/session/repetition.ts
+++ b/packages/opencode/src/session/repetition.ts
@@ -1,0 +1,21 @@
+// 50+ consecutive repeats of a 4-200 char pattern in the last 8KB indicates a model generation loop
+export const REPETITION_THRESHOLD = 50
+export const REPETITION_WINDOW = 8000
+
+export function detectRepetition(text: string): boolean {
+  if (text.length < REPETITION_WINDOW) return false
+  const tail = text.slice(-REPETITION_WINDOW)
+  for (let len = 4; len <= 200; len++) {
+    const pattern = tail.slice(-len)
+    let count = 0
+    let pos = tail.length - len
+    while (pos >= 0) {
+      if (tail.slice(pos, pos + len) === pattern) {
+        count++
+        pos -= len
+      } else break
+    }
+    if (count >= REPETITION_THRESHOLD) return true
+  }
+  return false
+}

--- a/packages/opencode/test/memory/file.test.ts
+++ b/packages/opencode/test/memory/file.test.ts
@@ -3,6 +3,7 @@ import path from "path"
 import fs from "fs/promises"
 import { Instance } from "../../src/project/instance"
 import { MemoryFile } from "../../src/memory/file"
+import { Memory } from "../../src/memory/types"
 import { tmpdir } from "../fixture/fixture"
 
 describe("memory.file", () => {
@@ -189,6 +190,54 @@ describe("memory.file", () => {
         await fs.mkdir(dir, { recursive: true })
         await Bun.write(path.join(dir, "bad.md"), "no frontmatter here")
         const read = await MemoryFile.readEntry("bad.md")
+        expect(read).toBeUndefined()
+      },
+    })
+  })
+
+  test.each(Memory.TYPES.map((t) => [t]))("readEntry parses valid type: %s", async (validType) => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const dir = MemoryFile.getMemoryDir()
+        await fs.mkdir(dir, { recursive: true })
+        const raw = `---\ntopic: test\ntype: ${validType}\n---\nsome content`
+        await Bun.write(path.join(dir, "valid-type.md"), raw)
+        const read = await MemoryFile.readEntry("valid-type.md")
+        expect(read).toBeDefined()
+        expect(read!.frontmatter.type).toBe(validType)
+        expect(read!.frontmatter.topic).toBe("test")
+        expect(read!.content).toBe("some content")
+      },
+    })
+  })
+
+  test("readEntry returns undefined for invalid type in frontmatter", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const dir = MemoryFile.getMemoryDir()
+        await fs.mkdir(dir, { recursive: true })
+        const raw = "---\ntopic: test\ntype: invalid-type\n---\nsome content"
+        await Bun.write(path.join(dir, "invalid-type.md"), raw)
+        const read = await MemoryFile.readEntry("invalid-type.md")
+        expect(read).toBeUndefined()
+      },
+    })
+  })
+
+  test("readEntry returns undefined for missing type in frontmatter", async () => {
+    await using tmp = await tmpdir()
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        const dir = MemoryFile.getMemoryDir()
+        await fs.mkdir(dir, { recursive: true })
+        const raw = "---\ntopic: test\n---\nsome content"
+        await Bun.write(path.join(dir, "no-type.md"), raw)
+        const read = await MemoryFile.readEntry("no-type.md")
         expect(read).toBeUndefined()
       },
     })

--- a/packages/opencode/test/session/repetition.test.ts
+++ b/packages/opencode/test/session/repetition.test.ts
@@ -1,29 +1,6 @@
 import { describe, test, expect } from "bun:test"
-
-// detectRepetition is a namespace-internal function in SessionProcessor.
-// We replicate the algorithm here to test it in isolation.
-// Constants match processor.ts: REPETITION_THRESHOLD=50, REPETITION_WINDOW=8000
-
-const REPETITION_THRESHOLD = 50
-const REPETITION_WINDOW = 8000
-
-function detectRepetition(text: string): boolean {
-  if (text.length < REPETITION_WINDOW) return false
-  const tail = text.slice(-REPETITION_WINDOW)
-  for (let len = 4; len <= 200; len++) {
-    const pattern = tail.slice(-len)
-    let count = 0
-    let pos = tail.length - len
-    while (pos >= 0) {
-      if (tail.slice(pos, pos + len) === pattern) {
-        count++
-        pos -= len
-      } else break
-    }
-    if (count >= REPETITION_THRESHOLD) return true
-  }
-  return false
-}
+import { detectRepetition } from "../../src/session/repetition"
+import { REPETITION_THRESHOLD, REPETITION_WINDOW } from "../../src/session/repetition"
 
 describe("session.detectRepetition", () => {
   test("no repetition returns false", () => {


### PR DESCRIPTION
## What
PR #56 のレビュー残り2件を修正。

## Why
- parseFrontmatter() が invalid type を無検証でキャストしていた
- repetition.test.ts が production コードを import せず独自実装していた

Closes #69

## Changes
1. memory/file.ts: Memory.TYPES に対するバリデーション追加
2. session/repetition.ts: 新規共有util
3. session/processor.ts: import に置換
4. test 更新

## Review
- code-reviewer Agent: CRITICAL/HIGH 0
- Codex CLI: No issues in PR A

## Test plan
- [x] bun test test/memory/file.test.ts — 19 pass
- [x] bun test test/session/repetition.test.ts — 8 pass
- [x] typecheck 13/13 pass