### PR TITLE
feat(rules): add OpenCode project rules for LLM context injection

### DIFF
--- a/.opencode/rules/coding-style.md
+++ b/.opencode/rules/coding-style.md
@@ -14,5 +14,5 @@
 - Use `namespace` + `interface` pattern consistent with this codebase (e.g., `Foo.Info`)
 
 ## Formatting
-- Run `bun format` before committing
+- Run `bunx prettier --write .` before committing (config in root `package.json`)
 - Follow existing file structure conventions — check neighbors before creating new patterns

--- a/.opencode/rules/coding-style.md
+++ b/.opencode/rules/coding-style.md
@@ -1,0 +1,18 @@
+# Coding Style
+
+## Required
+- Immutable: `return { ...obj, field }` — never mutate in place
+- High cohesion, low coupling — organize by feature/domain
+- Functions < 50 lines, files < 800 lines, nesting < 4 levels
+- Validate inputs with Zod; use parameterized queries (no string concat for SQL)
+- No `console.log` in production code; no hardcoded secrets — use env vars
+
+## TypeScript
+- Prefer `const` over `let`; never use `var`
+- Use explicit return types on exported functions
+- Prefer `Effect` patterns where the codebase uses them
+- Use `namespace` + `interface` pattern consistent with this codebase (e.g., `Foo.Info`)
+
+## Formatting
+- Run `bun format` before committing
+- Follow existing file structure conventions — check neighbors before creating new patterns

--- a/.opencode/rules/delegation.md
+++ b/.opencode/rules/delegation.md
@@ -1,0 +1,21 @@
+# Delegation
+
+## Task Assignment
+- Interactive design/decisions: handle directly
+- 2+ independent tasks: delegate to parallel agents
+- Single long-running autonomous task: delegate to background worker
+- Code review: use dedicated reviewer agent
+
+## Parallel Execution Limits
+- Sub-agents: max 5-7 concurrent
+- Bash commands: max 3-4 concurrent
+- Total active tasks: max 7
+
+## Review Pipeline
+- Source code changes: full review (code-reviewer + second opinion)
+- CI/config/docs only: light review (code-reviewer only)
+- docs/chore/ci branches: review optional
+
+## Context Window Management
+- At 20% remaining: stop new tasks, focus on completion
+- At 10% remaining: save state and suggest continuation session

--- a/.opencode/rules/git-workflow.md
+++ b/.opencode/rules/git-workflow.md
@@ -7,7 +7,7 @@
 
 ## Commits
 - Format: `<type>: <description>` or `<type>(<scope>): <description>`
-- Types: feat / fix / refactor / docs / test / chore / perf / ci / release
+- Types: feat / fix / docs / chore / refactor / test (enforced by `pr-standards.yml`)
 - One intent per commit — do not mix unrelated changes
 
 ## Pull Requests

--- a/.opencode/rules/git-workflow.md
+++ b/.opencode/rules/git-workflow.md
@@ -1,0 +1,21 @@
+# Git Workflow
+
+## Branches
+- Protected: dev, main — no direct push, PR only
+- Naming: `feat/<desc>`, `fix/<desc>`, `refactor/<desc>`, `chore/<desc>`
+- Base all branches on `dev` (not `main`)
+
+## Commits
+- Format: `<type>: <description>` or `<type>(<scope>): <description>`
+- Types: feat / fix / refactor / docs / test / chore / perf / ci / release
+- One intent per commit — do not mix unrelated changes
+
+## Pull Requests
+- 1 PR = 1 intent; branch name type must match PR title type
+- feat PRs must include tests
+- CI checks must all pass before merge (`gh pr checks`)
+- Fix PRs must reference the original PR/commit being fixed
+
+## Merge
+- Default: merge commit (`--merge`)
+- Squash only when explicitly requested

--- a/.opencode/rules/quality.md
+++ b/.opencode/rules/quality.md
@@ -1,0 +1,19 @@
+# Quality
+
+## Zero Tolerance
+- Fix all errors and warnings immediately — "out of scope" and "known issue" are not excuses
+- Before commit: lint, typecheck (`bun typecheck`), and tests must all pass
+
+## Completion Definition
+- "Done" = implementation + tests + doc updates + user-perspective verification
+- Re-read the original request before reporting completion; verify each item has code changes
+- Bug fixes: grep all instances -> fix all -> re-grep to confirm zero remaining
+
+## Pre-Merge Checklist
+- No env vars or secrets in code
+- Endpoint changes: verify client -> API route -> backend -> response alignment
+- Update related docs in the same PR (grep for references)
+
+## Fact Verification
+- Back claims with CLI output, git diff, or API responses
+- Mark unverified statements as "(unverified)"

--- a/.opencode/rules/security.md
+++ b/.opencode/rules/security.md
@@ -1,0 +1,19 @@
+# Security
+
+## Pre-Commit
+- No API keys, tokens, or credentials in source code
+- Sanitize user input — prevent XSS (escape HTML output)
+- Use CSRF protection on state-changing endpoints
+- Verify authentication and authorization on every protected route
+
+## Secrets
+- Store in environment variables only
+- Use `.env` files locally (never committed — must be in `.gitignore`)
+- Rotate secrets immediately if exposed
+
+## Incident Response
+1. Stop the bleeding (disable affected endpoint/key)
+2. Run security scan on affected code
+3. Fix CRITICAL and HIGH findings immediately
+4. Rotate any exposed secrets
+5. Grep for impact scope across the codebase

--- a/.opencode/rules/testing.md
+++ b/.opencode/rules/testing.md
@@ -4,7 +4,7 @@
 - Target: 80%+ (unit + integration + E2E combined)
 
 ## Test Levels
-- Unit: `bun test` — isolated logic, pure functions
+- Unit: `bun --cwd packages/opencode test` or `bun turbo test:ci` — isolated logic, pure functions
 - Integration: HTTP client tests — API endpoints, service interactions
 - E2E: Playwright or manual browser — never report curl tests as E2E
 

--- a/.opencode/rules/testing.md
+++ b/.opencode/rules/testing.md
@@ -1,0 +1,19 @@
+# Testing
+
+## Coverage
+- Target: 80%+ (unit + integration + E2E combined)
+
+## Test Levels
+- Unit: `bun test` — isolated logic, pure functions
+- Integration: HTTP client tests — API endpoints, service interactions
+- E2E: Playwright or manual browser — never report curl tests as E2E
+
+## TDD Workflow
+- RED: write a failing test first
+- GREEN: write minimal code to pass
+- IMPROVE: refactor while keeping tests green
+- Verify coverage after each cycle
+
+## Falsifiability
+- Every test must fail when the bug it guards against is reintroduced
+- If a test passes regardless of the bug's presence, it is not a valid test


### PR DESCRIPTION
## Summary
- `.opencode/rules/` に6つのルールファイルを追加（coding-style, git-workflow, quality, testing, security, delegation）
- `instruction.ts` が自動的にglob読み込みするため、コード変更なし

## What
OpenCode のプロジェクトルール `.opencode/rules/` ディレクトリに、LLMコンテキストに注入されるルールファイルを配置。

## Type
- [x] Feature

## Verify
- `instruction.ts:152-160` のglob `*.md` が6ファイルすべてを読み込むことを確認
- プロジェクトルールがグローバルルールをファイル名でオーバーライドすることを確認

## Checklist
- [x] ルールファイル作成
- [x] 読み込みパス検証
- [x] 各ルール30行以内

## Issue
Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)