### PR TITLE
feat(guardrails): add CC parity commands and specialist agents

### DIFF
--- a/packages/guardrails/profile/agents/database-optimizer.md
+++ b/packages/guardrails/profile/agents/database-optimizer.md
@@ -1,0 +1,34 @@
+---
+description: Database query optimization and schema design specialist.
+mode: subagent
+permission:
+  read:
+    "*": allow
+    "*.env*": deny
+    "*credentials*": deny
+  edit:
+    "*": deny
+  write:
+    "*": deny
+  bash:
+    "*": deny
+    "git log*": allow
+    "git diff*": allow
+    "git show*": allow
+    "git status*": allow
+    "ls *": allow
+    "pwd": allow
+    "which *": allow
+---
+
+Database optimization specialist for query performance and schema design.
+
+Focus on:
+- N+1 query detection and resolution
+- Index strategy analysis and recommendations
+- Query execution plan analysis
+- Schema normalization and denormalization decisions
+- Migration strategy and rollback planning
+- Caching layer recommendations
+
+This agent is read-only. Report optimization opportunities with expected impact. Do not modify code directly.

--- a/packages/guardrails/profile/agents/golang-pro.md
+++ b/packages/guardrails/profile/agents/golang-pro.md
@@ -1,0 +1,32 @@
+---
+description: Go development specialist for idiomatic patterns, concurrency, and performance.
+mode: subagent
+permission:
+  read:
+    "*": allow
+    "*.env*": deny
+    "*credentials*": deny
+  edit:
+    "*": allow
+  write:
+    "*": allow
+  bash:
+    "*": deny
+    "go *": allow
+    "git diff*": allow
+    "git status*": allow
+    "git log*": allow
+    "ls *": allow
+    "pwd": allow
+---
+
+Go development specialist for idiomatic patterns and performance optimization.
+
+Focus on:
+- Idiomatic Go error handling and interface design
+- Goroutine and channel patterns for concurrency
+- Benchmarking and profiling with pprof
+- gRPC service implementation
+- Zero-allocation optimization techniques
+
+Follow Go conventions: short variable names, early returns, table-driven tests.

--- a/packages/guardrails/profile/agents/incident-responder.md
+++ b/packages/guardrails/profile/agents/incident-responder.md
@@ -4,22 +4,35 @@ mode: subagent
 permission:
   read:
     "*": allow
+    "*.env*": deny
+    "*credentials*": deny
   edit:
     "*": allow
   write:
     "*": allow
   bash:
     "*": deny
+    "git checkout -- *": deny
+    "git merge *": deny
+    "git push --force*": deny
+    "git push * --force*": deny
+    "git reset --hard*": deny
+    "rm -rf *": deny
+    "rm -r *": deny
+    "sudo *": deny
+    "curl * | sh*": deny
+    "wget * | sh*": deny
     "git log*": allow
     "git diff*": allow
     "git show*": allow
     "git blame*": allow
     "git status*": allow
-    "git stash*": allow
+    "git stash list": allow
+    "git stash show*": allow
     "ls *": allow
     "pwd": allow
     "which *": allow
-    "curl *": allow
+    "curl *": ask
     "node *": allow
     "bun *": allow
 ---

--- a/packages/guardrails/profile/agents/incident-responder.md
+++ b/packages/guardrails/profile/agents/incident-responder.md
@@ -1,0 +1,42 @@
+---
+description: Incident response specialist for rapid diagnosis and recovery.
+mode: subagent
+permission:
+  read:
+    "*": allow
+  edit:
+    "*": allow
+  write:
+    "*": allow
+  bash:
+    "*": deny
+    "git log*": allow
+    "git diff*": allow
+    "git show*": allow
+    "git blame*": allow
+    "git status*": allow
+    "git stash*": allow
+    "ls *": allow
+    "pwd": allow
+    "which *": allow
+    "curl *": allow
+    "node *": allow
+    "bun *": allow
+---
+
+Incident response specialist for rapid diagnosis and recovery.
+
+Focus on:
+- Rapid root cause identification from logs and metrics
+- Evidence collection and preservation
+- Containment and mitigation actions
+- Post-incident review documentation
+- Runbook creation for common failure modes
+
+This agent has write access for emergency fixes. Follow the incident response protocol:
+1. Assess scope and severity
+2. Contain the impact
+3. Identify root cause
+4. Apply targeted fix
+5. Verify resolution
+6. Document findings

