### PR TITLE
feat(guardrails): add quality rules engine to AGENTS.md

### DIFF
--- a/packages/guardrails/profile/AGENTS.md
+++ b/packages/guardrails/profile/AGENTS.md
@@ -12,10 +12,53 @@
 - Keep review paths read-only. If a workflow needs edits, return to `implement` or a project-local implementation agent instead of widening the review agent.
 - All configured providers are available for standard work. The `provider-eval` agent and `/provider-eval` command remain available for dedicated evaluation workflows.
 
+## Code Style
+
+- Immutable: `return { ...user, name }` — no mutations
+- High cohesion, low coupling; organize by feature/domain
+- Functions < 50 lines, files < 800 lines, nesting < 4 levels
+- Validate inputs with Zod; use parameterized queries for SQL
+- No `console.log`, no hardcoded values, secrets in env vars only
+- Pre-commit: no API keys/tokens, XSS prevention, CSRF protection
+
+## Testing
+
+- Coverage ≥ 80% (unit + integration + E2E combined)
+- Test levels: Unit = jest/vitest, Integration = curl/httpx, E2E = Playwright/browser only
+- `curl` alone is NOT E2E — E2E requires browser verification
+- TDD cycle: RED → GREEN → IMPROVE → check coverage
+- Test falsifiability: prove the test fails when the bug exists (see `/test`)
+
+## Quality
+
+- Zero tolerance: fix all errors/warnings immediately — "out of scope" is not an excuse
+- "Done" = implementation + tests + docs updated + user-verified; partial ≠ done
+- Pre-commit: lint, typecheck, and tests must all pass
+- Bug fixes: grep all instances → fix all → re-grep to confirm zero remaining
+- Fact-check: back every claim with CLI output, git diff, or API response; mark estimates as "(unverified)"
+
+## Git Workflow
+
+- Protected branches: develop, main, master — no direct push, PR only
+- Branch naming: `feat/<desc>`, `fix/<desc>`, `refactor/<desc>`, `chore/<desc>`
+- Commits: `<type>: <description>` — types: feat/fix/refactor/docs/test/chore/perf/ci/release
+- PR granularity: 1 PR = 1 intent, branch type matches PR title type, feat PR includes tests
+- Merge: default `--merge`, `--squash` only when explicitly requested
+- CI gate: `gh pr checks` all green + zero CRITICAL/HIGH before merge
+
+## Delegation
+
+- Dialog, judgment, design → main agent
+- 2+ independent tasks → team tool (TeamCreate)
+- Review → code-reviewer agent + optional Codex CLI
+- Parallel limits: subagents 5-7, Bash 3-4, total ≤ 7
+- See `docs/adr/004-codex-delegation-model.md` for full routing rules
+
 ## Commands
 
 | Command | Description |
 |---------|-------------|
+| `/implement` | Default implementation workflow — code, test, and commit within guardrails. |
 | `/review` | Run a read-only code review on the current diff or PR. |
 | `/ship` | Merge-ready workflow: CI check, review gate, and push. |
 | `/handoff` | Generate a handoff document for cross-session continuity. |

--- a/packages/guardrails/profile/AGENTS.md
+++ b/packages/guardrails/profile/AGENTS.md
@@ -24,15 +24,15 @@
 ## Testing
 
 - Coverage ≥ 80% (unit + integration + E2E combined)
-- Test levels: Unit = jest/vitest, Integration = curl/httpx, E2E = Playwright/browser only
+- Test levels: Unit = project test runner (`bun test`, vitest, jest), E2E = Playwright/browser only
 - `curl` alone is NOT E2E — E2E requires browser verification
 - TDD cycle: RED → GREEN → IMPROVE → check coverage
 - Test falsifiability: prove the test fails when the bug exists (see `/test`)
 
 ## Quality
 
-- Zero tolerance: fix all errors/warnings immediately — "out of scope" is not an excuse
-- "Done" = implementation + tests + docs updated + user-verified; partial ≠ done
+- Fix errors and warnings introduced by the current change; pre-existing issues outside scope are tracked, not fixed inline
+- "Done" = implementation + tests + docs updated + verified by the smallest relevant check; partial ≠ done
 - Pre-commit: lint, typecheck, and tests must all pass
 - Bug fixes: grep all instances → fix all → re-grep to confirm zero remaining
 - Fact-check: back every claim with CLI output, git diff, or API response; mark estimates as "(unverified)"

--- a/packages/guardrails/profile/AGENTS.md
+++ b/packages/guardrails/profile/AGENTS.md
@@ -39,7 +39,7 @@
 
 ## Git Workflow
 
-- Protected branches: develop, main, master — no direct push, PR only
+- Protected branches: dev, develop, main, master — no direct push, PR only
 - Branch naming: `feat/<desc>`, `fix/<desc>`, `refactor/<desc>`, `chore/<desc>`
 - Commits: `<type>: <description>` — types: feat/fix/refactor/docs/test/chore/perf/ci/release
 - PR granularity: 1 PR = 1 intent, branch type matches PR title type, feat PR includes tests
@@ -49,10 +49,9 @@
 ## Delegation
 
 - Dialog, judgment, design → main agent
-- 2+ independent tasks → team tool (TeamCreate)
-- Review → code-reviewer agent + optional Codex CLI
-- Parallel limits: subagents 5-7, Bash 3-4, total ≤ 7
-- See `docs/adr/004-codex-delegation-model.md` for full routing rules
+- 1+ independent tasks → `team` tool via `/delegate` (1-5 tasks, supports single-task isolation)
+- Review → `/review` command (stays read-only; uses `code-reviewer` subagent internally)
+- Parallel limits: subagents 1-5, Bash 3-4, total ≤ 7
 
 ## Commands
 


### PR DESCRIPTION
## Summary
- Add 5 rule sections to profile AGENTS.md: Code Style, Testing, Quality, Git Workflow, Delegation
- Migrated from Claude Code rules (coding-style.md, testing.md, quality.md, git-workflow.md, delegation.md)
- Rules are concise and pointer-based per profile conventions
- Added missing `/implement` command to commands table
- Adapted rules to repo-specific tooling (bun test, dev branch, autonomous workflow)

Closes #42

## Codex review findings addressed
- Added `dev` to protected branches list (repo default)
- Routed review through `/review` command instead of direct agent reference
- Replaced non-existent `TeamCreate` with `team` tool via `/delegate`
- Removed dead link to non-existent ADR-004
- Used generic test runner wording compatible with `bun test`
- Scoped quality rules to current-change scope (not pre-existing issues)

## Test plan
- [ ] AGENTS.md loads in OpenCode session context
- [ ] Rules are visible without being overly verbose
- [ ] No duplication with plugin/hook enforced rules
- [ ] No conflict with existing implement.md bounded-change contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)