### PR TITLE
fix(guardrails): auto-allow bash for /test and /review commands

### DIFF
--- a/packages/guardrails/profile/agents/review.md
+++ b/packages/guardrails/profile/agents/review.md
@@ -19,7 +19,7 @@ permission:
     "gh pr checks*": allow
     "gh pr view*": allow
     "gh pr diff*": allow
-    "gh api *": allow
+    "gh api *": ask
 ---
 
 Review for regressions, missing validation, and missing verification.

--- a/packages/guardrails/profile/agents/review.md
+++ b/packages/guardrails/profile/agents/review.md
@@ -16,6 +16,10 @@ permission:
     "git status *": allow
     "git show *": allow
     "git log *": allow
+    "gh pr checks*": allow
+    "gh pr view*": allow
+    "gh pr diff*": allow
+    "gh api *": allow
 ---
 
 Review for regressions, missing validation, and missing verification.

--- a/packages/guardrails/profile/agents/test-runner.md
+++ b/packages/guardrails/profile/agents/test-runner.md
@@ -3,8 +3,15 @@ description: Run tests with pre-allowed test commands. Read-only except for test
 mode: subagent
 permission:
   "*": deny
-  read: allow
-  grep: allow
+  read:
+    "*": allow
+    "*.env*": deny
+    "*credentials*": deny
+    "*.pem": deny
+    "*.key": deny
+  grep:
+    "*": allow
+    "*.env*": deny
   glob: allow
   list: allow
   lsp: allow
@@ -32,6 +39,8 @@ permission:
     "git show*": allow
     "ls *": allow
     "wc *": allow
+    "pwd": allow
+    "which *": allow
   edit:
     "*": deny
   write:

--- a/packages/guardrails/profile/agents/test-runner.md
+++ b/packages/guardrails/profile/agents/test-runner.md
@@ -1,0 +1,48 @@
+---
+description: Run tests with pre-allowed test commands. Read-only except for test execution.
+mode: subagent
+permission:
+  "*": deny
+  read: allow
+  grep: allow
+  glob: allow
+  list: allow
+  lsp: allow
+  bash:
+    "*": deny
+    "bun test*": allow
+    "bun run test*": allow
+    "turbo test*": allow
+    "vitest*": allow
+    "jest*": allow
+    "pytest*": allow
+    "python -m pytest*": allow
+    "python3 -m pytest*": allow
+    "go test*": allow
+    "cargo test*": allow
+    "npm test*": allow
+    "npm run test*": allow
+    "npx vitest*": allow
+    "npx jest*": allow
+    "git diff*": allow
+    "git status*": allow
+    "git log*": allow
+    "git show*": allow
+    "ls *": allow
+    "wc *": allow
+    "cat *": allow
+    "head *": allow
+    "tail *": allow
+  edit:
+    "*": deny
+  write:
+    "*": deny
+---
+
+Test execution specialist. Run the most targeted test suite for the current change.
+
+Focus:
+- Identify changed files from git diff and map to test files
+- Run the smallest relevant test suite first, expand if needed
+- Report pass/fail/skip counts with failure details
+- Never edit source files — only run and report

--- a/packages/guardrails/profile/agents/test-runner.md
+++ b/packages/guardrails/profile/agents/test-runner.md
@@ -12,6 +12,8 @@ permission:
     "*": deny
     "bun test*": allow
     "bun run test*": allow
+    "bun --cwd * test*": allow
+    "bun turbo test*": allow
     "turbo test*": allow
     "vitest*": allow
     "jest*": allow
@@ -30,9 +32,6 @@ permission:
     "git show*": allow
     "ls *": allow
     "wc *": allow
-    "cat *": allow
-    "head *": allow
-    "tail *": allow
   edit:
     "*": deny
   write:

--- a/packages/guardrails/profile/commands/test.md
+++ b/packages/guardrails/profile/commands/test.md
@@ -1,6 +1,6 @@
 ---
 description: Run verification for the current change.
-agent: implement
+agent: test-runner
 ---
 
 Run tests relevant to the current change.


### PR DESCRIPTION
## Summary
- Create `test-runner` agent with pre-allowed test commands (bun, vitest, jest, pytest, go test, cargo test) and read-only permissions
- Switch `/test` command from `implement` agent to `test-runner` agent for non-interactive automation
- Add `gh` CLI commands (pr checks, pr view, pr diff, api) to `review` agent

Fixes #92

## Test plan
- [x] Typecheck pass
- [ ] `/test` in non-interactive mode executes without permission prompts
- [ ] `/review` can run `gh pr checks` and `gh api` without prompts
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)