### PR TITLE
fix(guardrails): bashData ReferenceError in workflow phase transitions

### DIFF
--- a/packages/guardrails/profile/plugins/guardrail.ts
+++ b/packages/guardrails/profile/plugins/guardrail.ts
@@ -1544,7 +1544,7 @@ export default async function guardrail(input: {
       if (item.tool === "bash") {
         const cmd = str(item.args?.command)
         const output = str(out.output)
-        const currentPhase = str(bashData.workflow_phase)
+        const currentPhase = str(data.workflow_phase)
         const pipelineActive = currentPhase && currentPhase !== "idle" && currentPhase !== "done" && currentPhase !== "blocked"
 
         // PR creation detection — only when implementing


### PR DESCRIPTION
## Summary

Fix ReferenceError: `bashData` is not defined at guardrail.ts:1547.
Variable should be `data` (the stash result in tool.execute.after scope).

Follow-up to PR #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)