### PR TITLE
fix(hook): inject stderr context from pass hooks into tool output

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -503,11 +503,6 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                     output,
                   )
 
-                  // Inject PreToolUse hook context into output
-                  if (hookResult.message) {
-                    output.output = `<hook-context>\n${hookResult.message}\n</hook-context>\n\n${output.output}`
-                  }
-
                   // PostToolUse hooks
                   const postHookResult = yield* Effect.promise(() =>
                     runHooks(hookCfg.hooks?.PostToolUse, item.id, {
@@ -524,12 +519,16 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                     }
                   }
 
-                  // Inject PostToolUse hook context into output
+                  // Inject hook context into output (immutable)
+                  let finalOutput = output.output
+                  if (hookResult.message) {
+                    finalOutput = `<hook-context>\n${hookResult.message}\n</hook-context>\n\n${finalOutput}`
+                  }
                   if (postHookResult.message) {
-                    output.output = `${output.output}\n\n<hook-context>\n${postHookResult.message}\n</hook-context>`
+                    finalOutput = `${finalOutput}\n\n<hook-context>\n${postHookResult.message}\n</hook-context>`
                   }
 
-                  return output
+                  return { ...output, output: finalOutput }
                 }),
               )
             },

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -48,7 +48,7 @@ import { Shell } from "@/shell/shell"
 import { AppFileSystem } from "@/filesystem"
 import { Truncate } from "@/tool/truncate"
 import { decodeDataUrl } from "@/util/data-url"
-import { runHooks, safeToolInput, type HookEnv } from "../hook"
+import { runHooks, safeToolInput, type HookEnv, type HookResult } from "../hook"
 import { Config } from "../config/config"
 import { Process } from "@/util/process"
 import { Cause, Effect, Exit, Layer, Option, Scope, ServiceMap } from "effect"
@@ -513,7 +513,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                     runHooks(hookCfg.hooks?.PostToolUse, item.id, {
                       ...hookEnv,
                       OPENCODE_HOOK_EVENT: "PostToolUse",
-                    }).catch((): { action: "pass" } => ({ action: "pass" })),
+                    }).catch((): HookResult => ({ action: "pass" })),
                   )
 
                   if (postHookResult.action === "block") {
@@ -591,7 +591,7 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   runHooks(mcpHookCfg.hooks?.PostToolUse, key, {
                     ...mcpHookEnv,
                     OPENCODE_HOOK_EVENT: "PostToolUse",
-                  }).catch((): { action: "pass" } => ({ action: "pass" })),
+                  }).catch((): HookResult => ({ action: "pass" })),
                 )
 
                 if (mcpPostResult.action === "block") {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -503,6 +503,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                     output,
                   )
 
+                  // Inject PreToolUse hook context into output
+                  if (hookResult.message) {
+                    output.output = `<hook-context>\n${hookResult.message}\n</hook-context>\n\n${output.output}`
+                  }
+
                   // PostToolUse hooks
                   const postHookResult = yield* Effect.promise(() =>
                     runHooks(hookCfg.hooks?.PostToolUse, item.id, {
@@ -517,6 +522,11 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                       output: postHookResult.message ?? "Tool output suppressed by hook",
                       metadata: {} as any,
                     }
+                  }
+
+                  // Inject PostToolUse hook context into output
+                  if (postHookResult.message) {
+                    output.output = `${output.output}\n\n<hook-context>\n${postHookResult.message}\n</hook-context>`
                   }
 
                   return output
@@ -621,10 +631,19 @@ NOTE: At any point in time through this workflow you should feel free to ask the
                   ...(truncated.truncated && { outputPath: truncated.outputPath }),
                 }
 
