### PR TITLE
feat: Hook System — shell script execution for tool lifecycle events

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -999,6 +999,17 @@ export namespace Config {
       layout: Layout.optional().describe("@deprecated Always uses stretch layout."),
       permission: Permission.optional(),
       tools: z.record(z.string(), z.boolean()).optional(),
+      hooks: z
+        .object({
+          PreToolUse: z.array(z.object({ command: z.string(), matcher: z.string().optional(), timeout: z.number().int().positive().optional() })),
+          PostToolUse: z.array(z.object({ command: z.string(), matcher: z.string().optional(), timeout: z.number().int().positive().optional() })),
+          SessionStart: z.array(z.object({ command: z.string(), matcher: z.string().optional(), timeout: z.number().int().positive().optional() })),
+          Notification: z.array(z.object({ command: z.string(), matcher: z.string().optional(), timeout: z.number().int().positive().optional() })),
+        })
+        .strict()
+        .partial()
+        .optional()
+        .describe("Shell script hooks for lifecycle events"),
       enterprise: z
         .object({
           url: z.string().optional().describe("Enterprise URL"),

--- a/packages/opencode/src/hook/execute.ts
+++ b/packages/opencode/src/hook/execute.ts
@@ -1,0 +1,99 @@
+import { Log } from "../util/log"
+import { Process } from "../util/process"
+import type { HookEntry } from "./schema"
+
+const log = Log.create({ service: "hook" })
+const DEFAULT_TIMEOUT = 10_000
+
+export interface HookEnv {
+  OPENCODE_HOOK_EVENT: string
+  OPENCODE_TOOL_NAME?: string
+  OPENCODE_TOOL_INPUT?: string
+  OPENCODE_PROJECT_DIR: string
+  OPENCODE_SESSION_ID: string
+}
+
+export interface HookResult {
+  action: "pass" | "block"
+  message?: string
+}
+
+export async function runHook(entry: HookEntry, env: HookEnv): Promise<HookResult> {
+  const timeout = entry.timeout ?? DEFAULT_TIMEOUT
+  const command = entry.command.replace(/^~/, process.env.HOME ?? "~")
+
+  try {
+    const result = await Process.run(["sh", "-c", command], {
+      env: toEnvRecord(env),
+      abort: AbortSignal.timeout(timeout),
+      nothrow: true,
+    })
+
+    const stderr = result.stderr.toString().trim()
+
+    if (result.code === 0) {
+      return { action: "pass", message: stderr || undefined }
+    }
+    if (result.code === 2) {
+      return { action: "block", message: stderr || "Blocked by hook" }
+    }
+
+    log.warn("hook exited with unexpected code", {
+      command: entry.command,
+      code: result.code,
+      stderr,
+    })
+    return { action: "pass" }
+  } catch (error) {
+    log.warn("hook execution failed", {
+      command: entry.command,
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return { action: "pass" }
+  }
+}
+
+function toEnvRecord(env: HookEnv): Record<string, string> {
+  const record: Record<string, string> = {
+    OPENCODE_HOOK_EVENT: env.OPENCODE_HOOK_EVENT,
+    OPENCODE_PROJECT_DIR: env.OPENCODE_PROJECT_DIR,
+    OPENCODE_SESSION_ID: env.OPENCODE_SESSION_ID,
+  }
+  if (env.OPENCODE_TOOL_NAME !== undefined) record.OPENCODE_TOOL_NAME = env.OPENCODE_TOOL_NAME
+  if (env.OPENCODE_TOOL_INPUT !== undefined) record.OPENCODE_TOOL_INPUT = env.OPENCODE_TOOL_INPUT
+  return record
+}
+
+export function matchesTool(matcher: string | undefined, toolName: string): boolean {
+  if (!matcher) return true
+  if (matcher === toolName) return true
+  if (matcher.endsWith("*")) {
+    return toolName.startsWith(matcher.slice(0, -1))
+  }
+  return false
+}
+
+export async function runHooks(
+  entries: HookEntry[] | undefined,
+  toolName: string,
+  env: HookEnv,
+): Promise<HookResult> {
+  if (!entries || entries.length === 0) return { action: "pass" }
+
+  const messages: string[] = []
+
+  for (const entry of entries) {
+    if (!matchesTool(entry.matcher, toolName)) continue
+
+    const result = await runHook(entry, env)
+    if (result.message) messages.push(result.message)
+    if (result.action === "block") {
+      return { action: "block", message: messages.join("\n") }
+    }
+  }
+
+  return {
+    action: "pass",
+    message: messages.length > 0 ? messages.join("\n") : undefined,
+  }
+}

--- a/packages/opencode/src/hook/index.ts
+++ b/packages/opencode/src/hook/index.ts
@@ -1,0 +1,9 @@
+export {
+  type HookEvent,
+  type HookEntry,
+  type HookConfig,
+  HOOK_EVENTS,
+  HookEntry as HookEntrySchema,
+  HookConfig as HookConfigSchema,
+} from "./schema"
+export { runHooks, runHook, matchesTool, type HookResult, type HookEnv } from "./execute"

--- a/packages/opencode/src/hook/schema.ts
+++ b/packages/opencode/src/hook/schema.ts
@@ -1,0 +1,26 @@
+import z from "zod"
+
+export const HOOK_EVENTS = ["PreToolUse", "PostToolUse", "SessionStart", "Notification"] as const
+export type HookEvent = (typeof HOOK_EVENTS)[number]
+
+export const HookEntry = z.object({
+  command: z.string().describe("Shell command or path to script"),
+  matcher: z.string().optional().describe("Tool name glob pattern (PreToolUse/PostToolUse only)"),
+  timeout: z.number().int().positive().optional().describe("Timeout in ms (default: 10000)"),
+})
+export type HookEntry = z.infer<typeof HookEntry>
+
+const hookEntryArray = z.array(HookEntry)
+
+export const HookConfig = z
+  .object({
+    PreToolUse: hookEntryArray,
+    PostToolUse: hookEntryArray,
+    SessionStart: hookEntryArray,
+    Notification: hookEntryArray,
+  })
+  .strict()
+  .partial()
+  .optional()
+  .describe("Shell script hooks for lifecycle events")
+export type HookConfig = z.infer<typeof HookConfig>

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -48,6 +48,8 @@ import { Shell } from "@/shell/shell"
 import { AppFileSystem } from "@/filesystem"
 import { Truncate } from "@/tool/truncate"
 import { decodeDataUrl } from "@/util/data-url"
+import { runHooks, type HookEnv } from "../hook"
+import { Config } from "../config/config"
 import { Process } from "@/util/process"
 import { Cause, Effect, Exit, Layer, Option, Scope, ServiceMap } from "effect"
 import { InstanceState } from "@/effect/instance-state"
@@ -100,6 +102,7 @@ export namespace SessionPrompt {
       const filetime = yield* FileTime.Service
       const registry = yield* ToolRegistry.Service
       const truncate = yield* Truncate.Service
+      const config = yield* Config.Service
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
       const scope = yield* Scope.Scope
       const instruction = yield* Instruction.Service
@@ -458,6 +461,27 @@ NOTE: At any point in time through this workflow you should feel free to ask the
               return Effect.runPromise(
                 Effect.gen(function* () {
                   const ctx = context(args, options)
+
+                  // Config hooks (shell scripts) — before plugin hooks
+                  const hookCfg = yield* config.get()
+                  const hookEnv: HookEnv = {
+                    OPENCODE_HOOK_EVENT: "PreToolUse",
+                    OPENCODE_TOOL_NAME: item.id,
+                    OPENCODE_TOOL_INPUT: JSON.stringify(args),
+                    OPENCODE_PROJECT_DIR: Instance.directory,
+                    OPENCODE_SESSION_ID: ctx.sessionID,
+                  }
+                  const hookResult = yield* Effect.promise(() =>
+                    runHooks(hookCfg.hooks?.PreToolUse, item.id, hookEnv),
+                  )
+                  if (hookResult.action === "block") {
+                    return {
+                      title: "Blocked by hook",
+                      output: hookResult.message ?? "Tool execution blocked by hook",
+                      metadata: {} as any,
+                    }
+                  }
+
                   yield* plugin.trigger(
                     "tool.execute.before",
                     { tool: item.id, sessionID: ctx.sessionID, callID: ctx.callID },
@@ -478,6 +502,15 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                     { tool: item.id, sessionID: ctx.sessionID, callID: ctx.callID, args },
                     output,
                   )
+
+                  // PostToolUse hooks
+                  yield* Effect.promise(() =>
+                    runHooks(hookCfg.hooks?.PostToolUse, item.id, {
+                      ...hookEnv,
+                      OPENCODE_HOOK_EVENT: "PostToolUse",
+                    }),
+                  )
+
                   return output
                 }),
               )
@@ -496,6 +529,30 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             Effect.runPromise(
               Effect.gen(function* () {
                 const ctx = context(args, opts)
+
+                // Config hooks (shell scripts) — before plugin hooks
+                const mcpHookCfg = yield* config.get()
+                const mcpHookEnv: HookEnv = {
+                  OPENCODE_HOOK_EVENT: "PreToolUse",
+                  OPENCODE_TOOL_NAME: key,
+                  OPENCODE_TOOL_INPUT: JSON.stringify(args),
+                  OPENCODE_PROJECT_DIR: Instance.directory,
+                  OPENCODE_SESSION_ID: ctx.sessionID,
+                }
+                const mcpHookResult = yield* Effect.promise(() =>
+                  runHooks(mcpHookCfg.hooks?.PreToolUse, key, mcpHookEnv),
+                )
+                if (mcpHookResult.action === "block") {
+                  return {
+                    content: [
+                      {
+                        type: "text" as const,
+                        text: mcpHookResult.message ?? "Tool execution blocked by hook",
+                      },
+                    ],
+                  }
+                }
+
                 yield* plugin.trigger(
                   "tool.execute.before",
                   { tool: key, sessionID: ctx.sessionID, callID: opts.toolCallId },
@@ -509,6 +566,14 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   "tool.execute.after",
                   { tool: key, sessionID: ctx.sessionID, callID: opts.toolCallId, args },
                   result,
+                )
+
+                // PostToolUse hooks
+                yield* Effect.promise(() =>
+                  runHooks(mcpHookCfg.hooks?.PostToolUse, key, {
+                    ...mcpHookEnv,
+                    OPENCODE_HOOK_EVENT: "PostToolUse",
+                  }),
                 )
 
                 const textParts: string[] = []
@@ -1330,6 +1395,16 @@ NOTE: At any point in time through this workflow you should feel free to ask the
             yield* sessions.setPermission({ sessionID: session.id, permission: permissions })
           }
 
+          // SessionStart hooks
+          const startHookCfg = yield* config.get()
+          yield* Effect.promise(() =>
+            runHooks(startHookCfg.hooks?.SessionStart, "", {
+              OPENCODE_HOOK_EVENT: "SessionStart",
+              OPENCODE_PROJECT_DIR: Instance.directory,
+              OPENCODE_SESSION_ID: input.sessionID,
+            }),
+          )
+
           if (input.noReply === true) return message
           return yield* loop({ sessionID: input.sessionID })
         },
@@ -1744,6 +1819,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
         Layer.provide(Agent.defaultLayer),
         Layer.provide(Bus.layer),
         Layer.provide(CrossSpawnSpawner.defaultLayer),
+        Layer.provide(Config.defaultLayer),
       ),
     ),
   )

--- a/packages/opencode/test/hook/execute.test.ts
+++ b/packages/opencode/test/hook/execute.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "bun:test"
+import { runHook, runHooks, matchesTool, type HookEnv } from "../../src/hook"
+import type { HookEntry } from "../../src/hook"
+
+function makeEnv(overrides?: Partial<HookEnv>): HookEnv {
+  return {
+    OPENCODE_HOOK_EVENT: "PreToolUse",
+    OPENCODE_TOOL_NAME: "bash",
+    OPENCODE_TOOL_INPUT: "{}",
+    OPENCODE_PROJECT_DIR: "/tmp/test",
+    OPENCODE_SESSION_ID: "test-session-id",
+    ...overrides,
+  }
+}
+
+describe("hook.execute", () => {
+  describe("runHook", () => {
+    test("exit 0 returns pass", async () => {
+      const entry: HookEntry = { command: "exit 0" }
+      const result = await runHook(entry, makeEnv())
+      expect(result.action).toBe("pass")
+    })
+
+    test("exit 0 with stderr returns pass with message", async () => {
+      const entry: HookEntry = { command: 'echo "info message" >&2; exit 0' }
+      const result = await runHook(entry, makeEnv())
+      expect(result.action).toBe("pass")
+      expect(result.message).toBe("info message")
+    })
+
+    test("exit 2 returns block with stderr", async () => {
+      const entry: HookEntry = { command: 'echo "not allowed" >&2; exit 2' }
+      const result = await runHook(entry, makeEnv())
+      expect(result.action).toBe("block")
+      expect(result.message).toBe("not allowed")
+    })
+
+    test("exit 2 without stderr returns block with default message", async () => {
+      const entry: HookEntry = { command: "exit 2" }
+      const result = await runHook(entry, makeEnv())
+      expect(result.action).toBe("block")
+      expect(result.message).toBe("Blocked by hook")
+    })
+
+    test("exit 1 returns pass (unexpected code warning)", async () => {
+      const entry: HookEntry = { command: "exit 1" }
+      const result = await runHook(entry, makeEnv())
+      expect(result.action).toBe("pass")
+    })
+
+    test("exit 3 returns pass (unexpected code warning)", async () => {
+      const entry: HookEntry = { command: "exit 3" }
+      const result = await runHook(entry, makeEnv())
+      expect(result.action).toBe("pass")
+    })
+
+    test("timeout returns pass", async () => {
+      const entry: HookEntry = { command: "sleep 10", timeout: 200 }
+      const result = await runHook(entry, makeEnv())
+      expect(result.action).toBe("pass")
+    }, 5000)
+
+    test("passes environment variables to script", async () => {
+      const entry: HookEntry = { command: 'echo "$OPENCODE_TOOL_NAME" >&2' }
+      const result = await runHook(entry, makeEnv({ OPENCODE_TOOL_NAME: "test_tool" }))
+      expect(result.action).toBe("pass")
+      expect(result.message).toBe("test_tool")
+    })
+
+    test("nonexistent command returns pass", async () => {
+      const entry: HookEntry = { command: "/nonexistent/path/script.sh" }
+      const result = await runHook(entry, makeEnv())
+      expect(result.action).toBe("pass")
+    })
+  })
+
+  describe("matchesTool", () => {
+    test("undefined matcher matches all", () => {
+      expect(matchesTool(undefined, "bash")).toBe(true)
+      expect(matchesTool(undefined, "read")).toBe(true)
+    })
+
+    test("exact match", () => {
+      expect(matchesTool("bash", "bash")).toBe(true)
+      expect(matchesTool("bash", "read")).toBe(false)
+    })
+
+    test("glob match with trailing wildcard", () => {
+      expect(matchesTool("bash*", "bash")).toBe(true)
+      expect(matchesTool("bash*", "bash_tool")).toBe(true)
+      expect(matchesTool("bash*", "read")).toBe(false)
+    })
+
+    test("glob prefix match", () => {
+      expect(matchesTool("mcp_*", "mcp_server")).toBe(true)
+      expect(matchesTool("mcp_*", "mcp_")).toBe(true)
+      expect(matchesTool("mcp_*", "other")).toBe(false)
+    })
+  })
+
+  describe("runHooks", () => {
+    test("empty entries returns pass", async () => {
+      const result = await runHooks([], "bash", makeEnv())
+      expect(result.action).toBe("pass")
+      expect(result.message).toBeUndefined()
+    })
+
+    test("undefined entries returns pass", async () => {
+      const result = await runHooks(undefined, "bash", makeEnv())
+      expect(result.action).toBe("pass")
+      expect(result.message).toBeUndefined()
+    })
+
+    test("runs multiple entries and collects messages", async () => {
+      const entries: HookEntry[] = [
+        { command: 'echo "first" >&2; exit 0' },
+        { command: 'echo "second" >&2; exit 0' },
+      ]
+      const result = await runHooks(entries, "bash", makeEnv())
+      expect(result.action).toBe("pass")
+      expect(result.message).toBe("first\nsecond")
+    })
+
+    test("stops at first block", async () => {
+      const entries: HookEntry[] = [
+        { command: 'echo "ok" >&2; exit 0' },
+        { command: 'echo "blocked" >&2; exit 2' },
+        { command: 'echo "never" >&2; exit 0' },
+      ]
+      const result = await runHooks(entries, "bash", makeEnv())
+      expect(result.action).toBe("block")
+      expect(result.message).toBe("ok\nblocked")
+    })
+
+    test("skips entries that do not match tool name", async () => {
+      const entries: HookEntry[] = [
+        { command: 'echo "matched" >&2; exit 0', matcher: "bash" },
+        { command: 'echo "skipped" >&2; exit 2', matcher: "read" },
+      ]
+      const result = await runHooks(entries, "bash", makeEnv())
+      expect(result.action).toBe("pass")
+      expect(result.message).toBe("matched")
+    })
+
+    test("entries without matcher run for all tools", async () => {
+      const entries: HookEntry[] = [{ command: 'echo "global" >&2; exit 0' }]
+      const result = await runHooks(entries, "any_tool", makeEnv())
+      expect(result.action).toBe("pass")
+      expect(result.message).toBe("global")
+    })
+  })
+})

--- a/packages/opencode/test/hook/schema.test.ts
+++ b/packages/opencode/test/hook/schema.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test"
+import { HOOK_EVENTS } from "../../src/hook"
+import { HookEntrySchema, HookConfigSchema } from "../../src/hook"
+
+describe("hook.schema", () => {
+  describe("HOOK_EVENTS", () => {
+    test("contains expected events", () => {
+      expect(HOOK_EVENTS).toEqual(["PreToolUse", "PostToolUse", "SessionStart", "Notification"])
+    })
+  })
+
+  describe("HookEntry", () => {
+    test("validates minimal entry", () => {
+      const result = HookEntrySchema.safeParse({ command: "echo hello" })
+      expect(result.success).toBe(true)
+    })
+
+    test("validates full entry", () => {
+      const result = HookEntrySchema.safeParse({
+        command: "echo hello",
+        matcher: "bash*",
+        timeout: 5000,
+      })
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.command).toBe("echo hello")
+        expect(result.data.matcher).toBe("bash*")
+        expect(result.data.timeout).toBe(5000)
+      }
+    })
+
+    test("rejects missing command", () => {
+      const result = HookEntrySchema.safeParse({})
+      expect(result.success).toBe(false)
+    })
+
+    test("rejects negative timeout", () => {
+      const result = HookEntrySchema.safeParse({ command: "echo", timeout: -1 })
+      expect(result.success).toBe(false)
+    })
+
+    test("rejects zero timeout", () => {
+      const result = HookEntrySchema.safeParse({ command: "echo", timeout: 0 })
+      expect(result.success).toBe(false)
+    })
+
+    test("rejects non-integer timeout", () => {
+      const result = HookEntrySchema.safeParse({ command: "echo", timeout: 1.5 })
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe("HookConfig", () => {
+    test("accepts valid config with all events", () => {
+      const result = HookConfigSchema.safeParse({
+        PreToolUse: [{ command: "echo pre" }],
+        PostToolUse: [{ command: "echo post" }],
+        SessionStart: [{ command: "echo start" }],
+        Notification: [{ command: "echo notify" }],
+      })
+      expect(result.success).toBe(true)
+    })
+
+    test("accepts partial config", () => {
+      const result = HookConfigSchema.safeParse({
+        PreToolUse: [{ command: "echo pre" }],
+      })
+      expect(result.success).toBe(true)
+    })
+
+    test("accepts undefined", () => {
+      const result = HookConfigSchema.safeParse(undefined)
+      expect(result.success).toBe(true)
+    })
+
+    test("rejects invalid event name", () => {
+      const result = HookConfigSchema.safeParse({
+        InvalidEvent: [{ command: "echo" }],
+      })
+      expect(result.success).toBe(false)
+    })
+
+    test("rejects invalid entry in array", () => {
+      const result = HookConfigSchema.safeParse({
+        PreToolUse: [{ notcommand: "echo" }],
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## What
Claude Code 互換の Hook System を実���。ツール実行の前後とセッ���ョン開始時にシェ���スクリプトを実行可能に。

## Why
OpenCode には報告前ファクトチェック強制、CI未通過マージブロック等のガードレールがない��
Claude Code は 47+ hook を PreToolUse/PostToolUse/SessionStart に登録���、exit code 2 でツール実行をブロックする。

Closes #46, closes #47

## Changes
- `hook/schema.ts`: 4イベ���ト種別 (PreToolUse, PostToolUse, SessionStart, Notification) の Zod スキーマ
- `hook/execute.ts`: シェルスクリプト実行エンジン (exit 0=pass, 2=block, other=warn, タイムアウト対応)
- `hook/index.ts`: barrel exports
- `config/config.ts`: hooks フィールド追加
- `session/prompt.ts`: plugin hooks の前に config hooks を挿入、SessionStart hook 統合
- 31 テスト (schema 10 + execute 21)

## Config Example
```json
{
  "hooks": {
    "PreToolUse": [{
      "command": "~/.opencode/hooks/factcheck.sh",
      "matcher": "bash",
      "timeout": 10000
    }]
  }
}
```

## Review
- code-reviewer Agent: running
- Codex CLI: pending (large diff)

## Test plan
- [x] bun test test/hook/ — 31 pass
- [x] typecheck 13/13 pass
- [ ] デプロイゲート 2: hook発火テスト + ブロックテスト