### PR TITLE
fix: non-macOS notification focus detection

### DIFF
--- a/packages/opencode/src/notification/index.ts
+++ b/packages/opencode/src/notification/index.ts
@@ -43,18 +43,37 @@ export function xml(title: string, message: string) {
 }
 
 export namespace Notification {
-  export async function terminalIsFocused(): Promise<boolean> {
-    if (platform() !== "darwin") return false
+  export async function terminalIsFocused(
+    overridePlatform?: NodeJS.Platform,
+  ): Promise<boolean> {
+    const os = overridePlatform ?? platform()
 
-    const result = await Process.text(
-      [
-        "osascript",
-        "-e",
-        'tell application "System Events" to get name of first application process whose frontmost is true',
-      ],
-      { nothrow: true },
-    )
-    return terminal(result.text.trim())
+    if (os === "darwin") {
+      const result = await Process.text(
+        [
+          "osascript",
+          "-e",
+          'tell application "System Events" to get name of first application process whose frontmost is true',
+        ],
+        { nothrow: true },
+      )
+      return terminal(result.text.trim())
+    }
+
+    if (os === "linux") {
+      const result = await Process.text(
+        ["xdotool", "getactivewindow", "getwindowpid"],
+        { nothrow: true },
+      )
+      if (result.code !== 0) return true
+      const pid = parseInt(result.text.trim(), 10)
+      if (isNaN(pid)) return true
+      return pid === process.pid || pid === process.ppid
+    }
+
+    if (os === "win32") return false
+
+    return true
   }
 
   export async function show(title: string, message: string): Promise<void> {

--- a/packages/opencode/test/notification.test.ts
+++ b/packages/opencode/test/notification.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, test } from "bun:test"
-import { terminal, xml } from "../src/notification"
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
+import { terminal, xml, Notification } from "../src/notification"
+import { Process } from "../src/util/process"
 
 describe("notification", () => {
   test("matches known terminal apps exactly after normalization", () => {
@@ -13,5 +14,72 @@ describe("notification", () => {
     expect(xml('A&B "title"', "<tag> & 'quote'")).toContain(
       "<text id='1'>A&amp;B &quot;title&quot;</text><text id='2'>&lt;tag&gt; &amp; &apos;quote&apos;</text>",
     )
+  })
+})
+
+describe("terminalIsFocused", () => {
+  let origText: typeof Process.text
+
+  beforeEach(() => {
+    origText = Process.text
+  })
+
+  afterEach(() => {
+    ;(Process as Record<string, unknown>).text = origText
+  })
+
+  test("returns false on win32 (allow notifications since show() works)", async () => {
+    const result = await Notification.terminalIsFocused("win32")
+    expect(result).toBe(false)
+  })
+
+  test("returns true on unsupported platforms (freebsd)", async () => {
+    const result = await Notification.terminalIsFocused("freebsd")
+    expect(result).toBe(true)
+  })
+
+  test("linux: returns true when xdotool fails (not installed)", async () => {
+    ;(Process as Record<string, unknown>).text = mock(async () => ({
+      code: 1,
+      stdout: Buffer.alloc(0),
+      stderr: Buffer.from("command not found"),
+      text: "",
+    }))
+    const result = await Notification.terminalIsFocused("linux")
+    expect(result).toBe(true)
+  })
+
+  test("linux: returns true when xdotool returns matching PID", async () => {
+    ;(Process as Record<string, unknown>).text = mock(async () => ({
+      code: 0,
+      stdout: Buffer.from(String(process.pid) + "\n"),
+      stderr: Buffer.alloc(0),
+      text: String(process.pid) + "\n",
+    }))
+    const result = await Notification.terminalIsFocused("linux")
+    expect(result).toBe(true)
+  })
+
+  test("linux: returns false when xdotool returns non-matching PID", async () => {
+    const fakePid = 99999
+    ;(Process as Record<string, unknown>).text = mock(async () => ({
+      code: 0,
+      stdout: Buffer.from(String(fakePid) + "\n"),
+      stderr: Buffer.alloc(0),
+      text: String(fakePid) + "\n",
+    }))
+    const result = await Notification.terminalIsFocused("linux")
+    expect(result).toBe(false)
+  })
+
+  test("linux: returns true when xdotool returns non-numeric output", async () => {
+    ;(Process as Record<string, unknown>).text = mock(async () => ({
+      code: 0,
+      stdout: Buffer.from("not-a-number\n"),
+      stderr: Buffer.alloc(0),
+      text: "not-a-number\n",
+    }))
+    const result = await Notification.terminalIsFocused("linux")
+    expect(result).toBe(true)
   })
 })


### PR DESCRIPTION
## What
Linux でのターミナルフォーカス検出を追加、Windows は通知許可、未知の OS は通知抑制。

## Why
terminalIsFocused() が macOS 以外で常に false を返し通知が常に発火していた。

Closes #68

## Changes
- notification/index.ts: Linux xdotool 対応、Windows false (通知許可)、unknown true (抑制)
- test/notification.test.ts: 6テスト追加

## Review
- code-reviewer Agent: completed
- Codex CLI: HIGH fixed — Windows return true→false に修正済み

## Test plan
- [x] bun test test/notification — 8 pass
- [x] typecheck 13/13 pass