### PR TITLE
fix: sign macOS builds and harden team runtime

### DIFF
--- a/packages/guardrails/profile/plugins/team.ts
+++ b/packages/guardrails/profile/plugins/team.ts
@@ -405,6 +405,10 @@ function yard(dir: string) {
   return path.join(dir, ".opencode", "team")
 }
 
+function projectRoot(directory: string, worktree: string) {
+  return worktree && worktree !== "/" ? worktree : directory
+}
+
 function rootkeep(dir: string) {
   if (dir === ".opencode") {
     return [
@@ -961,18 +965,22 @@ export default async function team(input: {
   worktree: string
   directory: string
 }) {
-  void sweep(input.client, input.worktree)
+  const inputRoot = projectRoot(input.directory, input.worktree)
+  void sweep(input.client, inputRoot)
   const job = async (ctx: Ctx, run: Run, item: Step) => {
+    const runRoot = projectRoot(ctx.directory, ctx.worktree)
+    const repoRoot = ctx.worktree && ctx.worktree !== "/" ? ctx.worktree : undefined
     const push = write(item.prompt, item.write)
     const prompt = direct(item.prompt)
-    const box = push && item.worktree ? await yardadd(ctx.worktree, `${run.id}-${item.id}`) : ctx.directory
-    const kept = box !== ctx.directory ? await carry(ctx.worktree, ctx.directory, box) : []
+    const useWorktree = push && item.worktree && !!repoRoot
+    const box = useWorktree ? await yardadd(repoRoot, `${run.id}-${item.id}`) : ctx.directory
+    const kept = useWorktree && repoRoot ? await carry(repoRoot, ctx.directory, box) : []
 
     todo(run, item.id, {
       state: "running",
       dir: box,
     })
-    await save(ctx.worktree, run)
+    await save(runRoot, run)
 
     const made = await input.client.session.create({
       body: {
@@ -989,7 +997,7 @@ export default async function team(input: {
     todo(run, item.id, {
       session: made.data.id,
     })
-    await save(ctx.worktree, run)
+    await save(runRoot, run)
 
     await input.client.session.promptAsync({
       path: { id: made.data.id },
@@ -1028,8 +1036,8 @@ export default async function team(input: {
     let err = out.error
     // [Phase6] Classify failure stage for abort reason tracking
     let failure_stage: Step["failure_stage"] = undefined
-    if (!err && push && box !== ctx.directory) {
-      const merged = await merge(ctx.worktree, box, run.id, item.id, kept)
+    if (!err && useWorktree && repoRoot && box !== ctx.directory) {
+      const merged = await merge(repoRoot, box, run.id, item.id, kept)
       patchfile = merged.patch
       if (!merged.merged) {
         err = merged.error || "Failed to merge worktree patch"
@@ -1045,7 +1053,7 @@ export default async function team(input: {
       error: err,
       failure_stage: err ? failure_stage : undefined,
     })
-    await save(ctx.worktree, run)
+    await save(runRoot, run)
     if (err) throw new Error(err)
     return out.text
   }
@@ -1069,7 +1077,9 @@ export default async function team(input: {
       ),
     },
     async execute(args, ctx) {
-      await sweep(input.client, ctx.worktree)
+      const runRoot = projectRoot(ctx.directory, ctx.worktree)
+      const canIsolate = Boolean(ctx.worktree && ctx.worktree !== "/")
+      await sweep(input.client, runRoot)
       defs(args.tasks)
       if (args.tasks.length < 1) throw new Error("team requires at least one task")
       const req = {
@@ -1107,7 +1117,7 @@ export default async function team(input: {
             depends: item.depends ?? [],
             agent: item.agent || "",
             write: write(item.prompt, item.write),
-            worktree: item.worktree !== false,
+            worktree: canIsolate && item.worktree !== false,
             provider: pick.provider,
             model: pick.model,
             variant: pick.variant,
@@ -1120,7 +1130,7 @@ export default async function team(input: {
           }
         }),
       }
-      await save(ctx.worktree, run)
+      await save(runRoot, run)
 
       const done = new Set<string>()
       const list = run.tasks
@@ -1141,7 +1151,7 @@ export default async function team(input: {
 
           if (args.strategy === "wave" && ready.length) {
             ready.forEach((item) => todo(run, item.id, { state: "queued" }))
-            await save(ctx.worktree, run)
+            await save(runRoot, run)
             await Promise.all(ready.map((item) => launch(item)))
           } else {
             ready.slice(0, Math.max(args.limit - active.size, 0)).forEach((item) => {
@@ -1156,20 +1166,20 @@ export default async function team(input: {
           }
 
           if (done.size === list.length) break
-          await save(ctx.worktree, run)
+          await save(runRoot, run)
         }
       } catch (err) {
         const item = run.tasks.find((item) => item.state === "error")
           ?? run.tasks.find((item) => item.state === "running" || item.state === "queued")
         fail(run, err instanceof Error ? err.message : String(err), item?.id)
-        await save(ctx.worktree, run)
+        await save(runRoot, run)
         await stop(input.client, run)
         throw err
       }
 
       run.state = run.tasks.some((item) => item.state === "error") ? "error" : "done"
       run.updated_at = now()
-      await save(ctx.worktree, run)
+      await save(runRoot, run)
       need.set(ctx.sessionID, {
         done: true,
         reason: "team",
@@ -1191,9 +1201,13 @@ export default async function team(input: {
       notify: z.boolean().optional().default(true),
     },
     async execute(args, ctx) {
-      await sweep(input.client, ctx.worktree)
+      const runRoot = projectRoot(ctx.directory, ctx.worktree)
+      const canIsolate = Boolean(ctx.worktree && ctx.worktree !== "/")
+      const detachedAbort = new AbortController()
+      await sweep(input.client, runRoot)
       const req = {
         ...ctx,
+        abort: detachedAbort.signal,
         permission: await rules(input.client, ctx),
       }
       const step: Step = {
@@ -1203,7 +1217,7 @@ export default async function team(input: {
         depends: [],
         agent: args.agent || "",
         write: write(args.prompt, args.write),
-        worktree: args.worktree !== false,
+        worktree: canIsolate && args.worktree !== false,
         ...lane({
           id: slug(args.description || args.agent || "worker") || "worker",
           description: args.description || "background worker",
@@ -1228,7 +1242,7 @@ export default async function team(input: {
         updated_at: now(),
         tasks: [step],
       }
-      await save(ctx.worktree, run)
+      await save(runRoot, run)
       req.metadata({
         title: args.description || "background run",
         metadata: {
@@ -1240,7 +1254,7 @@ export default async function team(input: {
         .then(async () => {
           run.state = "done"
           run.updated_at = now()
-          await save(ctx.worktree, run)
+          await save(runRoot, run)
           if (!args.notify) return
           await input.client.session.prompt({
             path: { id: req.sessionID },
@@ -1261,7 +1275,7 @@ export default async function team(input: {
         .catch(async (err: Error) => {
           const item = run.tasks.find((item) => item.state === "error" || item.state === "running" || item.state === "queued") || run.tasks[0]
           fail(run, err.message || "Unknown error", item?.id)
-          await save(ctx.worktree, run)
+          await save(runRoot, run)
           if (!args.notify) return
           await input.client.session.prompt({
             path: { id: req.sessionID },
@@ -1292,9 +1306,10 @@ export default async function team(input: {
       run_id: z.string().optional(),
     },
     async execute(args, ctx) {
-      await sweep(input.client, ctx.worktree)
-      const list = args.run_id ? [live.get(args.run_id) ?? (await load(ctx.worktree, args.run_id))].filter(isRun) : await scan(ctx.worktree)
-      const settled = await Promise.all(list.map((item) => reconcile(input.client, ctx.worktree, item)))
+      const runRoot = projectRoot(ctx.directory, ctx.worktree)
+      await sweep(input.client, runRoot)
+      const list = args.run_id ? [live.get(args.run_id) ?? (await load(runRoot, args.run_id))].filter(isRun) : await scan(runRoot)
+      const settled = await Promise.all(list.map((item) => reconcile(input.client, runRoot, item)))
       if (!settled.length) return "No team runs found."
       return settled.map((item) => note(item)).join("\n\n")
     },
@@ -1320,7 +1335,7 @@ export default async function team(input: {
         parts: Note[]
       },
     ) => {
-      void sweep(input.client, input.worktree)
+      void sweep(input.client, inputRoot)
       if (out.message.role !== "user") return
       if (kids.has(item.sessionID)) return
       if (item.agent && /(review|technical-writer|doc-updater)/i.test(item.agent)) return
@@ -1361,7 +1376,7 @@ export default async function team(input: {
         args: Record<string, unknown>
       },
     ) => {
-      void sweep(input.client, input.worktree)
+      void sweep(input.client, inputRoot)
       const gate = need.get(item.sessionID)
       if (!gate || gate.done) return
       if (item.tool === "team") return
@@ -1382,7 +1397,7 @@ export default async function team(input: {
         metadata: Record<string, unknown>
       },
     ) => {
-      void sweep(input.client, input.worktree)
+      void sweep(input.client, inputRoot)
       if (item.tool !== "team" && item.tool !== "background") return
       need.set(item.sessionID, {
         done: true,
@@ -1399,7 +1414,7 @@ export default async function team(input: {
         error: unknown
       },
     ) => {
-      void sweep(input.client, input.worktree)
+      void sweep(input.client, inputRoot)
       if (item.tool !== "team" && item.tool !== "background") return
       need.set(item.sessionID, {
         done: true,
@@ -1413,7 +1428,7 @@ export default async function team(input: {
         system: string[]
       },
     ) => {
-      void sweep(input.client, input.worktree)
+      void sweep(input.client, inputRoot)
       out.system.unshift(
         "When the user asks for a broad or multi-file implementation, decompose with the team tool before mutating files. Background work belongs in background; large implementation turns are hook-enforced.",
       )

--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -52,6 +52,36 @@ const baselineFlag = process.argv.includes("--baseline")
 const skipInstall = process.argv.includes("--skip-install")
 const plugin = createSolidTransformPlugin()
 const skipEmbedWebUi = process.argv.includes("--skip-embed-web-ui")
+const macosEntitlements = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-executable-page-protection</key>
+  <true/>
+  <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>
+`
+
+const signMacosBinary = async (binaryPath: string) => {
+  if (process.platform !== "darwin") return
+
+  const entitlementsPath = path.join(dir, "dist", "bun-macos-entitlements.plist")
+  await Bun.write(entitlementsPath, macosEntitlements)
+  try {
+    await $`codesign --remove-signature ${binaryPath}`.quiet().nothrow()
+    await $`codesign --force --deep --sign - --entitlements ${entitlementsPath} ${binaryPath}`
+  } finally {
+    await fs.promises.rm(entitlementsPath, { force: true }).catch(() => {})
+  }
+}
 
 const createEmbeddedWebUIBundle = async () => {
   console.log(`Building Web UI to embed in the binary`)
@@ -221,6 +251,10 @@ for (const item of targets) {
       OPENCODE_LIBC: item.os === "linux" ? `'${item.abi ?? "glibc"}'` : "",
     },
   })
+
+  if (item.os === "darwin") {
+    await signMacosBinary(`dist/${name}/bin/opencode`)
+  }
 
   // Smoke test: only run if binary is for current platform
   if (item.os === process.platform && item.arch === process.arch && !item.abi) {

--- a/packages/opencode/test/plugin/team.test.ts
+++ b/packages/opencode/test/plugin/team.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, expect, test } from "bun:test"
+import { readdir } from "fs/promises"
 import path from "path"
 import team from "../../../../packages/guardrails/profile/plugins/team"
 import { Instance } from "../../src/project/instance"
@@ -8,7 +9,7 @@ afterEach(async () => {
   await Instance.disposeAll()
 })
 
-async function createPlugin(dir: string) {
+async function createPlugin(dir: string, worktree = dir) {
   return team({
     client: {
       permission: {
@@ -35,17 +36,27 @@ async function createPlugin(dir: string) {
           return {}
         },
         async status() {
-          return { data: {} }
+          return { data: { ses_child: { type: "idle" } } }
         },
         async messages() {
-          return { data: [] }
+          return {
+            data: [
+              {
+                info: {
+                  role: "assistant",
+                  time: { completed: Date.now() },
+                },
+                parts: [{ type: "text", text: "done" }],
+              },
+            ],
+          }
         },
         async abort() {
           return {}
         },
       },
     },
-    worktree: dir,
+    worktree,
     directory: dir,
   })
 }
@@ -134,4 +145,64 @@ test("background failure also clears the parallel implementation gate", async ()
       { args: { filePath: path.join(tmp.path, "src", "a.ts"), oldString: "a", newString: "b" } },
     ),
   ).resolves.toBeUndefined()
+})
+
+test("background uses the session directory for state when no git worktree is available", async () => {
+  await using tmp = await tmpdir()
+  const plugin = await createPlugin(tmp.path, "/")
+
+  const result = await plugin.tool.background.execute(
+    {
+      description: "read-only non-git check",
+      prompt: "Run a read-only check in the current directory and report success.",
+      notify: false,
+      worktree: false,
+    },
+    {
+      sessionID: "ses_non_git_background",
+      messageID: "msg_non_git_background",
+      agent: "build",
+      directory: tmp.path,
+      worktree: "/",
+      abort: AbortSignal.timeout(5000),
+      metadata() {},
+      ask() {
+        return undefined as never
+      },
+    },
+  )
+
+  expect(result).toContain("state: done")
+  const entries = await readdir(path.join(tmp.path, ".opencode", "guardrails", "team-runs"))
+  expect(entries.some((item) => item.endsWith(".json"))).toBeTrue()
+})
+
+test("background detaches worker execution from the parent abort signal", async () => {
+  await using tmp = await tmpdir()
+  const plugin = await createPlugin(tmp.path, "/")
+  const controller = new AbortController()
+  controller.abort()
+
+  const result = await plugin.tool.background.execute(
+    {
+      description: "detached background check",
+      prompt: "Run a read-only check in the current directory and report success.",
+      notify: false,
+      worktree: false,
+    },
+    {
+      sessionID: "ses_detached_background",
+      messageID: "msg_detached_background",
+      agent: "build",
+      directory: tmp.path,
+      worktree: "/",
+      abort: controller.signal,
+      metadata() {},
+      ask() {
+        return undefined as never
+      },
+    },
+  )
+
+  expect(result).toContain("state: done")
 })

--- a/packages/script/src/index.ts
+++ b/packages/script/src/index.ts
@@ -23,11 +23,21 @@ const env = {
   OPENCODE_VERSION: process.env["OPENCODE_VERSION"],
   OPENCODE_RELEASE: process.env["OPENCODE_RELEASE"],
 }
+const sanitizeChannel = (value: string) => {
+  const channel = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[-.]+|[-.]+$/g, "")
+
+  return channel || "dev"
+}
 const CHANNEL = await (async () => {
-  if (env.OPENCODE_CHANNEL) return env.OPENCODE_CHANNEL
+  if (env.OPENCODE_CHANNEL) return sanitizeChannel(env.OPENCODE_CHANNEL)
   if (env.OPENCODE_BUMP) return "latest"
   if (env.OPENCODE_VERSION && !env.OPENCODE_VERSION.startsWith("0.0.0-")) return "latest"
-  return await $`git branch --show-current`.text().then((x) => x.trim())
+  return await $`git branch --show-current`.text().then((x) => sanitizeChannel(x))
 })()
 const IS_PREVIEW = CHANNEL !== "latest"
 


### PR DESCRIPTION
## Summary
- sign compiled darwin binaries with Bun's recommended macOS entitlements before smoke testing
- sanitize preview channels and version strings derived from branch names
- make team/background use the session directory for state when no git worktree is available
- detach background workers from the parent turn abort signal and cover the regressions in team plugin tests

## Verification
- bun run build
- bun run typecheck
- bun test test/plugin/team.test.ts
- bun test test/agent/agent.test.ts
- bun test test/plugin/trigger.test.ts
- bun test test/session/prompt-effect.test.ts
- bun test test/session/processor-effect.test.ts
- bun test test/session/snapshot-tool-race.test.ts
- installed binary checks via opencode run/serve with real team/background workflows