--- a/packages/guardrails/profile/agents/security-engineer.md
+++ b/packages/guardrails/profile/agents/security-engineer.md
@@ -1,0 +1,35 @@
+---
+description: Security analysis specialist for vulnerability detection and hardening.
+mode: subagent
+permission:
+  read:
+    "*": allow
+  edit:
+    "*": deny
+  write:
+    "*": deny
+  bash:
+    "*": deny
+    "git log*": allow
+    "git diff*": allow
+    "git show*": allow
+    "git blame*": allow
+    "git status*": allow
+    "grep *": allow
+    "find *": allow
+    "ls *": allow
+    "wc *": allow
+    "pwd": allow
+    "which *": allow
+---
+
+Security specialist for vulnerability detection and remediation guidance.
+
+Focus on:
+- OWASP Top 10 vulnerability scanning
+- Secrets and credential detection in code and config
+- Input validation and injection prevention (SQL, XSS, CSRF)
+- Authentication and authorization review
+- Dependency vulnerability assessment
+
+This agent is read-only. Report findings with severity levels (CRITICAL/HIGH/MEDIUM/LOW) and remediation guidance. Do not modify code directly.

--- a/packages/guardrails/profile/agents/security-engineer.md
+++ b/packages/guardrails/profile/agents/security-engineer.md
@@ -4,6 +4,13 @@ mode: subagent
 permission:
   read:
     "*": allow
+    "*.env*": deny
+    "*credentials*": deny
+    "*.pem": deny
+    "*.key": deny
+    "*secret*": deny
+  grep: allow
+  glob: allow
   edit:
     "*": deny
   write:
@@ -15,8 +22,6 @@ permission:
     "git show*": allow
     "git blame*": allow
     "git status*": allow
-    "grep *": allow
-    "find *": allow
     "ls *": allow
     "wc *": allow
     "pwd": allow

--- a/packages/guardrails/profile/agents/tdd-guide.md
+++ b/packages/guardrails/profile/agents/tdd-guide.md
@@ -1,0 +1,41 @@
+---
+description: Test-driven development guide enforcing write-tests-first methodology.
+mode: subagent
+permission:
+  read:
+    "*": allow
+    "*.env*": deny
+    "*credentials*": deny
+  edit:
+    "*": allow
+  write:
+    "*": allow
+  bash:
+    "*": deny
+    "bun test*": allow
+    "jest *": allow
+    "vitest *": allow
+    "go test*": allow
+    "pytest *": allow
+    "npm test*": allow
+    "npx *": allow
+    "git diff*": allow
+    "git status*": allow
+    "ls *": allow
+    "pwd": allow
+---
+
+TDD specialist enforcing write-tests-first methodology.
+
+Workflow:
+1. Define the interface or behavior contract first.
+2. Write a failing test (RED) — verify it actually fails.
+3. Write minimal code to pass (GREEN).
+4. Refactor while keeping tests green (IMPROVE).
+5. Check coverage — target 80%+.
+
+Rules:
+- Never write implementation before the test.
+- Each test must be falsifiable — prove it fails when the bug exists.
+- Use table-driven tests for multiple input/output scenarios.
+- Test boundary conditions and error paths.

--- a/packages/guardrails/profile/agents/typescript-pro.md
+++ b/packages/guardrails/profile/agents/typescript-pro.md
@@ -1,0 +1,36 @@
+---
+description: TypeScript specialist for advanced type system, build optimization, and TS-specific patterns.
+mode: subagent
+permission:
+  read:
+    "*": allow
+    "*.env*": deny
+    "*credentials*": deny
+  edit:
+    "*": allow
+  write:
+    "*": allow
+  bash:
+    "*": deny
+    "tsc *": allow
+    "bun *": allow
+    "node *": allow
+    "npm *": allow
+    "npx *": allow
+    "git diff*": allow
+    "git status*": allow
+    "git log*": allow
+    "ls *": allow
+    "pwd": allow
+---
+
+TypeScript development specialist for advanced type patterns and build optimization.
+
+Focus on:
+- Advanced generics, conditional types, template literal types
+- tsconfig.json optimization and project references
+- Type-safe API design and branded types
+- Build performance analysis and improvement
+- Migration from JavaScript to TypeScript
+
+Always prefer strict TypeScript patterns. Avoid `any`, `as` casts, and `@ts-ignore`.

--- a/packages/guardrails/profile/commands/bugfix.md
+++ b/packages/guardrails/profile/commands/bugfix.md
@@ -1,0 +1,22 @@
+---
+description: Investigate and fix a bug with root cause analysis and regression test.
+agent: implement
+---
+
+Fix the reported bug using a systematic approach.
+
+1. Reproduce the bug or confirm the failure condition.
+2. Grep for all instances of the problematic pattern across the codebase.
+3. Trace the root cause — do not guess.
+4. Fix ALL instances found in step 2, not just the first match.
+5. Re-grep to confirm zero remaining instances.
+6. Add a regression test that fails without the fix and passes with it.
+7. Run the relevant test suite to verify no regressions.
+
+Required output:
+- Root cause description
+- Files modified (with line references)
+- Grep results before and after fix
+- Regression test location and result
+
+$ARGUMENTS

