### PR TITLE
feat(guardrails): add CI hard block, architecture advisory, and post-deploy verify hooks

### DIFF
--- a/packages/guardrails/profile/plugins/guardrail.ts
+++ b/packages/guardrails/profile/plugins/guardrail.ts
@@ -510,6 +510,32 @@ export default async function guardrail(input: {
             throw new Error(text("merge blocked: run /review before merging"))
           }
         }
+        // CI hard block: verify all checks are green before gh pr merge
+        if (/\bgh\s+pr\s+merge\b/i.test(cmd)) {
+          try {
+            const prMatch = cmd.match(/\bgh\s+pr\s+merge\s+(\d+)/i)
+            const prArg = prMatch ? prMatch[1] : ""
+            const proc = Bun.spawn(["gh", "pr", "checks", ...(prArg ? [prArg] : [])], {
+              cwd: input.worktree,
+              stdout: "pipe",
+              stderr: "pipe",
+            })
+            const [ciOut] = await Promise.all([
+              new Response(proc.stdout).text(),
+              new Response(proc.stderr).text(),
+              proc.exited,
+            ])
+            if (proc.exitCode !== 0 || /fail|pending/i.test(ciOut)) {
+              await mark({ last_block: "bash", last_command: cmd, last_reason: "CI checks not all green" })
+              throw new Error(text("merge blocked: CI checks not all green — run `gh pr checks` to verify"))
+            }
+          } catch (e) {
+            if (String(e).includes("blocked")) throw e
+            // gh unavailable or network failure — log so CI skip is observable
+            await mark({ last_block: "bash:ci-warn", last_command: cmd, last_reason: "CI check verification failed" })
+            console.warn("[guardrail] CI check verification failed — gh may be unavailable: " + String(e))
+          }
+        }
         // Direct push to protected branches
         const protectedBranch = /^(main|master|develop|dev)$/
         if (/\bgit\s+push\b/i.test(cmd)) {
@@ -614,9 +640,33 @@ export default async function guardrail(input: {
         }
       }
 
+      // Architecture layer advisory
+      if ((item.tool === "edit" || item.tool === "write") && file && code(file)) {
+        const relFile = rel(input.worktree, file)
+        const content = typeof item.args?.content === "string" ? item.args.content :
+                        typeof item.args?.newString === "string" ? item.args.newString : ""
+        if (content) {
+          const isUI = /^(src\/(ui|components|tui)\/)/i.test(relFile)
+          const isAPI = /^(src\/(api|routes)\/)/i.test(relFile)
+          const importsDB = /from\s+['"].*\/(db|database|model|sql)\//i.test(content)
+          const importsUI = /from\s+['"].*\/(ui|components|tui)\//i.test(content)
+          if (isUI && importsDB) {
+            out.output += "\n⚠️ Architecture: UI layer importing from DB layer directly. Consider using a service/repository layer."
+          }
+          if (isAPI && importsUI) {
+            out.output += "\n⚠️ Architecture: API layer importing from UI layer. This creates a circular dependency risk."
+          }
+        }
+      }
+
       // CI status advisory after push/PR create
       if (item.tool === "bash" && /\b(git\s+push|gh\s+pr\s+create)\b/i.test(str(item.args?.command))) {
         out.output = (out.output || "") + "\n⚠️ Remember to verify CI status: `gh pr checks`"
+      }
+
+      // Post-merge deployment verification advisory
+      if (item.tool === "bash" && /\bgh\s+pr\s+merge\b/i.test(str(item.args?.command))) {
+        out.output = (out.output || "") + "\n🚀 Post-merge: verify deployment status and run smoke tests on the target environment."
       }
 
       if (item.tool === "task") {


### PR DESCRIPTION
### Issue for this PR

Closes #115

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds 3 high-priority guardrail hooks to `guardrail.ts` (708 → 757 lines):

1. **CI Hard Block** (tool.execute.before): Runs `gh pr checks` before allowing `gh pr merge`. Blocks if any check is failing/pending. Falls back to warning if `gh` is unavailable (with state tracking via `mark()`).

2. **Architecture Layer Advisory** (tool.execute.after): Warns when source file edits introduce cross-layer imports:
   - UI/components/TUI files importing from DB/database/model/SQL
   - API/routes files importing from UI/components/TUI

3. **Post-deploy Verification Advisory** (tool.execute.after): Reminds to verify deployment status after `gh pr merge` succeeds.

All existing functionality is preserved. The file remains under 800 lines (757).

### How did you verify your code works?

1. Typecheck: `bun turbo typecheck` — 13/13 pass
2. Code review: Fixed HIGH-severity silent error swallowing in CI hard block catch clause (now logs warning via `mark()`)
3. Verified all 3 hooks are at expected locations in the file

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR