### PR TITLE
feat(guardrails): delegation enforcement in plan mode

### DIFF
--- a/packages/guardrails/profile/plugins/guardrail.ts
+++ b/packages/guardrails/profile/plugins/guardrail.ts
@@ -259,6 +259,17 @@ export default async function guardrail(
             await ctx.mark({ workflow_phase: "implementing", workflow_review_attempts: 0 })
             await ctx.seen("workflow.plan_approved", { sessionID: "plan_exit" })
           }
+          const taskCount = num(data.active_task_count)
+          const hasDelegation = taskCount > 0 || Object.keys(data).filter((k) => typeof k === "string" && k.startsWith("delegation_")).some((k) => num(data[k]) > 0)
+          if (!hasDelegation) {
+            out.output = (out.output || "") + "\n\n⚠️ [DELEGATION ADVISORY] Plan approved without delegation assignments.\n" +
+              "ADR-004 rules: 2+ independent tasks → Agent Team (TeamCreate), " +
+              "1 large autonomous task → Codex CLI (route C), " +
+              "review → code-reviewer + Codex CLI (route A). " +
+              "Limits: sub-agents 5-7, Bash 3-4, Codex CLI 1. " +
+              "Consider assigning delegation before implementing."
+            await ctx.seen("delegation.plan_no_assignment", { task_count: taskCount })
+          }
         } catch {}
       }
 
@@ -563,6 +574,14 @@ export default async function guardrail(
         out.system.push("[WORKFLOW] Phase: " + phase + ". Pipeline: implement→test→review→fix→ship. Complete autonomously. Do not stop at PR creation.")
         out.system.push("When you discover problems outside the current scope, create follow-up issues: `gh issue create --title '<desc>' --body '<details>' --label 'tech-debt'`. Do NOT fix out-of-scope problems inline.")
       }
+      out.system.push(
+        "[DELEGATION] ADR-004 rules: " +
+        "2+ independent tasks → Agent Team (TeamCreate, max 5). " +
+        "1 large autonomous task → Codex CLI (route C). " +
+        "Review → code-reviewer + Codex CLI (route A). " +
+        "Limits: sub-agents 5-7, Bash 3-4, Codex CLI 1, total 7. " +
+        "Include delegation assignments in plans. Do not self-implement everything.",
+      )
     },
   }
 }

--- a/packages/guardrails/profile/plugins/guardrail.ts
+++ b/packages/guardrails/profile/plugins/guardrail.ts
@@ -260,7 +260,7 @@ export default async function guardrail(
             await ctx.seen("workflow.plan_approved", { sessionID: "plan_exit" })
           }
           const taskCount = num(data.active_task_count)
-          const hasDelegation = taskCount > 0 || Object.keys(data).filter((k) => typeof k === "string" && k.startsWith("delegation_")).some((k) => num(data[k]) > 0)
+          const hasDelegation = taskCount > 0 || Object.keys(data).filter((k) => k.startsWith("delegation_")).some((k) => num(data[k]) > 0)
           if (!hasDelegation) {
             out.output = (out.output || "") + "\n\n⚠️ [DELEGATION ADVISORY] Plan approved without delegation assignments.\n" +
               "ADR-004 rules: 2+ independent tasks → Agent Team (TeamCreate), " +

--- a/packages/opencode/test/scenario/guardrails.test.ts
+++ b/packages/opencode/test/scenario/guardrails.test.ts
@@ -1807,6 +1807,139 @@ test("team plugin resets need gate after team tool completes", async () => {
   })
 })
 
