### PR TITLE
fix: harden runtime path and team diagnostics

### DIFF
--- a/packages/guardrails/profile/plugins/guardrail-access.ts
+++ b/packages/guardrails/profile/plugins/guardrail-access.ts
@@ -29,9 +29,14 @@ export function createAccessHandlers(ctx: GuardrailContext) {
       const cmd = typeof out.args?.command === "string" ? out.args.command : ""
       const file = cmd.replaceAll("\\", "/")
       if (!cmd) return
-      if (has(file, sec) || file.includes(".opencode/guardrails/")) {
+      if (has(file, sec)) {
         await ctx.mark({ last_block: "bash", last_command: cmd, last_reason: "shell access to protected files" })
         throw new Error(text("shell access to protected files"))
+      }
+      const touchesGuardrailRuntime = file.includes(".opencode/guardrails/")
+      if (touchesGuardrailRuntime && bash(cmd)) {
+        await ctx.mark({ last_block: "bash", last_command: cmd, last_reason: "protected runtime or config mutation" })
+        throw new Error(text("protected runtime or config mutation"))
       }
       if (/\bdocker\s+build\b/i.test(cmd)) {
         const secretPatterns = [
@@ -59,7 +64,7 @@ export function createAccessHandlers(ctx: GuardrailContext) {
         }
       }
       if (!bash(cmd)) return
-      if (!cfg.some((rule) => rule.test(file)) && !file.includes(".opencode/guardrails/")) return
+      if (!cfg.some((rule) => rule.test(file)) && !touchesGuardrailRuntime) return
       await ctx.mark({ last_block: "bash", last_command: cmd, last_reason: "protected runtime or config mutation" })
       throw new Error(text("protected runtime or config mutation"))
     }

--- a/packages/guardrails/profile/plugins/team.ts
+++ b/packages/guardrails/profile/plugins/team.ts
@@ -145,6 +145,7 @@ type Step = {
   patch: string
   output: string
   error: string
+  no_patch: boolean
   updated_at?: string
   failure_stage?: "worktree_setup" | "session_create" | "execution" | "merge_back" | "aborted" | "timeout" | "blocked"
 }
@@ -498,6 +499,16 @@ function roots() {
   ]
 }
 
+function workspaceRuntime() {
+  return [
+    "node_modules",
+    ".pnpm-store",
+    ".yarn",
+    ".pnp.cjs",
+    ".pnp.loader.mjs",
+  ]
+}
+
 async function has(file: string) {
   return lstat(file).then(() => true).catch(() => false)
 }
@@ -542,6 +553,15 @@ async function carry(root: string, dir: string, next: string) {
           if (await graft(path.join(src, name), file)) {
             kept.push(path.relative(next, file))
           }
+        }
+      }
+    }
+
+    if (cur === root) {
+      for (const name of workspaceRuntime()) {
+        const file = path.join(next, name)
+        if (await graft(path.join(root, name), file)) {
+          kept.push(path.relative(next, file))
         }
       }
     }
