### PR TITLE
fix(guardrails): address review follow-up findings (#104-107)

### DIFF
--- a/packages/guardrails/profile/agents/incident-responder.md
+++ b/packages/guardrails/profile/agents/incident-responder.md
@@ -20,8 +20,6 @@ permission:
     "rm -rf *": deny
     "rm -r *": deny
     "sudo *": deny
-    "curl * | sh*": deny
-    "wget * | sh*": deny
     "git log*": allow
     "git diff*": allow
     "git show*": allow
@@ -33,6 +31,8 @@ permission:
     "pwd": allow
     "which *": allow
     "curl *": ask
+    "curl * | sh*": deny
+    "wget * | sh*": deny
     "node *": allow
     "bun *": allow
 ---

--- a/packages/guardrails/profile/agents/security-engineer.md
+++ b/packages/guardrails/profile/agents/security-engineer.md
@@ -9,7 +9,13 @@ permission:
     "*.pem": deny
     "*.key": deny
     "*secret*": deny
-  grep: allow
+  grep:
+    "*": allow
+    "*.env*": deny
+    "*credentials*": deny
+    "*.pem": deny
+    "*.key": deny
+    "*secret*": deny
   glob: allow
   edit:
     "*": deny

--- a/packages/guardrails/profile/plugins/guardrail.ts
+++ b/packages/guardrails/profile/plugins/guardrail.ts
@@ -609,7 +609,7 @@ export default async function guardrail(input: {
           out.output += "\n\n📝 Source code edited (3+ operations). Check if related documentation (README, AGENTS.md, ADRs) needs updating."
         }
         // Auto-format reminder after 3+ source edits
-        if (nextEditCount >= 3 && nextEditCount % 3 === 0) {
+        if (code(file) && nextEditCount >= 3 && nextEditCount % 3 === 0) {
           out.output = (out.output || "") + "\n🎨 " + nextEditCount + " source edits — consider running formatter (`prettier --write`, `biome format`, `go fmt`)."
         }
       }

--- a/packages/guardrails/profile/plugins/guardrail.ts
+++ b/packages/guardrails/profile/plugins/guardrail.ts
@@ -514,7 +514,7 @@ export default async function guardrail(input: {
         const protectedBranch = /^(main|master|develop|dev)$/
         if (/\bgit\s+push\b/i.test(cmd)) {
           // Check explicit branch target
-          const explicitMatch = cmd.match(/\bgit\s+push\s+\S+\s+(?:HEAD:)?(\S+)/i)
+          const explicitMatch = cmd.match(/\bgit\s+push\s+(?:(?:-\w+|--[\w-]+)\s+)*\S+\s+(?:HEAD:)?(\S+)/i)
           if (explicitMatch && protectedBranch.test(explicitMatch[1])) {
             throw new Error(text("direct push to protected branch blocked — use a PR workflow"))
           }
@@ -524,7 +524,7 @@ export default async function guardrail(input: {
             throw new Error(text("direct push to protected branch blocked — use a PR workflow"))
           }
           // Plain `git push` with no branch — check current branch
-          if (!/\bgit\s+push\s+\S+\s+\S+/i.test(cmd)) {
+          if (!/\bgit\s+push\s+(?:(?:-\w+|--[\w-]+)\s+)*\S+\s+\S+/i.test(cmd)) {
             try {
               const result = await git(input.worktree, ["branch", "--show-current"])
               if (result.stdout && protectedBranch.test(result.stdout.trim())) {


### PR DESCRIPTION
## Summary
- Fix push block regex bypassed by flags between push and remote (#104)
- Restrict security-engineer grep to deny sensitive files (#105)
- Reorder incident-responder curl rules for last-match-wins correctness (#106)
- Gate auto-format reminder with code(file) check (#107)

Closes #104, Closes #105, Closes #106, Closes #107

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

## Changes
4 atomic commits, each fixing one review follow-up finding:

1. **#104**: Add optional flag group `(?:(?:-\w+|--[\w-]+)\s+)*` to push block regex so `git push -u origin main` is correctly blocked
2. **#105**: Replace blanket `grep: allow` with pattern-based deny list mirroring read deny rules (.env, credentials, pem, key, secret)
3. **#106**: Move `curl *: ask` before `curl * | sh*: deny` so pipe-to-shell is denied under last-match-wins semantics
4. **#107**: Add `code(file)` guard to auto-format reminder so it only fires for source code edits, not docs/config

## Verification
- [x] `bun turbo typecheck` — 13/13 pass
- [ ] Deploy fire test: `git push -u origin main` blocked
- [ ] Deploy fire test: security-engineer grep `.env` denied
- [ ] Deploy fire test: incident-responder `curl X | sh` denied
- [ ] Deploy fire test: editing `.md` 3x does not trigger format reminder

## Checklist
- [x] Code follows project conventions
- [x] Each fix references its follow-up origin PR (#102, #100)
- [x] No breaking changes