### PR TITLE
feat(hook): wire Notification event to runtime at notification call sites

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -61,6 +61,8 @@ import { TuiConfig } from "@/config/tui"
 import { createTuiApi, TuiPluginRuntime, type RouteMap } from "./plugin"
 import { FormatError, FormatUnknownError } from "@/cli/error"
 import { Notification } from "@/notification"
+import { Config } from "@/config/config"
+import { runHooks, type HookEnv } from "@/hook"
 
 async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {
   // can't set raw mode if not a TTY
@@ -841,7 +843,23 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     if (focused) return
 
     const sessionID = evt.properties.sessionID
-    Notification.show("opencode", `${sessionID} completed`).catch(() => {})
+    const title = "opencode"
+    const body = `${sessionID} completed`
+
+    const cfg = await Config.get().catch(() => undefined)
+    const hookEntries = cfg?.hooks?.Notification
+    if (hookEntries && hookEntries.length > 0) {
+      const hookEnv: HookEnv = {
+        OPENCODE_HOOK_EVENT: "Notification",
+        OPENCODE_TOOL_INPUT: JSON.stringify({ title, body }),
+        OPENCODE_PROJECT_DIR: sdk.directory ?? "",
+        OPENCODE_SESSION_ID: sessionID,
+      }
+      const hookResult = await runHooks(hookEntries, "", hookEnv)
+      if (hookResult.action === "block") return
+    }
+
+    Notification.show(title, body).catch(() => {})
   })
 
   sdk.event.on("session.error", (evt) => {
@@ -855,10 +873,27 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       duration: 5000,
     })
 
-    void Notification.terminalIsFocused().then((focused) => {
+    void Notification.terminalIsFocused().then(async (focused) => {
       if (focused) return
       if (tuiConfig.notifications === false) return
-      Notification.show("opencode", `Error: ${message}`)
+
+      const title = "opencode"
+      const body = `Error: ${message}`
+
+      const cfg = await Config.get().catch(() => undefined)
+      const hookEntries = cfg?.hooks?.Notification
+      if (hookEntries && hookEntries.length > 0) {
+        const hookEnv: HookEnv = {
+          OPENCODE_HOOK_EVENT: "Notification",
+          OPENCODE_TOOL_INPUT: JSON.stringify({ title, body }),
+          OPENCODE_PROJECT_DIR: sdk.directory ?? "",
+          OPENCODE_SESSION_ID: "",
+        }
+        const hookResult = await runHooks(hookEntries, "", hookEnv)
+        if (hookResult.action === "block") return
+      }
+
+      Notification.show(title, body)
     })
   })
 

--- a/packages/opencode/src/cli/cmd/tui/app.tsx
+++ b/packages/opencode/src/cli/cmd/tui/app.tsx
@@ -64,6 +64,26 @@ import { Notification } from "@/notification"
 import { Config } from "@/config/config"
 import { runHooks, type HookEnv } from "@/hook"
 
+async function runNotificationHook(opts: {
+  title: string
+  body: string
+  sessionID: string
+  projectDir: string
+}): Promise<"pass" | "block"> {
+  const cfg = await Config.get().catch(() => undefined)
+  const hookEntries = cfg?.hooks?.Notification
+  if (!hookEntries || hookEntries.length === 0) return "pass"
+
+  const hookEnv: HookEnv = {
+    OPENCODE_HOOK_EVENT: "Notification",
+    OPENCODE_TOOL_INPUT: JSON.stringify({ title: opts.title, body: opts.body }),
+    OPENCODE_PROJECT_DIR: opts.projectDir,
+    OPENCODE_SESSION_ID: opts.sessionID,
+  }
+  const hookResult = await runHooks(hookEntries, "", hookEnv)
+  return hookResult.action
+}
+
 async function getTerminalBackgroundColor(): Promise<"dark" | "light"> {
   // can't set raw mode if not a TTY
   if (!process.stdin.isTTY) return "dark"
@@ -846,18 +866,7 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
     const title = "opencode"
     const body = `${sessionID} completed`
 
-    const cfg = await Config.get().catch(() => undefined)
-    const hookEntries = cfg?.hooks?.Notification
-    if (hookEntries && hookEntries.length > 0) {
-      const hookEnv: HookEnv = {
-        OPENCODE_HOOK_EVENT: "Notification",
-        OPENCODE_TOOL_INPUT: JSON.stringify({ title, body }),
-        OPENCODE_PROJECT_DIR: sdk.directory ?? "",
-        OPENCODE_SESSION_ID: sessionID,
-      }
-      const hookResult = await runHooks(hookEntries, "", hookEnv)
-      if (hookResult.action === "block") return
-    }
+    if ((await runNotificationHook({ title, body, sessionID, projectDir: sdk.directory ?? "" })) === "block") return
 
     Notification.show(title, body).catch(() => {})
   })
