### PR TITLE
feat(instruction): path-scoped rules via globs frontmatter

### DIFF
--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -4,10 +4,12 @@ import path from "path"
 import { Effect, Layer, ServiceMap } from "effect"
 import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http"
 import { Config } from "@/config/config"
+import { ConfigMarkdown } from "@/config/markdown"
 import { InstanceState } from "@/effect/instance-state"
 import { makeRuntime } from "@/effect/run-service"
 import { Flag } from "@/flag/flag"
 import { AppFileSystem } from "@/filesystem"
+import { Glob } from "@/util/glob"
 import { withTransientReadRetry } from "@/util/effect-http-client"
 import { Global } from "../global"
 import { Instance } from "../project/instance"
@@ -55,6 +57,12 @@ function extract(messages: MessageV2.WithParts[]) {
 }
 
 export namespace Instruction {
+  interface ParsedRule {
+    filepath: string
+    content: string // body WITHOUT frontmatter
+    globs: string[] | null // null = unconditional (always active)
+  }
+
   export interface Interface {
     readonly clear: (messageID: MessageID) => Effect.Effect<void>
     readonly systemPaths: () => Effect.Effect<Set<string>, AppFileSystem.Error>
@@ -82,6 +90,7 @@ export namespace Instruction {
             Effect.succeed({
               // Track which instruction files have already been attached for a given assistant message.
               claims: new Map<MessageID, Set<string>>(),
+              parsedRules: null as ParsedRule[] | null,
             }),
           ),
         )
@@ -106,6 +115,30 @@ export namespace Instruction {
         const read = Effect.fnUntraced(function* (filepath: string) {
           return yield* fs.readFileString(filepath).pipe(Effect.catch(() => Effect.succeed("")))
         })
+
+        const parseRuleFiles = async (files: string[]): Promise<ParsedRule[]> => {
+          const rules: ParsedRule[] = []
+          for (const filepath of files) {
+            try {
+              const md = await ConfigMarkdown.parse(filepath)
+              let globs: string[] | null = null
+              if (md.data?.globs) {
+                globs = Array.isArray(md.data.globs) ? md.data.globs : [md.data.globs]
+              }
+              rules.push({
+                filepath,
+                content: md.content,
+                globs,
+              })
+            } catch {
+              // Failed to parse frontmatter, treat as unconditional
+              const { Filesystem } = await import("../util/filesystem")
+              const content = await Filesystem.readText(filepath).catch(() => "")
+              rules.push({ filepath, content, globs: null })
+            }
+          }
+          return rules
+        }
 
         const fetch = Effect.fnUntraced(function* (url: string) {
           const res = yield* http.execute(HttpClientRequest.get(url)).pipe(
@@ -188,13 +221,19 @@ export namespace Instruction {
             ? []
             : yield* Effect.promise(() => filterSymlinkEscapes(rawProjectRuleFiles, projectRulesDir))
 
-          // Include all global rules (even if same filename exists in project)
-          for (const rule of globalRuleFiles) {
-            paths.add(path.resolve(rule))
-          }
-          // Include all project rules
-          for (const rule of projectRuleFiles) {
-            paths.add(path.resolve(rule))
+          // Parse all rule files and cache them
+          const allRuleFiles = [...globalRuleFiles, ...projectRuleFiles]
+          const parsed = yield* Effect.promise(() => parseRuleFiles(allRuleFiles))
+
+          // Store parsed rules in state for resolve() to use
+          const s = yield* InstanceState.get(state)
+          s.parsedRules = parsed
+
+          // Only add unconditional rules (no globs) to system paths
+          for (const rule of parsed) {
+            if (!rule.globs) {
+              paths.add(path.resolve(rule.filepath))
+            }
           }
 
           if (config.instructions) {
@@ -279,6 +318,37 @@ export namespace Instruction {
             }
 
             current = path.dirname(current)
+          }
+
+          // Check path-scoped rules (glob-matched)
+          const s2 = yield* InstanceState.get(state)
+          if (s2.parsedRules) {
+            const relativePath = path.relative(root, target)
+            for (const rule of s2.parsedRules) {
+              if (!rule.globs) continue // unconditional rules are in systemPaths
+              if (sys.has(rule.filepath) || already.has(rule.filepath)) continue
+
+              let set = s.claims.get(messageID)
+              if (!set) {
+                set = new Set()
+                s.claims.set(messageID, set)
+              }
+              if (set.has(rule.filepath)) continue
+
+              // Check if any glob pattern matches the file being read
+              const matches = rule.globs.some(
+                (glob) => Glob.match(glob, relativePath) || Glob.match(glob, target),
+              )
+              if (!matches) continue
+
+              set.add(rule.filepath)
+              if (rule.content) {
+                results.push({
+                  filepath: rule.filepath,
+                  content: `Instructions from: ${rule.filepath}\n${rule.content}`,
+                })
+              }
+            }
           }
 
           return results

--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -325,10 +325,9 @@ export namespace Instruction {
           }
 
           // Check path-scoped rules (glob-matched)
-          const s2 = yield* InstanceState.get(state)
-          if (s2.parsedRules) {
+          if (s.parsedRules) {
             const relativePath = path.relative(root, target)
-            for (const rule of s2.parsedRules) {
+            for (const rule of s.parsedRules) {
               if (!rule.globs) continue // unconditional rules are in systemPaths
               if (sys.has(rule.filepath) || already.has(rule.filepath)) continue
 

--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -5,6 +5,7 @@ import { Effect, Layer, ServiceMap } from "effect"
 import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http"
 import { Config } from "@/config/config"
 import { ConfigMarkdown } from "@/config/markdown"
+import { Filesystem } from "@/util/filesystem"
 import { InstanceState } from "@/effect/instance-state"
 import { makeRuntime } from "@/effect/run-service"
 import { Flag } from "@/flag/flag"
@@ -123,7 +124,13 @@ export namespace Instruction {
               const md = await ConfigMarkdown.parse(filepath)
               let globs: string[] | null = null
               if (md.data?.globs) {
-                globs = Array.isArray(md.data.globs) ? md.data.globs : [md.data.globs]
+                const raw = md.data.globs
+                if (typeof raw === "string") {
+                  globs = [raw]
+                } else if (Array.isArray(raw) && raw.length > 0 && raw.every((g: unknown) => typeof g === "string")) {
+                  globs = raw as string[]
+                }
+                // else: invalid or empty globs value, leave as null (unconditional)
               }
               rules.push({
                 filepath,
@@ -131,8 +138,6 @@ export namespace Instruction {
                 globs,
               })
             } catch {
-              // Failed to parse frontmatter, treat as unconditional
-              const { Filesystem } = await import("../util/filesystem")
               const content = await Filesystem.readText(filepath).catch(() => "")
               rules.push({ filepath, content, globs: null })
             }
@@ -221,16 +226,15 @@ export namespace Instruction {
             ? []
             : yield* Effect.promise(() => filterSymlinkEscapes(rawProjectRuleFiles, projectRulesDir))
 
-          // Parse all rule files and cache them
-          const allRuleFiles = [...globalRuleFiles, ...projectRuleFiles]
-          const parsed = yield* Effect.promise(() => parseRuleFiles(allRuleFiles))
-
-          // Store parsed rules in state for resolve() to use
+          // Parse rule files once and cache in state
           const s = yield* InstanceState.get(state)
-          s.parsedRules = parsed
+          if (!s.parsedRules) {
+            const allRuleFiles = [...globalRuleFiles, ...projectRuleFiles]
+            s.parsedRules = yield* Effect.promise(() => parseRuleFiles(allRuleFiles))
+          }
 
           // Only add unconditional rules (no globs) to system paths
-          for (const rule of parsed) {
+          for (const rule of s.parsedRules) {
             if (!rule.globs) {
               paths.add(path.resolve(rule.filepath))
             }

--- a/packages/opencode/test/session/instruction-scoped.test.ts
+++ b/packages/opencode/test/session/instruction-scoped.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test"
+import { ConfigMarkdown } from "../../src/config/markdown"
+
+describe("Path-Scoped Rules", () => {
+  describe("frontmatter parsing", () => {
+    test("parses globs from frontmatter", async () => {
+      const tmpDir = await import("node:os").then(os => os.tmpdir())
+      const tmpFile = `${tmpDir}/test-rule-${Date.now()}.md`
+      const content = `---\nglobs: ["src/**/*.ts"]\ndescription: Test rule\n---\n# Test Rule\n- Do something`
+      await Bun.write(tmpFile, content)
+
+      const result = await ConfigMarkdown.parse(tmpFile)
+      expect(result.data.globs).toEqual(["src/**/*.ts"])
+      expect(result.data.description).toBe("Test rule")
+      expect(result.content.trim()).toBe("# Test Rule\n- Do something")
+
+      await import("node:fs/promises").then(fs => fs.unlink(tmpFile))
+    })
+
+    test("parses single glob string", async () => {
+      const tmpDir = await import("node:os").then(os => os.tmpdir())
+      const tmpFile = `${tmpDir}/test-rule-single-${Date.now()}.md`
+      const content = `---\nglobs: "*.tsx"\n---\n# TSX Rule`
+      await Bun.write(tmpFile, content)
+
+      const result = await ConfigMarkdown.parse(tmpFile)
+      expect(result.data.globs).toBe("*.tsx")
+
+      await import("node:fs/promises").then(fs => fs.unlink(tmpFile))
+    })
+
+    test("rule without globs has no globs field", async () => {
+      const tmpDir = await import("node:os").then(os => os.tmpdir())
+      const tmpFile = `${tmpDir}/test-rule-noglob-${Date.now()}.md`
+      const content = `# Always Active Rule\n- Apply everywhere`
+      await Bun.write(tmpFile, content)
+
+      const result = await ConfigMarkdown.parse(tmpFile)
+      expect(result.data.globs).toBeUndefined()
+
+      await import("node:fs/promises").then(fs => fs.unlink(tmpFile))
+    })
+  })
+
+  describe("glob matching", () => {
+    test("matches file against glob pattern", async () => {
+      const { Glob } = await import("../../src/util/glob")
+      expect(Glob.match("src/**/*.ts", "src/memory/store.ts")).toBe(true)
+      expect(Glob.match("src/**/*.ts", "test/memory/store.test.ts")).toBe(false)
+    })
+
+    test("matches with multiple patterns", async () => {
+      const { Glob } = await import("../../src/util/glob")
+      const globs = ["packages/frontend/**/*.tsx", "packages/frontend/**/*.ts"]
+      const match = (filepath: string) => globs.some(g => Glob.match(g, filepath))
+
+      expect(match("packages/frontend/App.tsx")).toBe(true)
+      expect(match("packages/frontend/utils/helper.ts")).toBe(true)
+      expect(match("packages/backend/server.ts")).toBe(false)
+    })
+
+    test("handles dot files", async () => {
+      const { Glob } = await import("../../src/util/glob")
+      expect(Glob.match("**/*.ts", ".hidden/config.ts")).toBe(true)
+    })
+  })
+
+  describe("frontmatter stripping", () => {
+    test("content excludes frontmatter", async () => {
+      const tmpDir = await import("node:os").then(os => os.tmpdir())
+      const tmpFile = `${tmpDir}/test-strip-${Date.now()}.md`
+      const content = `---\nglobs: ["*.ts"]\n---\n# My Rule\n- Follow this`
+      await Bun.write(tmpFile, content)
+
+      const result = await ConfigMarkdown.parse(tmpFile)
+      expect(result.content.trim()).toBe("# My Rule\n- Follow this")
+      expect(result.content).not.toContain("---")
+      expect(result.content).not.toContain("globs")
+
+      await import("node:fs/promises").then(fs => fs.unlink(tmpFile))
+    })
+  })
+})

--- a/packages/opencode/test/session/instruction-scoped.test.ts
+++ b/packages/opencode/test/session/instruction-scoped.test.ts
@@ -1,44 +1,59 @@
-import { describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, test } from "bun:test"
+import path from "path"
 import { ConfigMarkdown } from "../../src/config/markdown"
+import { Instruction } from "../../src/session/instruction"
+import { Instance } from "../../src/project/instance"
+import { MessageID } from "../../src/session/schema"
+import { tmpdir } from "../fixture/fixture"
+
+afterEach(async () => {
+  await Instance.disposeAll()
+})
 
 describe("Path-Scoped Rules", () => {
   describe("frontmatter parsing", () => {
     test("parses globs from frontmatter", async () => {
-      const tmpDir = await import("node:os").then(os => os.tmpdir())
-      const tmpFile = `${tmpDir}/test-rule-${Date.now()}.md`
-      const content = `---\nglobs: ["src/**/*.ts"]\ndescription: Test rule\n---\n# Test Rule\n- Do something`
-      await Bun.write(tmpFile, content)
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          await Bun.write(
+            path.join(dir, "test-rule.md"),
+            "---\nglobs: [\"src/**/*.ts\"]\ndescription: Test rule\n---\n# Test Rule\n- Do something",
+          )
+        },
+      })
 
-      const result = await ConfigMarkdown.parse(tmpFile)
+      const result = await ConfigMarkdown.parse(path.join(tmp.path, "test-rule.md"))
       expect(result.data.globs).toEqual(["src/**/*.ts"])
       expect(result.data.description).toBe("Test rule")
       expect(result.content.trim()).toBe("# Test Rule\n- Do something")
-
-      await import("node:fs/promises").then(fs => fs.unlink(tmpFile))
     })
 
     test("parses single glob string", async () => {
-      const tmpDir = await import("node:os").then(os => os.tmpdir())
-      const tmpFile = `${tmpDir}/test-rule-single-${Date.now()}.md`
-      const content = `---\nglobs: "*.tsx"\n---\n# TSX Rule`
-      await Bun.write(tmpFile, content)
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          await Bun.write(
+            path.join(dir, "test-rule-single.md"),
+            "---\nglobs: \"*.tsx\"\n---\n# TSX Rule",
+          )
+        },
+      })
 
-      const result = await ConfigMarkdown.parse(tmpFile)
+      const result = await ConfigMarkdown.parse(path.join(tmp.path, "test-rule-single.md"))
       expect(result.data.globs).toBe("*.tsx")
-
-      await import("node:fs/promises").then(fs => fs.unlink(tmpFile))
     })
 
     test("rule without globs has no globs field", async () => {
-      const tmpDir = await import("node:os").then(os => os.tmpdir())
-      const tmpFile = `${tmpDir}/test-rule-noglob-${Date.now()}.md`
-      const content = `# Always Active Rule\n- Apply everywhere`
-      await Bun.write(tmpFile, content)
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          await Bun.write(
+            path.join(dir, "test-rule-noglob.md"),
+            "# Always Active Rule\n- Apply everywhere",
+          )
+        },
+      })
 
-      const result = await ConfigMarkdown.parse(tmpFile)
+      const result = await ConfigMarkdown.parse(path.join(tmp.path, "test-rule-noglob.md"))
       expect(result.data.globs).toBeUndefined()
-
-      await import("node:fs/promises").then(fs => fs.unlink(tmpFile))
     })
   })
 
@@ -52,7 +67,7 @@ describe("Path-Scoped Rules", () => {
     test("matches with multiple patterns", async () => {
       const { Glob } = await import("../../src/util/glob")
       const globs = ["packages/frontend/**/*.tsx", "packages/frontend/**/*.ts"]
-      const match = (filepath: string) => globs.some(g => Glob.match(g, filepath))
+      const match = (filepath: string) => globs.some((g) => Glob.match(g, filepath))
 
       expect(match("packages/frontend/App.tsx")).toBe(true)
       expect(match("packages/frontend/utils/helper.ts")).toBe(true)
@@ -67,17 +82,57 @@ describe("Path-Scoped Rules", () => {
 
   describe("frontmatter stripping", () => {
     test("content excludes frontmatter", async () => {
-      const tmpDir = await import("node:os").then(os => os.tmpdir())
-      const tmpFile = `${tmpDir}/test-strip-${Date.now()}.md`
-      const content = `---\nglobs: ["*.ts"]\n---\n# My Rule\n- Follow this`
-      await Bun.write(tmpFile, content)
+      await using tmp = await tmpdir({
+        init: async (dir) => {
+          await Bun.write(
+            path.join(dir, "test-strip.md"),
+            "---\nglobs: [\"*.ts\"]\n---\n# My Rule\n- Follow this",
+          )
+        },
+      })
 
-      const result = await ConfigMarkdown.parse(tmpFile)
+      const result = await ConfigMarkdown.parse(path.join(tmp.path, "test-strip.md"))
       expect(result.content.trim()).toBe("# My Rule\n- Follow this")
-      expect(result.content).not.toContain("---")
-      expect(result.content).not.toContain("globs")
+    })
+  })
 
-      await import("node:fs/promises").then(fs => fs.unlink(tmpFile))
+  describe("Instruction.resolve with glob-scoped rules", () => {
+    test("injects glob-scoped rule only when target matches", async () => {
+      await using tmp = await tmpdir({
+        git: true,
+        init: async (dir) => {
+          const rulesDir = path.join(dir, ".opencode", "rules")
+          await Bun.write(
+            path.join(rulesDir, "ts-style.md"),
+            "---\nglobs:\n  - \"src/**/*.ts\"\n---\nUse strict mode",
+          )
+          await Bun.write(path.join(dir, "src", "app.ts"), "const x = 1")
+          await Bun.write(path.join(dir, "readme.md"), "# Docs")
+        },
+      })
+
+      await Instance.provide({
+        directory: tmp.path,
+        fn: async () => {
+          // Matching file: should include the glob-scoped rule
+          const match = await Instruction.resolve(
+            [],
+            path.join(tmp.path, "src", "app.ts"),
+            MessageID.make("msg-glob-match"),
+          )
+          const tsRule = match.find((r) => r.content.includes("Use strict mode"))
+          expect(tsRule).toBeDefined()
+
+          // Non-matching file: should NOT include the glob-scoped rule
+          const noMatch = await Instruction.resolve(
+            [],
+            path.join(tmp.path, "readme.md"),
+            MessageID.make("msg-glob-nomatch"),
+          )
+          const noRule = noMatch.find((r) => r.content.includes("Use strict mode"))
+          expect(noRule).toBeUndefined()
+        },
+      })
     })
   })
 })


### PR DESCRIPTION
## Summary
- Add `globs` frontmatter support to `.opencode/rules/*.md` files for path-scoped rule injection
- Rules with `globs` field are only injected when the file being read matches the glob pattern
- Rules without `globs` continue to be always-active (current behavior)
- Uses existing `ConfigMarkdown.parse()` for frontmatter parsing and `Glob.match()` for pattern matching

## Test plan
- [ ] 7 new tests in `instruction-scoped.test.ts` (frontmatter parsing, glob matching, frontmatter stripping)
- [ ] Existing instruction tests remain passing
- [ ] Typecheck 0 errors

Refs: #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)