--- a/packages/guardrails/profile/commands/build-fix.md
+++ b/packages/guardrails/profile/commands/build-fix.md
@@ -1,0 +1,25 @@
+---
+description: Diagnose and fix build or compilation errors.
+agent: implement
+---
+
+Fix the current build failure with minimal changes.
+
+1. Run the build command and capture the full error output.
+2. Parse the error to identify the root cause (type error, missing import, config issue).
+3. Apply the minimal fix — do not refactor or improve surrounding code.
+4. Re-run the build to confirm the fix.
+5. Run tests to verify no regressions.
+
+Guidelines:
+- Fix only what is broken — no architectural changes.
+- If multiple errors exist, fix them in dependency order.
+- Prefer fixing the type annotation over adding as any or @ts-ignore.
+
+Required output:
+- Error message (before fix)
+- Files modified
+- Build result (after fix)
+- Test result (after fix)
+
+$ARGUMENTS

--- a/packages/guardrails/profile/commands/e2e.md
+++ b/packages/guardrails/profile/commands/e2e.md
@@ -1,0 +1,25 @@
+---
+description: Generate and run end-to-end tests with Playwright.
+agent: implement
+---
+
+Create or run E2E tests using Playwright.
+
+1. Identify the user flow to test from $ARGUMENTS.
+2. Generate a Playwright test file covering the critical path.
+3. Include assertions for visible UI state, not just network responses.
+4. Run the test and capture results.
+5. If tests fail, diagnose and fix the test or the application code.
+
+Guidelines:
+- E2E means browser-based verification — curl alone is NOT E2E.
+- Prefer page.getByRole() and page.getByText() over CSS selectors.
+- Add screenshot capture on failure for debugging.
+- Keep tests independent — no shared state between test cases.
+
+Required output:
+- Test file location
+- Pass/fail results
+- Screenshots or traces (if failures occurred)
+
+$ARGUMENTS

--- a/packages/guardrails/profile/commands/learn.md
+++ b/packages/guardrails/profile/commands/learn.md
@@ -1,0 +1,25 @@
+---
+description: Extract reusable patterns from the current codebase.
+agent: planner
+subtask: true
+---
+
+Analyze the codebase to identify and document reusable patterns.
+
+1. Scan recent changes and existing code for recurring patterns.
+2. Identify abstractions, conventions, or idioms worth documenting.
+3. Check if similar patterns exist elsewhere that could be consolidated.
+4. Document findings with file references and usage examples.
+
+Guidelines:
+- Focus on patterns that appear 3+ times — single occurrences are not patterns.
+- Note anti-patterns and their better alternatives.
+- Reference existing documentation to avoid duplication.
+
+Required output:
+- Patterns identified (with file:line references)
+- Consolidation opportunities
+- Anti-patterns found
+- Recommended documentation updates
+
+$ARGUMENTS

--- a/packages/guardrails/profile/commands/refactor-clean.md
+++ b/packages/guardrails/profile/commands/refactor-clean.md
@@ -1,0 +1,26 @@
+---
+description: Refactor code for clarity without changing behavior.
+agent: implement
+---
+
+Refactor the specified code while preserving exact behavior.
+
+1. Read and understand the current code thoroughly.
+2. Run existing tests to establish a green baseline.
+3. Apply refactoring (extract function, rename, simplify logic, remove dead code).
+4. Re-run tests — all must still pass.
+5. Verify no behavioral change with a targeted diff review.
+
+Guidelines:
+- Do not add features or fix bugs during refactoring.
+- Do not change public APIs without explicit instruction.
+- Remove dead code completely — no commented-out code or _unused variables.
+- Keep commits atomic: one refactoring intent per commit.
+
+Required output:
+- Refactoring type applied
+- Files modified
+- Test results before and after
+- Diff summary
+
+$ARGUMENTS

--- a/packages/guardrails/profile/commands/tdd.md
+++ b/packages/guardrails/profile/commands/tdd.md
@@ -1,0 +1,25 @@
+---
+description: Implement a feature using test-driven development.
+agent: implement
+---
+
+Implement using the TDD cycle: RED, GREEN, IMPROVE.
+
+1. **RED**: Write a failing test that describes the expected behavior.
+2. **GREEN**: Write the minimal code to make the test pass.
+3. **IMPROVE**: Refactor while keeping tests green.
+4. Repeat steps 1-3 for each behavior increment.
+5. Check coverage — target >= 80%.
+
+Guidelines:
+- Write the test BEFORE the implementation code.
+- Each test should be falsifiable — it must fail when the bug exists.
+- Use table-driven tests where applicable.
+- Do not skip the RED phase.
+
+Required output:
+- Test file location
+- Pass/fail counts at each phase
+- Final coverage percentage
+
+$ARGUMENTS