@@ -873,28 +882,22 @@ function App(props: { onSnapshot?: () => Promise<string[]> }) {
       duration: 5000,
     })
 
-    void Notification.terminalIsFocused().then(async (focused) => {
-      if (focused) return
-      if (tuiConfig.notifications === false) return
+    void Notification.terminalIsFocused()
+      .then(async (focused) => {
+        if (focused) return
+        if (tuiConfig.notifications === false) return
 
-      const title = "opencode"
-      const body = `Error: ${message}`
+        const title = "opencode"
+        const body = `Error: ${message}`
+        // sessionID is optional on session.error (see Session.Event.Error schema);
+        // fall back to empty string when the server omits it.
+        const sessionID = evt.properties.sessionID ?? ""
 
-      const cfg = await Config.get().catch(() => undefined)
-      const hookEntries = cfg?.hooks?.Notification
-      if (hookEntries && hookEntries.length > 0) {
-        const hookEnv: HookEnv = {
-          OPENCODE_HOOK_EVENT: "Notification",
-          OPENCODE_TOOL_INPUT: JSON.stringify({ title, body }),
-          OPENCODE_PROJECT_DIR: sdk.directory ?? "",
-          OPENCODE_SESSION_ID: "",
-        }
-        const hookResult = await runHooks(hookEntries, "", hookEnv)
-        if (hookResult.action === "block") return
-      }
+        if ((await runNotificationHook({ title, body, sessionID, projectDir: sdk.directory ?? "" })) === "block") return
 
-      Notification.show(title, body)
-    })
+        Notification.show(title, body).catch(() => {})
+      })
+      .catch(() => {})
   })
 
   sdk.event.on("installation.update-available", async (evt) => {

--- a/packages/opencode/test/hook/notification-hook.test.ts
+++ b/packages/opencode/test/hook/notification-hook.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test"
+import { runHooks, type HookEnv } from "../../src/hook"
+import type { HookEntry } from "../../src/hook"
+
+function makeNotificationEnv(overrides?: Partial<HookEnv>): HookEnv {
+  return {
+    OPENCODE_HOOK_EVENT: "Notification",
+    OPENCODE_TOOL_INPUT: JSON.stringify({ title: "opencode", body: "session completed" }),
+    OPENCODE_PROJECT_DIR: "/tmp/test",
+    OPENCODE_SESSION_ID: "test-session-id",
+    ...overrides,
+  }
+}
+
+describe("hook.notification", () => {
+  describe("Notification hook env vars", () => {
+    test("receives OPENCODE_HOOK_EVENT as Notification", async () => {
+      const entry: HookEntry = {
+        command: 'test "$OPENCODE_HOOK_EVENT" = "Notification" && exit 0 || exit 1',
+      }
+      const result = await runHooks([entry], "", makeNotificationEnv())
+      expect(result.action).toBe("pass")
+    })
+
+    test("receives OPENCODE_TOOL_INPUT with title and body", async () => {
+      const entry: HookEntry = {
+        command: 'echo "$OPENCODE_TOOL_INPUT" >&2; exit 0',
+      }
+      const env = makeNotificationEnv({
+        OPENCODE_TOOL_INPUT: JSON.stringify({ title: "opencode", body: "test completed" }),
+      })
+      const result = await runHooks([entry], "", env)
+      expect(result.action).toBe("pass")
+      expect(result.message).toContain("opencode")
+      expect(result.message).toContain("test completed")
+    })
+
+    test("receives OPENCODE_PROJECT_DIR", async () => {
+      const entry: HookEntry = {
+        command: 'echo "$OPENCODE_PROJECT_DIR" >&2; exit 0',
+      }
+      const env = makeNotificationEnv({ OPENCODE_PROJECT_DIR: "/my/project" })
+      const result = await runHooks([entry], "", env)
+      expect(result.action).toBe("pass")
+      expect(result.message).toBe("/my/project")
+    })
+
+    test("receives OPENCODE_SESSION_ID", async () => {
+      const entry: HookEntry = {
+        command: 'echo "$OPENCODE_SESSION_ID" >&2; exit 0',
+      }
+      const env = makeNotificationEnv({ OPENCODE_SESSION_ID: "sess-abc123" })
+      const result = await runHooks([entry], "", env)
+      expect(result.action).toBe("pass")
+      expect(result.message).toBe("sess-abc123")
+    })
+
+    test("OPENCODE_TOOL_NAME is not set for notification hooks", async () => {
+      const entry: HookEntry = {
+        command: 'test -z "$OPENCODE_TOOL_NAME" && echo "empty" >&2 || echo "set" >&2; exit 0',
+      }
+      const result = await runHooks([entry], "", makeNotificationEnv())
+      expect(result.action).toBe("pass")
+      expect(result.message).toBe("empty")
+    })
+  })
+
+  describe("block action suppresses notification", () => {
+    test("exit 2 returns block", async () => {
+      const entries: HookEntry[] = [
+        { command: 'echo "suppressed" >&2; exit 2' },
+      ]
+      const result = await runHooks(entries, "", makeNotificationEnv())
+      expect(result.action).toBe("block")
+      expect(result.message).toBe("suppressed")
+    })
+
+    test("first entry passes, second blocks", async () => {
+      const entries: HookEntry[] = [
+        { command: 'echo "logging" >&2; exit 0' },
+        { command: 'echo "blocked" >&2; exit 2' },
+      ]
+      const result = await runHooks(entries, "", makeNotificationEnv())
+      expect(result.action).toBe("block")
+      expect(result.message).toBe("logging\nblocked")
+    })
+  })
+
+  describe("pass action allows notification", () => {
+    test("exit 0 returns pass", async () => {
+      const entries: HookEntry[] = [{ command: "exit 0" }]
+      const result = await runHooks(entries, "", makeNotificationEnv())
+      expect(result.action).toBe("pass")
+    })
+
+    test("multiple passing entries all run", async () => {
+      const entries: HookEntry[] = [
+        { command: 'echo "first" >&2; exit 0' },
+        { command: 'echo "second" >&2; exit 0' },
+      ]
+      const result = await runHooks(entries, "", makeNotificationEnv())
+      expect(result.action).toBe("pass")
+      expect(result.message).toBe("first\nsecond")
+    })
+
+    test("unexpected exit code (1) treated as pass", async () => {
+      const entries: HookEntry[] = [{ command: "exit 1" }]
+      const result = await runHooks(entries, "", makeNotificationEnv())
+      expect(result.action).toBe("pass")
+    })
+  })
+
+  describe("empty/undefined entries", () => {
+    test("undefined entries returns pass", async () => {
+      const result = await runHooks(undefined, "", makeNotificationEnv())
+      expect(result.action).toBe("pass")
+    })
+
+    test("empty entries returns pass", async () => {
+      const result = await runHooks([], "", makeNotificationEnv())
+      expect(result.action).toBe("pass")
+    })
+  })
+
+  describe("matcher is ignored for notification hooks (toolName is empty)", () => {
+    test("entries with matcher still run when toolName is empty", async () => {
+      const entries: HookEntry[] = [
+        { command: 'echo "ran" >&2; exit 0', matcher: "bash" },
+      ]
+      // matcher "bash" does not match empty string toolName, so this entry is skipped
+      const result = await runHooks(entries, "", makeNotificationEnv())
+      expect(result.action).toBe("pass")
+      expect(result.message).toBeUndefined()
+    })
+
+    test("entries without matcher run for notification hooks", async () => {
+      const entries: HookEntry[] = [
+        { command: 'echo "global" >&2; exit 0' },
+      ]
+      const result = await runHooks(entries, "", makeNotificationEnv())
+      expect(result.action).toBe("pass")
+      expect(result.message).toBe("global")
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- `app.tsx` の2つの `Notification.show()` 呼び出し箇所に `runHooks(hooks?.Notification, ...)` を追加
- block時は通知をスキップ、pass時は通常通知
- 14テスト追加、全49 hookテストパス

## What
Issue #79: `Notification` hookイベントがschemaに定義済みだがruntime未接続。`session.idle` と `session.error` のNotification発火前にhook実行を追加。

## Type
- [x] Feature

## Verify
- `bun test test/hook/` — 49テスト全パス
- `bun typecheck` — 13パッケージ全パス
- Notification hook設定 → セッション完了時にhook発火確認

## Checklist
- [x] session.idle通知にhook追加
- [x] session.error通知にhook追加
- [x] Config.get()でhook設定取得
- [x] block時の通知スキップ
- [x] テスト追加 (14件)

## Issue
Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)