+                // Inject hook context from PreToolUse and PostToolUse
+                let mcpOutput = truncated.content
+                if (mcpHookResult.message) {
+                  mcpOutput = `<hook-context>\n${mcpHookResult.message}\n</hook-context>\n\n${mcpOutput}`
+                }
+                if (mcpPostResult.message) {
+                  mcpOutput = `${mcpOutput}\n\n<hook-context>\n${mcpPostResult.message}\n</hook-context>`
+                }
+
                 return {
                   title: "",
                   metadata,
-                  output: truncated.content,
+                  output: mcpOutput,
                   attachments: attachments.map((attachment) => ({
                     ...attachment,
                     id: PartID.ascending(),

--- a/packages/opencode/test/hook/context-injection.test.ts
+++ b/packages/opencode/test/hook/context-injection.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from "bun:test"
+import { runHooks, type HookEnv } from "../../src/hook"
+import type { HookEntry } from "../../src/hook"
+
+function makeEnv(overrides?: Partial<HookEnv>): HookEnv {
+  return {
+    OPENCODE_HOOK_EVENT: "PreToolUse",
+    OPENCODE_TOOL_NAME: "bash",
+    OPENCODE_TOOL_INPUT: "{}",
+    OPENCODE_PROJECT_DIR: "/tmp/test",
+    OPENCODE_SESSION_ID: "test-session-id",
+    ...overrides,
+  }
+}
+
+/**
+ * Applies PreToolUse hook context injection to built-in tool output.
+ * Mirrors the logic in prompt.ts Site 1.
+ */
+function injectPreToolUseContext(
+  hookMessage: string | undefined,
+  originalOutput: string,
+): string {
+  if (hookMessage) {
+    return `<hook-context>\n${hookMessage}\n</hook-context>\n\n${originalOutput}`
+  }
+  return originalOutput
+}
+
+/**
+ * Applies PostToolUse hook context injection to built-in tool output.
+ * Mirrors the logic in prompt.ts Site 2.
+ */
+function injectPostToolUseContext(
+  hookMessage: string | undefined,
+  currentOutput: string,
+): string {
+  if (hookMessage) {
+    return `${currentOutput}\n\n<hook-context>\n${hookMessage}\n</hook-context>`
+  }
+  return currentOutput
+}
+
+describe("hook context injection", () => {
+  describe("PreToolUse pass-with-message injects <hook-context>", () => {
+    test("stderr message from exit 0 produces hook-context prefix", async () => {
+      const entries: HookEntry[] = [
+        { command: 'echo "security warning: path is sensitive" >&2; exit 0' },
+      ]
+      const result = await runHooks(entries, "bash", makeEnv())
+
+      expect(result.action).toBe("pass")
+      expect(result.message).toBe("security warning: path is sensitive")
+
+      const toolOutput = "file contents here"
+      const injected = injectPreToolUseContext(result.message, toolOutput)
+      expect(injected).toBe(
+        `<hook-context>\nsecurity warning: path is sensitive\n</hook-context>\n\n${toolOutput}`,
+      )
+    })
+
+    test("multiple hook messages are joined and wrapped", async () => {
+      const entries: HookEntry[] = [
+        { command: 'echo "check-1: ok" >&2; exit 0' },
+        { command: 'echo "check-2: warning" >&2; exit 0' },
+      ]
+      const result = await runHooks(entries, "bash", makeEnv())
+
+      expect(result.action).toBe("pass")
+      expect(result.message).toBe("check-1: ok\ncheck-2: warning")
+
+      const toolOutput = "tool result"
+      const injected = injectPreToolUseContext(result.message, toolOutput)
+      expect(injected).toContain("<hook-context>")
+      expect(injected).toContain("check-1: ok\ncheck-2: warning")
+      expect(injected).toEndWith(toolOutput)
+    })
+  })
+
+  describe("pass-without-message leaves output unchanged", () => {
+    test("exit 0 without stderr produces no injection", async () => {
+      const entries: HookEntry[] = [{ command: "exit 0" }]
+      const result = await runHooks(entries, "bash", makeEnv())
+
+      expect(result.action).toBe("pass")
+      expect(result.message).toBeUndefined()
+
+      const toolOutput = "original output"
+      const injected = injectPreToolUseContext(result.message, toolOutput)
+      expect(injected).toBe(toolOutput)
+    })
+
+    test("empty entries produce no injection", async () => {
+      const result = await runHooks([], "bash", makeEnv())
+
+      expect(result.action).toBe("pass")
+      expect(result.message).toBeUndefined()
+
+      const toolOutput = "original output"
+      const injected = injectPreToolUseContext(result.message, toolOutput)
+      expect(injected).toBe(toolOutput)
+    })
+  })
+
+  describe("block still works as before", () => {
+    test("exit 2 returns block and does not reach injection", async () => {
+      const entries: HookEntry[] = [
+        { command: 'echo "forbidden" >&2; exit 2' },
+      ]
+      const result = await runHooks(entries, "bash", makeEnv())
+
+      expect(result.action).toBe("block")
+      expect(result.message).toBe("forbidden")
+
+      // In prompt.ts, block returns early before injection code runs.
+      // Verify the block message is usable as-is for the error output.
+      expect(result.message).not.toContain("<hook-context>")
+    })
+  })
+
+  describe("PostToolUse context injection", () => {
+    test("post-hook message is appended as suffix", async () => {
+      const entries: HookEntry[] = [
+        { command: 'echo "audit: file was read" >&2; exit 0' },
+      ]
+      const result = await runHooks(
+        entries,
+        "bash",
+        makeEnv({ OPENCODE_HOOK_EVENT: "PostToolUse" }),
+      )
+
+      expect(result.action).toBe("pass")
+      expect(result.message).toBe("audit: file was read")
+
+      const toolOutput = "file contents here"
+      const injected = injectPostToolUseContext(result.message, toolOutput)
+      expect(injected).toBe(
+        `${toolOutput}\n\n<hook-context>\naudit: file was read\n</hook-context>`,
+      )
+    })
+
+    test("post-hook without message leaves output unchanged", async () => {
+      const entries: HookEntry[] = [{ command: "exit 0" }]
+      const result = await runHooks(
+        entries,
+        "bash",
+        makeEnv({ OPENCODE_HOOK_EVENT: "PostToolUse" }),
+      )
+
+      expect(result.action).toBe("pass")
+      expect(result.message).toBeUndefined()
+
+      const toolOutput = "original output"
+      const injected = injectPostToolUseContext(result.message, toolOutput)
+      expect(injected).toBe(toolOutput)
+    })
+  })
+
+  describe("combined Pre + Post injection", () => {
+    test("both hooks inject context around tool output", async () => {
+      const preEntries: HookEntry[] = [
+        { command: 'echo "pre-context: checking" >&2; exit 0' },
+      ]
+      const postEntries: HookEntry[] = [
+        { command: 'echo "post-context: logged" >&2; exit 0' },
+      ]
+
+      const preResult = await runHooks(preEntries, "bash", makeEnv())
+      const postResult = await runHooks(
+        postEntries,
+        "bash",
+        makeEnv({ OPENCODE_HOOK_EVENT: "PostToolUse" }),
+      )
+
+      let output = "tool execution result"
+      output = injectPreToolUseContext(preResult.message, output)
+      output = injectPostToolUseContext(postResult.message, output)
+
+      expect(output).toStartWith("<hook-context>\npre-context: checking\n</hook-context>")
+      expect(output).toContain("tool execution result")
+      expect(output).toEndWith("<hook-context>\npost-context: logged\n</hook-context>")
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- `prompt.ts` の4つのhook呼び出し箇所で、pass時の `hookResult.message` を `<hook-context>` タグとしてtool outputに注入
- Built-in tools: PreToolUse → prefix、PostToolUse → suffix
- MCP tools: 同様のパターンでcontent配列に注入
- `.catch()` の戻り値型を `HookResult` に修正
- 8テスト追加、全43 hookテストパス

## What
Issue #47 の受入基準「exit 0: stderrがあればコンテキスト注入」を実装。`runHooks()` は正しく pass message を返していたが、`prompt.ts` が `action === "block"` のみチェックして破棄していた。

## Type
- [x] Bug fix

## Verify
- `bun test test/hook/` — 43テスト全パス (既存22 + schema13 + 新規8)
- `bun typecheck` — 全パッケージパス
- hook が stderr 出力 + exit 0 → `<hook-context>` がtool outputに含まれることを確認

## Checklist
- [x] Built-in tools PreToolUse/PostToolUse 注入
- [x] MCP tools PreToolUse/PostToolUse 注入
- [x] .catch() 型修正
- [x] テスト追加 (8件)
- [x] execute.ts 変更なし

## Issue
Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)