### PR TITLE
[codex] Fix team merge with gitignored .opencode config

### DIFF
--- a/packages/guardrails/profile/plugins/team.ts
+++ b/packages/guardrails/profile/plugins/team.ts
@@ -479,6 +479,26 @@ function runtimeSpec() {
   return runtime.map((item) => `:(exclude)${item}`)
 }
 
+async function ignoredCarrySpec(dir: string, kept: string[]) {
+  const roots = new Set(
+    kept
+      .map((item) => item.split(/[\\/]/)[0])
+      .filter((item): item is string => Boolean(item)),
+  )
+  const spec: string[] = []
+  for (const root of roots) {
+    const ignored = await git(dir, ["check-ignore", "-q", "--", root, `${root}/`])
+    if (ignored.code === 0) spec.push(`:(exclude)${root}`, `:(exclude)${root}/**`)
+  }
+  return spec
+}
+
+async function workFiles(dir: string, spec: string[]) {
+  const out = await git(dir, ["ls-files", "-z", "--modified", "--deleted", "--others", "--exclude-standard", "--", ".", ...spec])
+  if (out.code !== 0) throw new Error(out.err || out.out || "Failed to list worktree changes")
+  return out.out.split("\0").filter(Boolean)
+}
+
 function docs() {
   return [
     "AGENTS.md",
@@ -642,21 +662,23 @@ async function yardrm(dir: string, item: string) {
 
 async function merge(dir: string, item: string, run: string, id: string, kept: string[] = []) {
   await Promise.all(kept.map((file) => rm(path.join(item, file), { force: true, recursive: true }).catch(() => undefined)))
-  const spec = runtimeSpec()
+  const spec = [...runtimeSpec(), ...(await ignoredCarrySpec(item, kept))]
   // Stage all worker-owned files while excluding runtime state that is created locally during execution.
-  const add = await git(item, ["add", "-A", "--", ".", ...spec])
-  if (add.code !== 0) throw new Error(add.err || add.out || "Failed to stage worktree changes")
-  const changed = await git(item, ["diff", "--cached", "--name-only", "--diff-filter=ACDMRTUXB", "--", ".", ...spec])
-  if (changed.code !== 0) throw new Error(changed.err || changed.out || "Failed to list worktree changes")
-  const files = changed.out
-    .split("\n")
-    .map((line) => line.trim())
-    .filter(Boolean)
+  const files = await workFiles(item, spec)
   if (!files.length) {
     await yardrm(dir, item)
     return { patch: "", merged: true }
   }
-  const diff = await git(item, ["diff", "--cached", "--binary", "--", ".", ...spec])
+  const add = await git(item, ["add", "-A", "--", ...files])
+  if (add.code !== 0) throw new Error(add.err || add.out || "Failed to stage worktree changes")
+  const changed = await git(item, ["diff", "--cached", "--name-only", "-z", "--diff-filter=ACDMRTUXB", "--", ...files])
+  if (changed.code !== 0) throw new Error(changed.err || changed.out || "Failed to list worktree changes")
+  const staged = changed.out.split("\0").filter(Boolean)
+  if (!staged.length) {
+    await yardrm(dir, item)
+    return { patch: "", merged: true }
+  }
+  const diff = await git(item, ["diff", "--cached", "--binary", "--", ...staged])
   if (diff.code !== 0) throw new Error(diff.err || diff.out || "Failed to read worktree diff")
   const next = patch(dir, run, id)
   await Bun.write(next, diff.out)
@@ -678,8 +700,8 @@ async function merge(dir: string, item: string, run: string, id: string, kept: s
   } catch { /* verification is advisory */ }
   // Auto-commit only the files produced by the worker patch so unrelated parent edits stay untouched.
   try {
-    if (files.length > 0) {
-      await git(dir, ["add", "--", ...files])
+    if (staged.length > 0) {
+      await git(dir, ["add", "--", ...staged])
       const commitMsg = `chore(team): apply worker changes from task ${id}`
       const commit = await git(dir, ["commit", "-m", commitMsg])
       if (commit.code !== 0 && !commit.err.includes("nothing to commit")) {

--- a/packages/opencode/test/plugin/team.test.ts
+++ b/packages/opencode/test/plugin/team.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, expect, test } from "bun:test"
-import { readdir } from "fs/promises"
+import { mkdir, readdir } from "fs/promises"
 import path from "path"
 import team from "../../../../packages/guardrails/profile/plugins/team"
 import { Instance } from "../../src/project/instance"
@@ -60,6 +60,207 @@ async function createPlugin(dir: string, worktree = dir) {
     directory: dir,
   })
 }
+
+test("team merges worker output when local .opencode config is gitignored", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      await Bun.write(path.join(dir, ".gitignore"), ".opencode/\n")
+      await Bun.write(path.join(dir, "README.md"), "# test\n")
+      await mkdir(path.join(dir, ".opencode", "plugins"), { recursive: true })
+      await Bun.write(path.join(dir, ".opencode", "opencode.jsonc"), `{"plugin":["./plugins/team.ts"]}\n`)
+      await Bun.write(path.join(dir, ".opencode", "plugins", "team.ts"), "export default async function team() {}\n")
+      await Bun.$`git add .gitignore README.md`.cwd(dir).quiet()
+      await Bun.$`git commit -m "seed"`.cwd(dir).quiet()
+    },
+  })
+
+  let box = ""
+  const plugin = await team({
+    client: {
+      permission: {
+        async list() {
+          return { data: [] }
+        },
+      },
+      question: {
+        async list() {
+          return { data: [] }
+        },
+      },
+      session: {
+        async get() {
+          return { data: { permission: [] } }
+        },
+        async create() {
+          return { data: { id: "ses_child_ignored_opencode" } }
+        },
+        async promptAsync(input) {
+          box = input.query.directory
+          expect(await Bun.file(path.join(box, ".opencode", "opencode.jsonc")).text()).toContain("./plugins/team.ts")
+          expect(await Bun.file(path.join(box, ".opencode", "plugins", "team.ts")).text()).toContain("export default")
+          await Bun.write(path.join(box, "worker.txt"), "worker output\n")
+        },
+        async prompt() {
+          return {}
+        },
+        async status() {
+          return { data: { ses_child_ignored_opencode: { type: "idle" } } }
+        },
+        async messages() {
+          return {
+            data: [
+              {
+                info: {
+                  role: "assistant",
+                  time: { completed: Date.now() },
+                },
+                parts: [{ type: "text", text: "done" }],
+              },
+            ],
+          }
+        },
+        async abort() {
+          return {}
+        },
+      },
+    },
+    worktree: tmp.path,
+    directory: tmp.path,
+  })
+
+  const out = await plugin.tool.team.execute(
+    {
+      strategy: "parallel",
+      limit: 1,
+      tasks: [
+        {
+          id: "ignored-opencode",
+          prompt: "write worker output",
+          write: true,
+        },
+      ],
+    },
+    {
+      sessionID: "ses_parent",
+      messageID: "msg_parent",
+      agent: "implement",
+      directory: tmp.path,
+      worktree: tmp.path,
+      abort: AbortSignal.timeout(5000),
+      metadata() {},
+      ask() {
+        return undefined as never
+      },
+    },
+  )
+
+  expect(out).toContain("- ignored-opencode: done")
+  expect(box).toContain(path.join(".opencode", "team"))
+  expect(await Bun.file(path.join(tmp.path, "worker.txt")).text()).toBe("worker output\n")
+  expect(await Bun.file(path.join(tmp.path, ".opencode", "opencode.jsonc")).exists()).toBeTrue()
+})
+
+test("team merge tolerates uncommitted removal of the .opencode gitignore rule", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      await Bun.write(path.join(dir, ".gitignore"), ".opencode/\n")
+      await Bun.write(path.join(dir, "README.md"), "# test\n")
+      await mkdir(path.join(dir, ".opencode", "plugins"), { recursive: true })
+      await Bun.write(path.join(dir, ".opencode", "opencode.jsonc"), `{"plugin":["./plugins/team.ts"]}\n`)
+      await Bun.write(path.join(dir, ".opencode", "plugins", "team.ts"), "export default async function team() {}\n")
+      await Bun.$`git add .gitignore README.md`.cwd(dir).quiet()
+      await Bun.$`git commit -m "seed"`.cwd(dir).quiet()
+      await Bun.write(path.join(dir, ".gitignore"), "# temporarily removed during repair\n")
+    },
+  })
+
+  let box = ""
+  const plugin = await team({
+    client: {
+      permission: {
+        async list() {
+          return { data: [] }
+        },
+      },
+      question: {
+        async list() {
+          return { data: [] }
+        },
+      },
+      session: {
+        async get() {
+          return { data: { permission: [] } }
+        },
+        async create() {
+          return { data: { id: "ses_child_uncommitted_gitignore" } }
+        },
+        async promptAsync(input) {
+          box = input.query.directory
+          expect(await Bun.file(path.join(box, ".gitignore")).text()).toContain(".opencode/")
+          expect(await Bun.file(path.join(box, ".opencode", "opencode.jsonc")).text()).toContain("./plugins/team.ts")
+          await Bun.write(path.join(box, "worker-uncommitted.txt"), "worker output\n")
+        },
+        async prompt() {
+          return {}
+        },
+        async status() {
+          return { data: { ses_child_uncommitted_gitignore: { type: "idle" } } }
+        },
+        async messages() {
+          return {
+            data: [
+              {
+                info: {
+                  role: "assistant",
+                  time: { completed: Date.now() },
+                },
+                parts: [{ type: "text", text: "done" }],
+              },
+            ],
+          }
+        },
+        async abort() {
+          return {}
+        },
+      },
+    },
+    worktree: tmp.path,
+    directory: tmp.path,
+  })
+
+  const out = await plugin.tool.team.execute(
+    {
+      strategy: "parallel",
+      limit: 1,
+      tasks: [
+        {
+          id: "uncommitted-gitignore",
+          prompt: "write worker output",
+          write: true,
+        },
+      ],
+    },
+    {
+      sessionID: "ses_parent",
+      messageID: "msg_parent",
+      agent: "implement",
+      directory: tmp.path,
+      worktree: tmp.path,
+      abort: AbortSignal.timeout(5000),
+      metadata() {},
+      ask() {
+        return undefined as never
+      },
+    },
+  )
+
+  expect(out).toContain("- uncommitted-gitignore: done")
+  expect(box).toContain(path.join(".opencode", "team"))
+  expect(await Bun.file(path.join(tmp.path, "worker-uncommitted.txt")).text()).toBe("worker output\n")
+  expect(await Bun.file(path.join(tmp.path, ".gitignore")).text()).not.toContain(".opencode/")
+})
 
 test("background success clears the parallel implementation gate", async () => {
   await using tmp = await tmpdir({ git: true })


### PR DESCRIPTION
## Summary

Fixes the team worker merge path when a project intentionally ignores `.opencode/` in `.gitignore`.

The team plugin carries local OpenCode config into isolated worker worktrees so child sessions can load project-local plugins and settings. Worker worktrees are created from `HEAD`, so even if a user temporarily removes `.opencode/` from the parent worktree `.gitignore`, the child worktree can still inherit the committed ignore rule from `HEAD`. The old merge path then ran `git add -A -- .`, causing Git to abort on the carried ignored `.opencode` directory before the worker patch could merge back.

## Changes

- List merge candidates with `git ls-files --modified --deleted --others --exclude-standard` instead of staging the entire worker worktree.
- Exclude carried config roots from merge pathspecs when Git treats them as ignored support files.
- Add regression coverage for both:
  - committed `.gitignore` containing `.opencode/`
  - parent worktree temporarily removing `.opencode/` while worker `HEAD` still ignores it

## Validation

- `bun test test/plugin/team.test.ts --timeout 30000`
- `bun run --cwd packages/opencode typecheck`
- Push pre-hook: `bun turbo typecheck`

Additional local validation in the linked development checkout:

- `bun test test/plugin/team.test.ts --timeout 30000`
- `bun test test/scenario/guardrails.test.ts --timeout 30000`
- `bun run --cwd packages/opencode typecheck`