### PR TITLE
fix(guardrails): use project-scoped path for team worktree (Issue #155)

### DIFF
--- a/packages/guardrails/profile/plugins/team.ts
+++ b/packages/guardrails/profile/plugins/team.ts
@@ -223,7 +223,7 @@ function patch(dir: string, run: string, id: string) {
 }
 
 function yard(dir: string) {
-  return path.join(path.dirname(dir), `.${path.basename(dir)}-opencode-team`)
+  return path.join(dir, ".opencode", "team")
 }
 
 function isRun(data: unknown): data is Run {


### PR DESCRIPTION
## Summary
- Fix `yard()` function in `team.ts` that was creating worktree directories in the parent directory (e.g. `~/Developer/.opencode-opencode-team`) instead of within the project
- Changed to `path.join(dir, ".opencode", "team")` to keep team data scoped inside the project's `.opencode/` directory, matching the established pattern

Closes #155

## Test plan
- [ ] Verify `yard()` returns `<project>/.opencode/team` instead of `<parent>/.<project>-opencode-team`
- [ ] Confirm `yardadd()` creates worktrees under `.opencode/team/` within the project
- [ ] Verify no regressions in team/background tool execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>