### PR TITLE
fix(hook): CRITICAL env var size + 3 HIGH review findings

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -41,6 +41,7 @@ import { Duration, Effect, Layer, Option, ServiceMap } from "effect"
 import { Flock } from "@/util/flock"
 import { isPathPluginSpec, parsePluginSpecifier, resolvePathPluginTarget } from "@/plugin/shared"
 import { Npm } from "@/npm"
+import { HookConfig } from "../hook/schema"
 
 export namespace Config {
   const ModelId = z.string().meta({ $ref: "https://models.dev/model-schema.json#/$defs/Model" })
@@ -999,17 +1000,7 @@ export namespace Config {
       layout: Layout.optional().describe("@deprecated Always uses stretch layout."),
       permission: Permission.optional(),
       tools: z.record(z.string(), z.boolean()).optional(),
-      hooks: z
-        .object({
-          PreToolUse: z.array(z.object({ command: z.string(), matcher: z.string().optional(), timeout: z.number().int().positive().optional() })),
-          PostToolUse: z.array(z.object({ command: z.string(), matcher: z.string().optional(), timeout: z.number().int().positive().optional() })),
-          SessionStart: z.array(z.object({ command: z.string(), matcher: z.string().optional(), timeout: z.number().int().positive().optional() })),
-          Notification: z.array(z.object({ command: z.string(), matcher: z.string().optional(), timeout: z.number().int().positive().optional() })),
-        })
-        .strict()
-        .partial()
-        .optional()
-        .describe("Shell script hooks for lifecycle events"),
+      hooks: HookConfig,
       enterprise: z
         .object({
           url: z.string().optional().describe("Enterprise URL"),

--- a/packages/opencode/src/hook/execute.ts
+++ b/packages/opencode/src/hook/execute.ts
@@ -5,6 +5,13 @@ import type { HookEntry } from "./schema"
 const log = Log.create({ service: "hook" })
 const DEFAULT_TIMEOUT = 10_000
 
+const MAX_HOOK_INPUT_ENV = 128 * 1024 // 128KB
+export function safeToolInput(args: unknown): string {
+  const raw = JSON.stringify(args)
+  if (raw.length <= MAX_HOOK_INPUT_ENV) return raw
+  return raw.slice(0, MAX_HOOK_INPUT_ENV) + "\n[truncated]"
+}
+
 export interface HookEnv {
   OPENCODE_HOOK_EVENT: string
   OPENCODE_TOOL_NAME?: string

--- a/packages/opencode/src/hook/index.ts
+++ b/packages/opencode/src/hook/index.ts
@@ -6,4 +6,4 @@ export {
   HookEntry as HookEntrySchema,
   HookConfig as HookConfigSchema,
 } from "./schema"
-export { runHooks, runHook, matchesTool, type HookResult, type HookEnv } from "./execute"
+export { runHooks, runHook, matchesTool, safeToolInput, type HookResult, type HookEnv } from "./execute"

--- a/packages/opencode/src/hook/schema.ts
+++ b/packages/opencode/src/hook/schema.ts
@@ -4,7 +4,7 @@ export const HOOK_EVENTS = ["PreToolUse", "PostToolUse", "SessionStart", "Notifi
 export type HookEvent = (typeof HOOK_EVENTS)[number]
 
 export const HookEntry = z.object({
-  command: z.string().describe("Shell command or path to script"),
+  command: z.string().min(1).describe("Shell command or path to script"),
   matcher: z.string().optional().describe("Tool name glob pattern (PreToolUse/PostToolUse only)"),
   timeout: z.number().int().positive().optional().describe("Timeout in ms (default: 10000)"),
 })

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -48,7 +48,7 @@ import { Shell } from "@/shell/shell"
 import { AppFileSystem } from "@/filesystem"
 import { Truncate } from "@/tool/truncate"
 import { decodeDataUrl } from "@/util/data-url"
-import { runHooks, type HookEnv } from "../hook"
+import { runHooks, safeToolInput, type HookEnv } from "../hook"
 import { Config } from "../config/config"
 import { Process } from "@/util/process"
 import { Cause, Effect, Exit, Layer, Option, Scope, ServiceMap } from "effect"
@@ -467,7 +467,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   const hookEnv: HookEnv = {
                     OPENCODE_HOOK_EVENT: "PreToolUse",
                     OPENCODE_TOOL_NAME: item.id,
-                    OPENCODE_TOOL_INPUT: JSON.stringify(args),
+                    OPENCODE_TOOL_INPUT: safeToolInput(args),
                     OPENCODE_PROJECT_DIR: Instance.directory,
                     OPENCODE_SESSION_ID: ctx.sessionID,
                   }
@@ -504,12 +504,20 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   )
 
                   // PostToolUse hooks
-                  yield* Effect.promise(() =>
+                  const postHookResult = yield* Effect.promise(() =>
                     runHooks(hookCfg.hooks?.PostToolUse, item.id, {
                       ...hookEnv,
                       OPENCODE_HOOK_EVENT: "PostToolUse",
-                    }),
+                    }).catch((): { action: "pass" } => ({ action: "pass" })),
                   )
+
+                  if (postHookResult.action === "block") {
+                    return {
+                      title: "Blocked by post-execution hook",
+                      output: postHookResult.message ?? "Tool output suppressed by hook",
+                      metadata: {} as any,
+                    }
+                  }
 
                   return output
                 }),
@@ -535,7 +543,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 const mcpHookEnv: HookEnv = {
                   OPENCODE_HOOK_EVENT: "PreToolUse",
                   OPENCODE_TOOL_NAME: key,
-                  OPENCODE_TOOL_INPUT: JSON.stringify(args),
+                  OPENCODE_TOOL_INPUT: safeToolInput(args),
                   OPENCODE_PROJECT_DIR: Instance.directory,
                   OPENCODE_SESSION_ID: ctx.sessionID,
                 }
@@ -569,12 +577,18 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                 )
 
                 // PostToolUse hooks
-                yield* Effect.promise(() =>
+                const mcpPostResult = yield* Effect.promise(() =>
                   runHooks(mcpHookCfg.hooks?.PostToolUse, key, {
                     ...mcpHookEnv,
                     OPENCODE_HOOK_EVENT: "PostToolUse",
-                  }),
+                  }).catch((): { action: "pass" } => ({ action: "pass" })),
                 )