+test("plan_exit delegation enforcement emits advisory when no delegation assigned", async () => {
+  await withProfile(async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await fs.mkdir(path.join(dir, "src"), { recursive: true })
+        await Bun.write(path.join(dir, "src", "app.ts"), "export const app = 1\n")
+      },
+    })
+    const files = guard(tmp.path)
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        // 1. Initialize session
+        await Plugin.trigger(
+          "event",
+          { event: { type: "session.created", properties: { sessionID: "session_plan_test" } } },
+          {},
+        )
+        await wait()
+
+        // 2. Fire plan_exit without any prior task delegation
+        const planOut = { title: "plan_exit", output: "Plan approved", metadata: {} }
+        await Plugin.trigger(
+          "tool.execute.after",
+          { tool: "plan_exit", sessionID: "session_plan_test", callID: "call_plan_exit", args: {} },
+          planOut,
+        )
+        await wait()
+
+        // Verify delegation advisory is emitted
+        expect(planOut.output).toContain("DELEGATION ADVISORY")
+        expect(planOut.output).toContain("ADR-004")
+
+        // Verify workflow phase transitioned
+        const state = await Bun.file(files.state).json()
+        expect(state.workflow_phase).toBe("implementing")
+
+        // Verify event logged
+        const log = await Bun.file(files.log).text()
+        expect(log).toContain("delegation.plan_no_assignment")
+      },
+    })
+  })
+})
+
+test("plan_exit delegation enforcement skips advisory when delegation exists", async () => {
+  await withProfile(async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await fs.mkdir(path.join(dir, "src"), { recursive: true })
+        await Bun.write(path.join(dir, "src", "app.ts"), "export const app = 1\n")
+      },
+    })
+    const files = guard(tmp.path)
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        // 1. Initialize session
+        await Plugin.trigger(
+          "event",
+          { event: { type: "session.created", properties: { sessionID: "session_plan_deleg" } } },
+          {},
+        )
+        await wait()
+
+        // 2. Create a task (delegation exists)
+        await Plugin.trigger(
+          "tool.execute.before",
+          { tool: "task", sessionID: "session_plan_deleg", callID: "call_task_pre" },
+          { args: { subagent_type: "explore", prompt: "research" } },
+        )
+        await wait()
+
+        // 3. Fire plan_exit — advisory should NOT appear
+        const planOut = { title: "plan_exit", output: "Plan approved", metadata: {} }
+        await Plugin.trigger(
+          "tool.execute.after",
+          { tool: "plan_exit", sessionID: "session_plan_deleg", callID: "call_plan_exit_2", args: {} },
+          planOut,
+        )
+        await wait()
+
+        // Verify NO delegation advisory
+        expect(planOut.output).not.toContain("DELEGATION ADVISORY")
+
+        // Verify workflow phase still transitions
+        const state = await Bun.file(files.state).json()
+        expect(state.workflow_phase).toBe("implementing")
+      },
+    })
+  })
+})
+
+test("system transform includes delegation rules", async () => {
+  await withProfile(async () => {
+    await using tmp = await tmpdir({
+      git: true,
+      init: async (dir) => {
+        await Bun.write(path.join(dir, "src", "app.ts"), "export const app = 1\n").catch(() => {
+          fs.mkdir(path.join(dir, "src"), { recursive: true }).then(() =>
+            Bun.write(path.join(dir, "src", "app.ts"), "export const app = 1\n"),
+          )
+        })
+      },
+    })
+
+    await Instance.provide({
+      directory: tmp.path,
+      fn: async () => {
+        await Plugin.trigger(
+          "event",
+          { event: { type: "session.created", properties: { sessionID: "session_sys_deleg" } } },
+          {},
+        )
+        await wait()
+
+        const sysOut = { system: [] as string[] }
+        await Plugin.trigger(
+          "experimental.chat.system.transform",
+          {},
+          sysOut,
+        )
+
+        expect(sysOut.system.some((s) => s.includes("[DELEGATION]") && s.includes("ADR-004"))).toBe(true)
+      },
+    })
+  })
+})
+
 for (const replay of Object.values(replays)) {
   it.live(`guardrail replay keeps ${replay.command} executable`, () =>
     run(replay).pipe(

--- a/packages/opencode/test/scenario/guardrails.test.ts
+++ b/packages/opencode/test/scenario/guardrails.test.ts
@@ -1909,11 +1909,8 @@ test("system transform includes delegation rules", async () => {
     await using tmp = await tmpdir({
       git: true,
       init: async (dir) => {
-        await Bun.write(path.join(dir, "src", "app.ts"), "export const app = 1\n").catch(() => {
-          fs.mkdir(path.join(dir, "src"), { recursive: true }).then(() =>
-            Bun.write(path.join(dir, "src", "app.ts"), "export const app = 1\n"),
-          )
-        })
+        await fs.mkdir(path.join(dir, "src"), { recursive: true })
+        await Bun.write(path.join(dir, "src", "app.ts"), "export const app = 1\n")
       },
     })
 


### PR DESCRIPTION
## Summary
- Add delegation advisory to `plan_exit` handler: emits warning when plan is approved without delegation assignments (ADR-004 rules)
- Add delegation rules to system prompt via `experimental.chat.system.transform`: model always sees agent/team/codex limits
- Track `delegation.plan_no_assignment` events in events.jsonl

## Changes
- `packages/guardrails/profile/plugins/guardrail.ts`: plan_exit delegation check + system prompt injection
- `packages/opencode/test/scenario/guardrails.test.ts`: 3 new tests (37 total, all pass)

Fixes #159

## Test plan
- [x] 37/37 scenario tests pass locally
- [ ] CI unit + typecheck pass
- [ ] Verify advisory appears when plan_exit fires without delegation
- [ ] Verify advisory suppressed when task delegation exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)