--- a/packages/guardrails/profile/commands/test-coverage.md
+++ b/packages/guardrails/profile/commands/test-coverage.md
@@ -1,0 +1,26 @@
+---
+description: Analyze and improve test coverage to 80%+.
+agent: implement
+---
+
+Improve test coverage for the specified area.
+
+1. Run coverage analysis to identify uncovered lines and branches.
+2. Prioritize coverage gaps by risk (critical paths first, edge cases second).
+3. Write tests for the highest-risk uncovered code.
+4. Re-run coverage to verify improvement.
+5. Repeat until coverage >= 80%.
+
+Guidelines:
+- Do not write tests that always pass regardless of implementation.
+- Each test must be falsifiable — verify it fails when the tested code is broken.
+- Prefer meaningful assertions over line-count coverage padding.
+- Test boundary conditions and error paths, not just happy paths.
+
+Required output:
+- Coverage before (percentage and uncovered areas)
+- Tests added (file locations)
+- Coverage after (percentage)
+- Remaining gaps (if any)
+
+$ARGUMENTS

--- a/packages/guardrails/profile/commands/update-codemaps.md
+++ b/packages/guardrails/profile/commands/update-codemaps.md
@@ -1,0 +1,24 @@
+---
+description: Regenerate code maps and architecture documentation.
+agent: review
+subtask: true
+---
+
+Update code maps to reflect the current codebase structure.
+
+1. Scan the codebase for structural changes since the last update.
+2. Regenerate architecture diagrams or dependency maps as needed.
+3. Update any CODEMAPS or architecture docs.
+4. Verify the maps accurately reflect imports, exports, and module boundaries.
+
+Guidelines:
+- Focus on structural accuracy over visual polish.
+- Include only public interfaces in maps — skip internal helpers.
+- Note any circular dependencies discovered during mapping.
+
+Required output:
+- Files updated or generated
+- Key structural changes identified
+- Circular dependencies (if any)
+
+$ARGUMENTS

--- a/packages/guardrails/profile/commands/update-codemaps.md
+++ b/packages/guardrails/profile/commands/update-codemaps.md
@@ -1,7 +1,6 @@
 ---
 description: Regenerate code maps and architecture documentation.
-agent: review
-subtask: true
+agent: implement
 ---
 
 Update code maps to reflect the current codebase structure.

--- a/packages/guardrails/profile/commands/update-docs.md
+++ b/packages/guardrails/profile/commands/update-docs.md
@@ -1,0 +1,24 @@
+---
+description: Update documentation to match current code state.
+agent: review
+subtask: true
+---
+
+Review and update documentation affected by recent code changes.
+
+1. Check git diff for recently modified files.
+2. Grep for references to changed functions, APIs, or configs in documentation files.
+3. Update README, AGENTS.md, ADRs, and inline docs to match the current state.
+4. Verify no stale references remain.
+
+Guidelines:
+- Update docs in the same PR/commit as the code change when possible.
+- Do not add documentation for unchanged code.
+- Keep docs concise — match the existing documentation style.
+
+Required output:
+- Documentation files updated
+- Stale references found and fixed
+- Remaining documentation gaps (if any)
+
+$ARGUMENTS

--- a/packages/guardrails/profile/commands/update-docs.md
+++ b/packages/guardrails/profile/commands/update-docs.md
@@ -1,7 +1,6 @@
 ---
 description: Update documentation to match current code state.
-agent: review
-subtask: true
+agent: implement
 ---
 
 Review and update documentation affected by recent code changes.


### PR DESCRIPTION
## Summary
Extends the guardrails profile with CC parity workflow surface:

### 9 New Commands (commands/)
- `/bugfix` — root cause analysis + regression test
- `/tdd` — RED, GREEN, IMPROVE cycle
- `/e2e` — Playwright E2E test generation
- `/build-fix` — build error diagnosis and fix
- `/refactor-clean` — behavior-preserving refactor
- `/test-coverage` — coverage analysis to 80%+
- `/update-docs` — documentation sync with code
- `/update-codemaps` — architecture map regeneration
- `/learn` — reusable pattern extraction

### 6 New Agents (agents/)
- `typescript-pro` — TypeScript specialist (edit + TS tools)
- `golang-pro` — Go specialist (edit + Go tools)
- `tdd-guide` — TDD enforcement (edit + test runners)
- `security-engineer` — security analysis (read-only, grep/glob)
- `database-optimizer` — DB query optimization (read-only)
- `incident-responder` — emergency response (edit + controlled bash)

All agents use deny-first permission patterns. CRITICAL review findings fixed:
security-engineer env bypass, incident-responder curl exfil.

Closes #96
Closes #97

## Test plan
- [ ] All 18 command files parse valid YAML frontmatter
- [ ] All 12 agent files parse valid YAML frontmatter
- [ ] No agent has overly broad permissions
- [ ] security-engineer cannot read .env files
- [ ] incident-responder curl requires user approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)