+
+                if (mcpPostResult.action === "block") {
+                  return {
+                    content: [{ type: "text" as const, text: mcpPostResult.message ?? "Tool output suppressed by hook" }],
+                  }
+                }
 
                 const textParts: string[] = []
                 const attachments: Omit<MessageV2.FilePart, "id" | "sessionID" | "messageID">[] = []

--- a/packages/opencode/test/hook/execute.test.ts
+++ b/packages/opencode/test/hook/execute.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { runHook, runHooks, matchesTool, type HookEnv } from "../../src/hook"
+import { runHook, runHooks, matchesTool, safeToolInput, type HookEnv } from "../../src/hook"
 import type { HookEntry } from "../../src/hook"
 
 function makeEnv(overrides?: Partial<HookEnv>): HookEnv {
@@ -147,6 +147,29 @@ describe("hook.execute", () => {
       const result = await runHooks(entries, "any_tool", makeEnv())
       expect(result.action).toBe("pass")
       expect(result.message).toBe("global")
+    })
+  })
+
+  describe("safeToolInput", () => {
+    test("returns JSON for small input", () => {
+      const result = safeToolInput({ key: "value" })
+      expect(result).toBe('{"key":"value"}')
+    })
+
+    test("truncates input exceeding 128KB", () => {
+      const largeArgs = { data: "x".repeat(256 * 1024) }
+      const result = safeToolInput(largeArgs)
+      expect(result.length).toBeLessThanOrEqual(128 * 1024 + 12) // 128KB + "\n[truncated]"
+      expect(result).toEndWith("\n[truncated]")
+    })
+
+    test("does not truncate input exactly at 128KB", () => {
+      // Create input that serializes to exactly 128KB
+      const targetLen = 128 * 1024
+      const overhead = '{"d":""}'.length
+      const filler = "a".repeat(targetLen - overhead)
+      const result = safeToolInput({ d: filler })
+      expect(result).not.toContain("[truncated]")
     })
   })
 })

--- a/packages/opencode/test/hook/schema.test.ts
+++ b/packages/opencode/test/hook/schema.test.ts
@@ -48,6 +48,11 @@ describe("hook.schema", () => {
       const result = HookEntrySchema.safeParse({ command: "echo", timeout: 1.5 })
       expect(result.success).toBe(false)
     })
+
+    test("rejects empty command string", () => {
+      const result = HookEntrySchema.safeParse({ command: "" })
+      expect(result.success).toBe(false)
+    })
   })
 
   describe("HookConfig", () => {


### PR DESCRIPTION
## What
Hook System (PR #74) の code-reviewer 指摘を修正。

## Why
CRITICAL: OPENCODE_TOOL_INPUT が OS limit 超過で hook を無言バイパスする可能性。

Closes #75

## Changes
- CRITICAL: safeToolInput() で 128KB に truncate
- HIGH: config.ts の inline schema を hook/schema.ts から import に統一
- HIGH: PostToolUse block 結果を検査・反映
- HIGH: command に z.string().min(1) 追加
- テスト 35 pass (4件追加)

## Test plan
- [x] bun test test/hook/ — 35 pass
- [x] typecheck 13/13 pass