### PR TITLE
fix(ci): replace blacksmith runners with ubuntu-latest for fork

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   generate:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/pr-management.yml
+++ b/.github/workflows/pr-management.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check-duplicates:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   unit:
     name: unit (linux)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -70,7 +70,7 @@ jobs:
 
   e2e:
     name: e2e (linux)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     env:
       PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.playwright-browsers
     steps:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   typecheck:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## What
Blacksmith runners を ubuntu-latest に置換。

## Why
Blacksmith は upstream 専用の有料 CI サービス。フォークでは全 CI ジョブが永久 queued。

Closes #77

## Changes
- test.yml, typecheck.yml, generate.yml, pr-management.yml の runs-on を ubuntu-latest に
- 20件の stuck queued ランをキャンセル済み

## Test plan
- [ ] CI ジョブが実際に ubuntu-latest で実行されること