### PR TITLE
fix(guardrails): harden infrastructure agent permissions

### DIFF
--- a/packages/guardrails/profile/agents/cloud-architect.md
+++ b/packages/guardrails/profile/agents/cloud-architect.md
@@ -6,9 +6,15 @@ permission:
     "*": allow
     "*.env*": deny
     "*credentials*": deny
+    "*.pem": deny
+    "*.key": deny
+    "*secret*": deny
   grep:
     "*": allow
     "*.env*": deny
+    "*.pem": deny
+    "*.key": deny
+    "*secret*": deny
   glob: allow
   edit:
     "*": deny

--- a/packages/guardrails/profile/agents/deployment-engineer.md
+++ b/packages/guardrails/profile/agents/deployment-engineer.md
@@ -6,9 +6,15 @@ permission:
     "*": allow
     "*.env*": deny
     "*credentials*": deny
+    "*.pem": deny
+    "*.key": deny
+    "*secret*": deny
   grep:
     "*": allow
     "*.env*": deny
+    "*.pem": deny
+    "*.key": deny
+    "*secret*": deny
   glob: allow
   edit:
     "*": allow
@@ -18,13 +24,18 @@ permission:
     "*": deny
     "docker build*": allow
     "docker compose*": allow
+    "docker compose push*": deny
+    "docker push*": deny
     "docker ps*": allow
     "docker images*": allow
     "docker logs*": allow
     "kubectl get*": allow
     "kubectl describe*": allow
     "kubectl logs*": allow
-    "kubectl rollout*": allow
+    "kubectl rollout status*": allow
+    "kubectl rollout history*": allow
+    "kubectl rollout restart*": ask
+    "kubectl rollout undo*": ask
     "git diff*": allow
     "git status*": allow
     "git log*": allow

--- a/packages/guardrails/profile/agents/terraform-engineer.md
+++ b/packages/guardrails/profile/agents/terraform-engineer.md
@@ -7,10 +7,16 @@ permission:
     "*.env*": deny
     "*credentials*": deny
     "*.tfvars": deny
+    "*.pem": deny
+    "*.key": deny
+    "*secret*": deny
   grep:
     "*": allow
     "*.env*": deny
     "*.tfvars": deny
+    "*.pem": deny
+    "*.key": deny
+    "*secret*": deny
   glob: allow
   edit:
     "*": allow


### PR DESCRIPTION
## Summary
- Add missing secret file deny patterns to infrastructure agents
- Restrict kubectl rollout mutating subcommands to ask mode
- Add explicit docker push deny to deployment-engineer

Follow-up from PR #113 code review (CRITICAL-2, HIGH-3, HIGH-4).

## Type of change
- [x] Bug fix (security permission hardening)

## Changes
**terraform-engineer, cloud-architect, deployment-engineer:**
- Added `*.pem`, `*.key`, `*secret*` deny to read and grep permissions (matching security-engineer pattern)

**deployment-engineer only:**
- Split `kubectl rollout*: allow` into `kubectl rollout status/history: allow` + `kubectl rollout restart/undo: ask`
- Added explicit `docker push*: deny` and `docker compose push*: deny`

## Verification
- [x] `bun turbo typecheck` — 13/13 pass
- [x] YAML structure validated
- [x] Permission patterns consistent with security-engineer baseline

## Checklist
- [x] Code follows project conventions
- [x] References follow-up origin (PR #113 review)
- [x] No breaking changes