### PR TITLE
fix(guardrails): resolve 6 operational bugs + plan_exit hardcode + config alignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 .idea
 .vscode
 .codex
+.opencode/
 *~
 playground
 tmp

--- a/packages/guardrails/profile/plugins/guardrail.ts
+++ b/packages/guardrails/profile/plugins/guardrail.ts
@@ -557,19 +557,17 @@ export default async function guardrail(input: {
       // Branch hygiene: surface stored branch warning from session.created
       const branchWarn = str(data.branch_warning)
       if (branchWarn) {
-        try {
-          const statusCheck = await git(input.worktree, ["status", "--porcelain"])
-          const dirty = statusCheck.stdout.trim().length > 0
-          out.parts.push({
-            id: crypto.randomUUID(),
-            sessionID: out.message.sessionID,
-            messageID: out.message.id,
-            type: "text",
-            text: dirty
-              ? `${branchWarn} Uncommitted changes detected — stash or commit before switching branches.`
-              : branchWarn,
-          })
-        } catch { /* git status may fail */ }
+        const statusCheck = await git(input.worktree, ["status", "--porcelain"]).catch(() => ({ stdout: "", stderr: "" }))
+        const dirty = statusCheck.stdout.trim().length > 0 && !statusCheck.stderr.trim()
+        out.parts.push({
+          id: crypto.randomUUID(),
+          sessionID: out.message.sessionID,
+          messageID: out.message.id,
+          type: "text",
+          text: dirty
+            ? `${branchWarn} Uncommitted changes detected — stash or commit before switching branches.`
+            : branchWarn,
+        })
         await mark({ branch_warning: "" })
       }
     },

--- a/packages/guardrails/profile/plugins/guardrail.ts
+++ b/packages/guardrails/profile/plugins/guardrail.ts
@@ -554,6 +554,24 @@ export default async function guardrail(input: {
       } catch {
         // git fetch may fail in offline or no-remote scenarios; skip silently
       }
+      // Branch hygiene: surface stored branch warning from session.created
+      const branchWarn = str(data.branch_warning)
+      if (branchWarn) {
+        try {
+          const statusCheck = await git(input.worktree, ["status", "--porcelain"])
+          const dirty = statusCheck.stdout.trim().length > 0
+          out.parts.push({
+            id: crypto.randomUUID(),
+            sessionID: out.message.sessionID,
+            messageID: out.message.id,
+            type: "text",
+            text: dirty
+              ? `${branchWarn} Uncommitted changes detected — stash or commit before switching branches.`
+              : branchWarn,
+          })
+        } catch { /* git status may fail */ }
+        await mark({ branch_warning: "" })
+      }
     },
     "tool.execute.before": async (
       item: { tool: string; args?: unknown },
@@ -577,7 +595,7 @@ export default async function guardrail(input: {
       if ((item.tool === "edit" || item.tool === "write") && file && code(file)) {
         const count = await budget()
         if (count >= 4) {
-          const err = `context budget exceeded after ${count} source reads; call the team tool to delegate this edit to an isolated worker, or narrow scope`
+          const err = `context budget exceeded after ${count} source reads. Recovery: (1) call \`team\` tool to delegate edit to isolated worker, (2) use \`background\` tool for side work, (3) narrow edit scope to fewer files`
           await mark({ last_block: item.tool, last_file: rel(input.worktree, file), last_reason: err })
           throw new Error(text(err))
         }
@@ -828,7 +846,7 @@ export default async function guardrail(input: {
         if (/\b(git\s+push|gh\s+pr\s+merge)\b/i.test(cmd) && !/\bfetch\b/i.test(cmd)) {
           if (!flag(bashData.tests_executed) && num(bashData.edit_count) >= 3) {
             await mark({ stop_test_warning: true })
-            await seen("stop_test_gate.untested", { edit_count: num(data.edit_count) })
+            await seen("stop_test_gate.untested", { edit_count: num(bashData.edit_count) })
           }
         }
         if (!bash(cmd)) return

--- a/packages/guardrails/profile/plugins/team.ts
+++ b/packages/guardrails/profile/plugins/team.ts
@@ -666,7 +666,7 @@ export default async function team(input: {
           run.state = "error"
           run.updated_at = now()
           // Classify failure stage from step state and error content
-          const task = run.tasks[0]
+          const task = run.tasks.find((t) => t.state === "error" || t.state === "running") || run.tasks[0]
           const stage = !task?.dir ? "worktree_setup"
             : !task?.session ? "session_create"
             : /merge|patch|apply/.test(err.message || "") ? "merge_back"

--- a/packages/guardrails/profile/plugins/team.ts
+++ b/packages/guardrails/profile/plugins/team.ts
@@ -283,7 +283,10 @@ async function yardrm(dir: string, item: string) {
 }
 
 async function merge(dir: string, item: string, run: string, id: string) {
-  const diff = await git(item, ["diff", "--binary"])
+  // Stage all files (including untracked) to capture new files in the diff
+  const add = await git(item, ["add", "-A"])
+  if (add.code !== 0) throw new Error(add.err || add.out || "Failed to stage worktree changes")
+  const diff = await git(item, ["diff", "--cached", "--binary"])
   if (diff.code !== 0) throw new Error(diff.err || diff.out || "Failed to read worktree diff")
   if (!diff.out.trim()) {
     await yardrm(dir, item)
@@ -446,7 +449,9 @@ export default async function team(input: {
     if (!err && push && box !== ctx.directory) {
       const merged = await merge(ctx.worktree, box, run.id, item.id)
       patchfile = merged.patch
-      if (!merged.merged) err = merged.error || "Failed to merge worktree patch"
+      if (!merged.merged) {
+        err = merged.error || "Failed to merge worktree patch"
+      }
     }
 
     todo(run, item.id, {
@@ -660,6 +665,13 @@ export default async function team(input: {
         .catch(async (err: Error) => {
           run.state = "error"
           run.updated_at = now()
+          // Classify failure stage from step state and error content
+          const task = run.tasks[0]
+          const stage = !task?.dir ? "worktree_setup"
+            : !task?.session ? "session_create"
+            : /merge|patch|apply/.test(err.message || "") ? "merge_back"
+            : /abort/i.test(err.message || "") ? "aborted"
+            : "execution"
           await save(ctx.worktree, run)
           if (!args.notify) return
           await input.client.session.prompt({
@@ -672,7 +684,7 @@ export default async function team(input: {
               parts: [
                 {
                   type: "text",
-                  text: `Background run ${run.id} failed.\n\n${err.message || "Unknown error"}`,
+                  text: `Background run ${run.id} failed at stage: ${stage}.\n\n${err.message || "Unknown error"}\n\n${note(run)}`,
                 },
               ],
             },

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -284,7 +284,8 @@ export namespace SessionPrompt {
             })
           }
           const wasPlan = input.messages.some((msg) => msg.info.role === "assistant" && msg.info.agent === "plan")
-          if (wasPlan && input.agent.name === "build") {
+          const defaultAgentName = yield* agents.defaultAgent()
+          if (wasPlan && input.agent.name === defaultAgentName) {
             userMessage.parts.push({
               id: PartID.ascending(),
               messageID: userMessage.info.id,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -284,8 +284,7 @@ export namespace SessionPrompt {
             })
           }
           const wasPlan = input.messages.some((msg) => msg.info.role === "assistant" && msg.info.agent === "plan")
-          const defaultAgentName = yield* agents.defaultAgent()
-          if (wasPlan && input.agent.name === defaultAgentName) {
+          if (wasPlan && input.agent.name === (yield* agents.defaultAgent())) {
             userMessage.parts.push({
               id: PartID.ascending(),
               messageID: userMessage.info.id,

--- a/packages/opencode/src/tool/plan.ts
+++ b/packages/opencode/src/tool/plan.ts
@@ -27,11 +27,11 @@ export const PlanExitTool = Tool.define("plan_exit", {
       sessionID: ctx.sessionID,
       questions: [
         {
-          question: `Plan at ${plan} is complete. Would you like to switch to the build agent and start implementing?`,
-          header: "Build Agent",
+          question: `Plan at ${plan} is complete. Would you like to switch to the implementation agent and start implementing?`,
+          header: "Implementation Agent",
           custom: false,
           options: [
-            { label: "Yes", description: "Switch to build agent and start implementing the plan" },
+            { label: "Yes", description: "Switch to implementation agent and start implementing the plan" },
             { label: "No", description: "Stay with plan agent to continue refining the plan" },
           ],
         },
@@ -43,6 +43,7 @@ export const PlanExitTool = Tool.define("plan_exit", {
     if (answer === "No") throw new Question.RejectedError()
 
     const model = await getLastModel(ctx.sessionID)
+    const defaultAgent = await Agent.defaultAgent()
 
     const userMsg: MessageV2.User = {
       id: MessageID.ascending(),
@@ -51,7 +52,7 @@ export const PlanExitTool = Tool.define("plan_exit", {
       time: {
         created: Date.now(),
       },
-      agent: await Agent.defaultAgent(),
+      agent: defaultAgent,
       model,
     }
     await Session.updateMessage(userMsg)
@@ -65,8 +66,8 @@ export const PlanExitTool = Tool.define("plan_exit", {
     } satisfies MessageV2.TextPart)
 
     return {
-      title: "Switching to build agent",
-      output: "User approved switching to build agent. Wait for further instructions.",
+      title: `Switching to ${defaultAgent} agent`,
+      output: `User approved switching to ${defaultAgent} agent. Wait for further instructions.`,
       metadata: {},
     }
   },

--- a/packages/opencode/src/tool/plan.ts
+++ b/packages/opencode/src/tool/plan.ts
@@ -5,6 +5,7 @@ import { Question } from "../question"
 import { Session } from "../session"
 import { MessageV2 } from "../session/message-v2"
 import { Provider } from "../provider/provider"
+import { Agent } from "../agent/agent"
 import { Instance } from "../project/instance"
 import { type SessionID, MessageID, PartID } from "../session/schema"
 import EXIT_DESCRIPTION from "./plan-exit.txt"
@@ -50,7 +51,7 @@ export const PlanExitTool = Tool.define("plan_exit", {
       time: {
         created: Date.now(),
       },
-      agent: "build",
+      agent: await Agent.defaultAgent(),
       model,
     }
     await Session.updateMessage(userMsg)


### PR DESCRIPTION
## Summary

- **Team merge untracked fix**: `git diff --binary` → `git add -A && git diff --cached --binary` to capture new files created by workers
- **Background abort classification**: failure stage (worktree_setup/session_create/merge_back/aborted/execution) included in notification
- **Context budget recovery**: error message now lists 3 numbered recovery options
- **Branch hygiene preflight**: surfaces `branch_warning` from `session.created` with dirty-state detection on first user message
- **plan_exit agent hardcode**: `agent: "build"` → `agent: await Agent.defaultAgent()` respects profile's `default_agent` config
- **prompt.ts BUILD_SWITCH**: dynamically matches default agent name instead of hardcoded "build"
- **stop-test-gate CRITICAL fix**: pre-existing undeclared `data` → `bashData` reference (runtime crash on push with 3+ edits)
- **.gitignore**: added `.opencode/` to prevent guardrail state noise in git status
- **Config alignment**: removed permission keys from `~/.config/opencode/opencode.jsonc` that profile overrides (read, edit, task, webfetch, etc.)

## Files changed

| File | Changes |
|------|---------|
| `.gitignore` | Added `.opencode/` |
| `packages/guardrails/profile/plugins/team.ts` | merge() untracked fix, abort classification |
| `packages/guardrails/profile/plugins/guardrail.ts` | context budget msg, branch hygiene, stop-test-gate fix |
| `packages/opencode/src/tool/plan.ts` | Agent.defaultAgent() import + usage |
| `packages/opencode/src/session/prompt.ts` | Dynamic default agent name matching |

## Test plan

- [x] `bun run build --single` — smoke test passed
- [x] Plugin syntax verified via `bun --eval import()`
- [x] Typecheck passed (turbo, 13/13 packages)
- [x] `.opencode/` no longer visible in `git status`
- [x] Code review: 0 CRITICAL, 0 HIGH after fixes
- [ ] Deploy verification: launch via wrapper, confirm plugins load

🤖 Generated with [Claude Code](https://claude.com/claude-code)