### PR TITLE
fix(guardrails): case-insensitive tool name matching in factcheck hook

### DIFF
--- a/.opencode/hooks/enforce-factcheck-before-edit.sh
+++ b/.opencode/hooks/enforce-factcheck-before-edit.sh
@@ -6,8 +6,9 @@
 TOOL="$OPENCODE_TOOL_NAME"
 INPUT="$OPENCODE_TOOL_INPUT"
 
-# Only apply to write/edit tools
-case "$TOOL" in
+# Only apply to write/edit tools (case-insensitive)
+TOOL_LOWER=$(printf '%s' "$TOOL" | tr '[:upper:]' '[:lower:]')
+case "$TOOL_LOWER" in
   write|edit) ;;
   *) exit 0 ;;
 esac


### PR DESCRIPTION
## Summary
Fix 4 failing tests in factcheck.test.ts. The enforce-factcheck-before-edit.sh
case statement only matched lowercase tool names (write|edit) but OpenCode sends
capitalized names (Write|Edit). Convert to lowercase before matching.

Closes #99

## Test plan
- [ ] All 91 hook tests pass (previously 87 pass, 4 fail)
- [ ] factcheck.test.ts: 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)