@@ -822,6 +842,7 @@ function note(run: Run) {
       item.session ? `session=${item.session}` : "",
       item.dir ? `dir=${item.dir}` : "",
       item.patch ? `patch=${item.patch}` : "",
+      item.no_patch ? "no_patch=true" : "",
       item.failure_stage ? `failure_stage=${item.failure_stage}` : "",
       item.error ? `error=${clip(item.error, 240)}` : "",
       item.output ? `output=${clip(item.output, 240)}` : "",
@@ -1049,6 +1070,7 @@ export default async function team(input: {
     todo(run, item.id, {
       state: err ? "error" : "done",
       patch: patchfile,
+      no_patch: !err && item.write && useWorktree && patchfile === "",
       output: out.text,
       error: err,
       failure_stage: err ? failure_stage : undefined,
@@ -1125,6 +1147,7 @@ export default async function team(input: {
             dir: "",
             session: "",
             patch: "",
+            no_patch: false,
             output: "",
             error: "",
           }
@@ -1229,6 +1252,7 @@ export default async function team(input: {
         dir: "",
         session: "",
         patch: "",
+        no_patch: false,
         output: "",
         error: "",
       }

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -27,6 +27,7 @@ import { BashTool } from "../../tool/bash"
 import { TodoWriteTool } from "../../tool/todo"
 import { Locale } from "../../util"
 import { AppRuntime } from "@/effect/app-runtime"
+import { canonicalizeWorkingDirectory } from "../../util/cwd"
 
 type ToolProps<T> = {
   input: Tool.InferParameters<T>
@@ -309,8 +310,7 @@ export const RunCommand = cmd({
       if (!args.dir) return undefined
       if (args.attach) return args.dir
       try {
-        process.chdir(args.dir)
-        return process.cwd()
+        return canonicalizeWorkingDirectory(args.dir)
       } catch {
         UI.error("Failed to change directory to " + args.dir)
         process.exit(1)
@@ -669,7 +669,7 @@ export const RunCommand = cmd({
       return await execute(sdk)
     }
 
-    await bootstrap(process.cwd(), async () => {
+    await bootstrap(canonicalizeWorkingDirectory(), async () => {
       const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
         const request = new Request(input, init)
         return Server.Default().app.fetch(request)

--- a/packages/opencode/src/cli/cmd/tui/attach.ts
+++ b/packages/opencode/src/cli/cmd/tui/attach.ts
@@ -3,6 +3,7 @@ import { UI } from "@/cli/ui"
 import { tui } from "./app"
 import { win32DisableProcessedInput, win32InstallCtrlCGuard } from "./win32"
 import { TuiConfig } from "@/cli/cmd/tui/config/tui"
+import { canonicalizeWorkingDirectory } from "../../../util/cwd"
 
 export const AttachCommand = cmd({
   command: "attach <url>",
@@ -51,8 +52,7 @@ export const AttachCommand = cmd({
       const directory = (() => {
         if (!args.dir) return undefined
         try {
-          process.chdir(args.dir)
-          return process.cwd()
+          return canonicalizeWorkingDirectory(args.dir)
         } catch {
           // If the directory doesn't exist locally (remote attach), pass it through.
           return args.dir

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -39,8 +39,15 @@ import { PluginCommand } from "./cli/cmd/plug"
 import { Heap } from "./cli/heap"
 import { drizzle } from "drizzle-orm/bun-sqlite"
 import { ensureProcessMetadata } from "./util/opencode-process"
+import { canonicalizeWorkingDirectory } from "./util/cwd"
 
 const processMetadata = ensureProcessMetadata("main")
+
+try {
+  canonicalizeWorkingDirectory()
+} catch {
+  // Keep startup resilient when cwd disappears or cannot be resolved.
+}
 
 process.on("unhandledRejection", (e) => {
   Log.Default.error("rejection", {

--- a/packages/opencode/src/util/cwd.ts
+++ b/packages/opencode/src/util/cwd.ts
@@ -1,0 +1,13 @@
+import { AppFileSystem } from "@opencode-ai/shared/filesystem"
+
+export function canonicalizeWorkingDirectory(dir?: string) {
+  if (dir) {
+    process.chdir(dir)
+  }
+  const cwd = process.cwd()
+  const resolved = AppFileSystem.resolve(cwd)
+  if (resolved !== cwd) {
+    process.chdir(resolved)
+  }
+  return resolved
+}

--- a/packages/opencode/test/plugin/guardrail-access.test.ts
+++ b/packages/opencode/test/plugin/guardrail-access.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test"
+import { createAccessHandlers } from "../../../../packages/guardrails/profile/plugins/guardrail-access"
+import type { GuardrailContext } from "../../../../packages/guardrails/profile/plugins/guardrail-context"
+
+function context() {
+  const marks: Record<string, unknown>[] = []
+  const ctx: GuardrailContext = {
+    input: {
+      client: {} as GuardrailContext["input"]["client"],
+      directory: "/tmp/project",
+      worktree: "/tmp/project",
+    },
+    mode: "enforced",
+    root: "/tmp/project/.opencode/guardrails",
+    log: "/tmp/project/.opencode/guardrails/events.jsonl",
+    state: "/tmp/project/.opencode/guardrails/state.json",
+    allow: {},
+    hasCodexMcp: false,
+    maxParallelTasks: 5,
+    maxSessionCost: 10,
+    agentModelTier: {},
+    tierModels: {},
+    domainDirs: {},
+    async mark(data) {
+      marks.push(data)
+    },
+    async seen() {},
+    note() {
+      return { sessionID: undefined, permission: undefined, patterns: undefined }
+    },
+    hidden() {
+      return false
+    },
+    code() {
+      return false
+    },
+    fact() {
+      return false
+    },
+    stale() {
+      return false
+    },
+    factLine() {
+      return ""
+    },
+    reviewLine() {
+      return ""
+    },
+    compact() {
+      return ""
+    },
+    deny() {
+      return undefined
+    },
+    baseline() {
+      return undefined
+    },
+    async version() {
+      return undefined
+    },
+    async budget() {
+      return 0
+    },
+    gate() {
+      return undefined
+    },
+  }
+  return { ctx, marks }
+}
+
+describe("guardrail-access", () => {
+  test("allows read-only shell access to .opencode/guardrails", async () => {
+    const { ctx, marks } = context()
+    const access = createAccessHandlers(ctx)
+
+    await expect(
+      access.toolBeforeAccess(
+        { tool: "bash", args: { command: "ls -la .opencode/guardrails/" } },
+        { args: { command: "ls -la .opencode/guardrails/" } },
+      ),
+    ).resolves.toBeUndefined()
+
+    expect(marks).toHaveLength(0)
+  })
+
+  test("blocks mutating shell access to .opencode/guardrails", async () => {
+    const { ctx, marks } = context()
+    const access = createAccessHandlers(ctx)
+
+    await expect(
+      access.toolBeforeAccess(
+        { tool: "bash", args: { command: "rm -rf .opencode/guardrails/" } },
+        { args: { command: "rm -rf .opencode/guardrails/" } },
+      ),
+    ).rejects.toThrow("protected runtime or config mutation")
+
+    expect(marks).toHaveLength(1)
+    expect(marks[0]?.last_reason).toBe("protected runtime or config mutation")
+  })
+})

--- a/packages/opencode/test/plugin/team.test.ts
+++ b/packages/opencode/test/plugin/team.test.ts
@@ -5,11 +5,17 @@ import team from "../../../../packages/guardrails/profile/plugins/team"
 import { Instance } from "../../src/project/instance"
 import { tmpdir } from "../fixture/fixture"
 
+type TeamClient = Parameters<typeof team>[0]["client"]
+
 afterEach(async () => {
   await Instance.disposeAll()
 })
 
-async function createPlugin(dir: string, worktree = dir) {
+async function createPlugin(
+  dir: string,
+  worktree = dir,
+  overrides?: Partial<NonNullable<TeamClient["session"]>>,
+) {
   return team({
     client: {
       permission: {
@@ -54,6 +60,7 @@ async function createPlugin(dir: string, worktree = dir) {
         async abort() {
           return {}
         },
+        ...overrides,
       },
     },
     worktree,
@@ -205,4 +212,56 @@ test("background detaches worker execution from the parent abort signal", async 
   )
 
   expect(result).toContain("state: done")
+})
+
+test("team worktrees carry root node_modules into isolated write tasks", async () => {
+  await using tmp = await tmpdir({ git: true })
+  await Bun.write(path.join(tmp.path, "package.json"), '{"name":"fixture","private":true}')
+  await Bun.write(path.join(tmp.path, "tracked.txt"), "tracked\n")
+  await Bun.$`git add package.json tracked.txt`.cwd(tmp.path).quiet()
+  await Bun.$`git commit -m "test: seed worktree fixture"`.cwd(tmp.path).quiet()
+  await Bun.$`mkdir -p node_modules`.cwd(tmp.path).quiet()
+  await Bun.write(path.join(tmp.path, "node_modules", ".keep"), "")
+
+  let workerDir = ""
+  let workerSawNodeModules = false
+  const plugin = await createPlugin(tmp.path, tmp.path, {
+    async promptAsync(input) {
+      workerDir = input.query.directory
+      workerSawNodeModules = await Bun.file(path.join(workerDir, "node_modules", ".keep")).exists()
+      return {}
+    },
+  })
+
+  const result = await plugin.tool.team.execute(
+    {
+      strategy: "parallel",
+      limit: 1,
+      tasks: [
+        {
+          id: "write-task",
+          description: "write task in isolated worktree",
+          prompt: "Edit a file in the repository and verify dependencies are available.",
+          write: true,
+        },
+      ],
+    },
+    {
+      sessionID: "ses_team_worktree",
+      messageID: "msg_team_worktree",
+      agent: "implement",
+      directory: tmp.path,
+      worktree: tmp.path,
+      abort: AbortSignal.timeout(5000),
+      metadata() {},
+      ask() {
+        return undefined as never
+      },
+    },
+  )
+
+  expect(workerDir).not.toBe(tmp.path)
+  expect(workerSawNodeModules).toBeTrue()
+  expect(result).toContain("state: done")
+  expect(result).toContain("no_patch=true")
 })

--- a/packages/opencode/test/util/cwd.test.ts
+++ b/packages/opencode/test/util/cwd.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test"
+import path from "path"
+import fs from "fs/promises"
+import { canonicalizeWorkingDirectory } from "../../src/util/cwd"
+import { tmpdir } from "../fixture/fixture"
+
+describe("canonicalizeWorkingDirectory", () => {
+  test("normalizes casing when the filesystem accepts mixed-case aliases", async () => {
+    await using tmp = await tmpdir()
+    const mixedCaseDir = path.join(tmp.path, "CaseCheck")
+    await fs.mkdir(mixedCaseDir, { recursive: true })
+
+    const parent = path.dirname(mixedCaseDir)
+    const lowerAlias = path.join(parent, "casecheck")
+    try {
+      await fs.access(lowerAlias)
+    } catch {
+      return
+    }
+
+    const previous = process.cwd()
+    try {
+      const resolved = canonicalizeWorkingDirectory(lowerAlias)
+      expect(resolved).toBe(mixedCaseDir)
+      expect(process.cwd()).toBe(mixedCaseDir)
+    } finally {
+      process.chdir(previous)
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- canonicalize cwd at startup and in run/attach so mixed-case macOS paths do not poison git operations
- allow read-only bash inspection of .opencode/guardrails while still blocking mutations, and carry workspace runtime directories into isolated team worktrees
- surface no_patch=true for isolated write tasks that complete without a merged patch, with regression tests and live runtime verification

## Verification
- bun run build
- bun run typecheck
- bun test test/agent/agent.test.ts
- bun test test/plugin/team.test.ts
- bun test test/plugin/trigger.test.ts
- bun test test/plugin/guardrail-access.test.ts
- bun test test/util/cwd.test.ts
- bun test test/session/prompt-effect.test.ts
- bun test test/session/processor-effect.test.ts
- bun test test/session/snapshot-tool-race.test.ts
- live installed binary: lower-case path git commit via --pure run
- live installed binary: read-only bash access to .opencode/guardrails
- live installed binary: team JSON output surfaces no_patch=true
- live installed binary: serve + attach background run reaches state done and writes BG_OK
