### PR TITLE
[codex] Fix team worker absolute path isolation

### DIFF
--- a/packages/guardrails/profile/plugins/team.ts
+++ b/packages/guardrails/profile/plugins/team.ts
@@ -410,6 +410,18 @@ function projectRoot(directory: string, worktree: string) {
   return worktree && worktree !== "/" ? worktree : directory
 }
 
+function within(root: string, file: string) {
+  const rel = path.relative(root, file)
+  return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel))
+}
+
+function rebase(text: string, root: string, box: string) {
+  const src = path.resolve(root)
+  const dst = path.resolve(box)
+  if (src === dst) return text
+  return text.split(src).join(dst)
+}
+
 function rootkeep(dir: string) {
   if (dir === ".opencode") {
     return [
@@ -655,21 +667,21 @@ async function yardadd(dir: string, id: string) {
   // Step 1: Create worktree without checking out files (upstream pattern)
   const made = await git(dir, ["worktree", "add", "--detach", "--no-checkout", next, "HEAD"])
   if (made.code !== 0) {
-    await git(dir, ["worktree", "remove", "--force", next]).catch(() => {})
+    await yardrm(dir, next)
     throw new Error(made.err || made.out || "Failed to create git worktree")
   }
 
   // Step 2: Hard reset to populate working directory (upstream pattern)
   const populated = await git(next, ["reset", "--hard"])
   if (populated.code !== 0) {
-    await git(dir, ["worktree", "remove", "--force", next]).catch(() => {})
+    await yardrm(dir, next)
     throw new Error(`Worktree created but population failed: ${populated.err || populated.out}`)
   }
 
   // Step 3: Verify files are actually present in the working directory
   const check = await git(next, ["ls-files", "--cached"])
   if (check.code !== 0 || !check.out.trim()) {
-    await git(dir, ["worktree", "remove", "--force", next]).catch(() => {})
+    await yardrm(dir, next)
     throw new Error("Worktree is empty after reset --hard — cannot proceed with delegation")
   }
 
@@ -677,60 +689,61 @@ async function yardadd(dir: string, id: string) {
 }
 
 async function yardrm(dir: string, item: string) {
-  await git(dir, ["worktree", "remove", "--force", item])
+  const base = path.resolve(yard(dir))
+  const next = path.resolve(item)
+  if (!within(base, next)) return
+  await git(dir, ["worktree", "remove", "--force", next]).catch(() => undefined)
+  await rm(next, { force: true, recursive: true }).catch(() => undefined)
 }
 
 async function merge(dir: string, item: string, run: string, id: string, kept: string[] = []) {
-  await Promise.all(kept.map((file) => rm(path.join(item, file), { force: true, recursive: true }).catch(() => undefined)))
-  const spec = [...runtimeSpec(), ...(await ignoredCarrySpec(item, kept))]
-  // Stage all worker-owned files while excluding runtime state that is created locally during execution.
-  const files = await workFiles(item, spec)
-  if (!files.length) {
-    await yardrm(dir, item)
-    return { patch: "", merged: true }
-  }
-  const add = await git(item, ["add", "-A", "--", ...files])
-  if (add.code !== 0) throw new Error(add.err || add.out || "Failed to stage worktree changes")
-  const changed = await git(item, ["diff", "--cached", "--name-only", "-z", "--diff-filter=ACDMRTUXB", "--", ...files])
-  if (changed.code !== 0) throw new Error(changed.err || changed.out || "Failed to list worktree changes")
-  const staged = changed.out.split("\0").filter(Boolean)
-  if (!staged.length) {
-    await yardrm(dir, item)
-    return { patch: "", merged: true }
-  }
-  const diff = await git(item, ["diff", "--cached", "--binary", "--", ...staged])
-  if (diff.code !== 0) throw new Error(diff.err || diff.out || "Failed to read worktree diff")
-  const next = patch(dir, run, id)
-  await Bun.write(next, diff.out)
-  const out = await git(dir, ["apply", "--3way", next])
-  if (out.code !== 0) return { patch: next, merged: false, error: out.err || out.out || "Failed to apply patch" }
-  // [Phase6] Post-merge verification: confirm patch applied cleanly
-  const verification: { ok: boolean; issues: string[] } = { ok: true, issues: [] }
   try {
-    const diffStat = await git(dir, ["diff", "--stat", "HEAD"])
-    if (!diffStat.out.trim() && diff.out.trim()) {
-      verification.ok = false
-      verification.issues.push("Patch was non-empty but no diff detected after apply")
-    }
-    const status = await git(dir, ["status", "--porcelain"])
-    const untracked = status.out.trim().split("\n").filter((l: string) => l.startsWith("??")).length
-    if (untracked > 5) {
-      verification.issues.push(`${untracked} untracked files after merge — check for stale artifacts`)
-    }
-  } catch { /* verification is advisory */ }
-  // Auto-commit only the files produced by the worker patch so unrelated parent edits stay untouched.
-  try {
-    if (staged.length > 0) {
-      await git(dir, ["add", "--", ...staged])
-      const commitMsg = `chore(team): apply worker changes from task ${id}`
-      const commit = await git(dir, ["commit", "-m", commitMsg])
-      if (commit.code !== 0 && !commit.err.includes("nothing to commit")) {
-        verification.issues.push(`Auto-commit failed: ${commit.err || commit.out}`)
+    await Promise.all(kept.map((file) => rm(path.join(item, file), { force: true, recursive: true }).catch(() => undefined)))
+    const spec = [...runtimeSpec(), ...(await ignoredCarrySpec(item, kept))]
+    // Stage all worker-owned files while excluding runtime state that is created locally during execution.
+    const files = await workFiles(item, spec)
+    if (!files.length) return { patch: "", merged: true }
+    const add = await git(item, ["add", "-A", "--", ...files])
+    if (add.code !== 0) throw new Error(add.err || add.out || "Failed to stage worktree changes")
+    const changed = await git(item, ["diff", "--cached", "--name-only", "-z", "--diff-filter=ACDMRTUXB", "--", ...files])
+    if (changed.code !== 0) throw new Error(changed.err || changed.out || "Failed to list worktree changes")
+    const staged = changed.out.split("\0").filter(Boolean)
+    if (!staged.length) return { patch: "", merged: true }
+    const diff = await git(item, ["diff", "--cached", "--binary", "--", ...staged])
+    if (diff.code !== 0) throw new Error(diff.err || diff.out || "Failed to read worktree diff")
+    const next = patch(dir, run, id)
+    await Bun.write(next, diff.out)
+    const out = await git(dir, ["apply", "--3way", next])
+    if (out.code !== 0) return { patch: next, merged: false, error: out.err || out.out || "Failed to apply patch" }
+    // [Phase6] Post-merge verification: confirm patch applied cleanly
+    const verification: { ok: boolean; issues: string[] } = { ok: true, issues: [] }
+    try {
+      const diffStat = await git(dir, ["diff", "--stat", "HEAD"])
+      if (!diffStat.out.trim() && diff.out.trim()) {
+        verification.ok = false
+        verification.issues.push("Patch was non-empty but no diff detected after apply")
       }
-    }
-  } catch { /* auto-commit is best-effort; parent session can still commit manually */ }
-  await yardrm(dir, item)
-  return { patch: next, merged: true, verification }
+      const status = await git(dir, ["status", "--porcelain"])
+      const untracked = status.out.trim().split("\n").filter((l: string) => l.startsWith("??")).length
+      if (untracked > 5) {
+        verification.issues.push(`${untracked} untracked files after merge — check for stale artifacts`)
+      }
+    } catch { /* verification is advisory */ }
+    // Auto-commit only the files produced by the worker patch so unrelated parent edits stay untouched.
+    try {
+      if (staged.length > 0) {
+        await git(dir, ["add", "--", ...staged])
+        const commitMsg = `chore(team): apply worker changes from task ${id}`
+        const commit = await git(dir, ["commit", "-m", commitMsg])
+        if (commit.code !== 0 && !commit.err.includes("nothing to commit")) {
+          verification.issues.push(`Auto-commit failed: ${commit.err || commit.out}`)
+        }
+      }
+    } catch { /* auto-commit is best-effort; parent session can still commit manually */ }
+    return { patch: next, merged: true, verification }
+  } finally {
+    await yardrm(dir, item).catch(() => undefined)
+  }
 }
 
 async function idle(client: Client, id: string, dir: string, abort: AbortSignal) {
@@ -1014,10 +1027,10 @@ export default async function team(input: {
     const runRoot = projectRoot(ctx.directory, ctx.worktree)
     const repoRoot = ctx.worktree && ctx.worktree !== "/" ? ctx.worktree : undefined
     const push = write(item.prompt, item.write)
-    const prompt = direct(item.prompt)
     const useWorktree = push && item.worktree && !!repoRoot
     const box = useWorktree ? await yardadd(repoRoot, `${run.id}-${item.id}`) : ctx.directory
     const kept = useWorktree && repoRoot ? await carry(repoRoot, ctx.directory, box) : []
+    const prompt = direct(useWorktree && repoRoot ? rebase(item.prompt, repoRoot, box) : item.prompt)
 
     todo(run, item.id, {
       state: "running",

--- a/packages/guardrails/profile/plugins/team.ts
+++ b/packages/guardrails/profile/plugins/team.ts
@@ -480,6 +480,26 @@ function runtimeSpec() {
   return runtime.map((item) => `:(exclude)${item}`)
 }
 
+async function ignoredCarrySpec(dir: string, kept: string[]) {
+  const roots = new Set(
+    kept
+      .map((item) => item.split(/[\\/]/)[0])
+      .filter((item): item is string => Boolean(item)),
+  )
+  const spec: string[] = []
+  for (const root of roots) {
+    const ignored = await git(dir, ["check-ignore", "-q", "--", root, `${root}/`])
+    if (ignored.code === 0) spec.push(`:(exclude)${root}`, `:(exclude)${root}/**`)
+  }
+  return spec
+}
+
+async function workFiles(dir: string, spec: string[]) {
+  const out = await git(dir, ["ls-files", "-z", "--modified", "--deleted", "--others", "--exclude-standard", "--", ".", ...spec])
+  if (out.code !== 0) throw new Error(out.err || out.out || "Failed to list worktree changes")
+  return out.out.split("\0").filter(Boolean)
+}
+
 function docs() {
   return [
     "AGENTS.md",
@@ -662,21 +682,23 @@ async function yardrm(dir: string, item: string) {
 
 async function merge(dir: string, item: string, run: string, id: string, kept: string[] = []) {
   await Promise.all(kept.map((file) => rm(path.join(item, file), { force: true, recursive: true }).catch(() => undefined)))
-  const spec = runtimeSpec()
+  const spec = [...runtimeSpec(), ...(await ignoredCarrySpec(item, kept))]
   // Stage all worker-owned files while excluding runtime state that is created locally during execution.
-  const add = await git(item, ["add", "-A", "--", ".", ...spec])
-  if (add.code !== 0) throw new Error(add.err || add.out || "Failed to stage worktree changes")
-  const changed = await git(item, ["diff", "--cached", "--name-only", "--diff-filter=ACDMRTUXB", "--", ".", ...spec])
-  if (changed.code !== 0) throw new Error(changed.err || changed.out || "Failed to list worktree changes")
-  const files = changed.out
-    .split("\n")
-    .map((line) => line.trim())
-    .filter(Boolean)
+  const files = await workFiles(item, spec)
   if (!files.length) {
     await yardrm(dir, item)
     return { patch: "", merged: true }
   }
-  const diff = await git(item, ["diff", "--cached", "--binary", "--", ".", ...spec])
+  const add = await git(item, ["add", "-A", "--", ...files])
+  if (add.code !== 0) throw new Error(add.err || add.out || "Failed to stage worktree changes")
+  const changed = await git(item, ["diff", "--cached", "--name-only", "-z", "--diff-filter=ACDMRTUXB", "--", ...files])
+  if (changed.code !== 0) throw new Error(changed.err || changed.out || "Failed to list worktree changes")
+  const staged = changed.out.split("\0").filter(Boolean)
+  if (!staged.length) {
+    await yardrm(dir, item)
+    return { patch: "", merged: true }
+  }
+  const diff = await git(item, ["diff", "--cached", "--binary", "--", ...staged])
   if (diff.code !== 0) throw new Error(diff.err || diff.out || "Failed to read worktree diff")
   const next = patch(dir, run, id)
   await Bun.write(next, diff.out)
@@ -698,8 +720,8 @@ async function merge(dir: string, item: string, run: string, id: string, kept: s
   } catch { /* verification is advisory */ }
   // Auto-commit only the files produced by the worker patch so unrelated parent edits stay untouched.
   try {
-    if (files.length > 0) {
-      await git(dir, ["add", "--", ...files])
+    if (staged.length > 0) {
+      await git(dir, ["add", "--", ...staged])
       const commitMsg = `chore(team): apply worker changes from task ${id}`
       const commit = await git(dir, ["commit", "-m", commitMsg])
       if (commit.code !== 0 && !commit.err.includes("nothing to commit")) {

--- a/packages/opencode/test/plugin/team.test.ts
+++ b/packages/opencode/test/plugin/team.test.ts
@@ -269,6 +269,107 @@ test("team merge tolerates uncommitted removal of the .opencode gitignore rule",
   expect(await Bun.file(path.join(tmp.path, ".gitignore")).text()).not.toContain(".opencode/")
 })
 
+test("team rewrites parent absolute paths into isolated worker prompts", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      await mkdir(path.join(dir, "src"), { recursive: true })
+      await Bun.write(path.join(dir, "src", "target.txt"), "before\n")
+      await Bun.$`git add src/target.txt`.cwd(dir).quiet()
+      await Bun.$`git commit -m "seed"`.cwd(dir).quiet()
+    },
+  })
+
+  let box = ""
+  const parent = path.join(tmp.path, "src", "target.txt")
+  const plugin = await team({
+    client: {
+      permission: {
+        async list() {
+          return { data: [] }
+        },
+      },
+      question: {
+        async list() {
+          return { data: [] }
+        },
+      },
+      session: {
+        async get() {
+          return { data: { permission: [] } }
+        },
+        async create() {
+          return { data: { id: "ses_child_absolute_path" } }
+        },
+        async promptAsync(input) {
+          box = input.query.directory
+          const text = input.body.parts[0]?.text ?? ""
+          const target = path.join(box, "src", "target.txt")
+          expect(text).toContain(target)
+          expect(text).not.toContain(parent)
+          await Bun.write(target, "after\n")
+        },
+        async prompt() {
+          return {}
+        },
+        async status() {
+          return { data: { ses_child_absolute_path: { type: "idle" } } }
+        },
+        async messages() {
+          return {
+            data: [
+              {
+                info: {
+                  role: "assistant",
+                  time: { completed: Date.now() },
+                },
+                parts: [{ type: "text", text: "done" }],
+              },
+            ],
+          }
+        },
+        async abort() {
+          return {}
+        },
+      },
+    },
+    worktree: tmp.path,
+    directory: tmp.path,
+  })
+
+  const out = await plugin.tool.team.execute(
+    {
+      strategy: "parallel",
+      limit: 1,
+      tasks: [
+        {
+          id: "absolute-path",
+          prompt: `Edit ${parent} and replace the contents with after.`,
+          write: true,
+        },
+      ],
+    },
+    {
+      sessionID: "ses_parent",
+      messageID: "msg_parent",
+      agent: "implement",
+      directory: tmp.path,
+      worktree: tmp.path,
+      abort: AbortSignal.timeout(5000),
+      metadata() {},
+      ask() {
+        return undefined as never
+      },
+    },
+  )
+
+  expect(out).toContain("- absolute-path: done")
+  expect(box).toContain(path.join(".opencode", "team"))
+  expect(await Bun.file(parent).text()).toBe("after\n")
+  const list = await readdir(path.join(tmp.path, ".opencode", "team"), { withFileTypes: true }).catch(() => [])
+  expect(list.filter((item) => item.isDirectory()).length).toBe(0)
+})
+
 test("background success clears the parallel implementation gate", async () => {
   await using tmp = await tmpdir({ git: true })
   const plugin = await createPlugin(tmp.path)

--- a/packages/opencode/test/plugin/team.test.ts
+++ b/packages/opencode/test/plugin/team.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, expect, test } from "bun:test"
-import { readdir } from "fs/promises"
+import { mkdir, readdir } from "fs/promises"
 import path from "path"
 import team from "../../../../packages/guardrails/profile/plugins/team"
 import { Instance } from "../../src/project/instance"
@@ -67,6 +67,207 @@ async function createPlugin(
     directory: dir,
   })
 }
+
+test("team merges worker output when local .opencode config is gitignored", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      await Bun.write(path.join(dir, ".gitignore"), ".opencode/\n")
+      await Bun.write(path.join(dir, "README.md"), "# test\n")
+      await mkdir(path.join(dir, ".opencode", "plugins"), { recursive: true })
+      await Bun.write(path.join(dir, ".opencode", "opencode.jsonc"), `{"plugin":["./plugins/team.ts"]}\n`)
+      await Bun.write(path.join(dir, ".opencode", "plugins", "team.ts"), "export default async function team() {}\n")
+      await Bun.$`git add .gitignore README.md`.cwd(dir).quiet()
+      await Bun.$`git commit -m "seed"`.cwd(dir).quiet()
+    },
+  })
+
+  let box = ""
+  const plugin = await team({
+    client: {
+      permission: {
+        async list() {
+          return { data: [] }
+        },
+      },
+      question: {
+        async list() {
+          return { data: [] }
+        },
+      },
+      session: {
+        async get() {
+          return { data: { permission: [] } }
+        },
+        async create() {
+          return { data: { id: "ses_child_ignored_opencode" } }
+        },
+        async promptAsync(input) {
+          box = input.query.directory
+          expect(await Bun.file(path.join(box, ".opencode", "opencode.jsonc")).text()).toContain("./plugins/team.ts")
+          expect(await Bun.file(path.join(box, ".opencode", "plugins", "team.ts")).text()).toContain("export default")
+          await Bun.write(path.join(box, "worker.txt"), "worker output\n")
+        },
+        async prompt() {
+          return {}
+        },
+        async status() {
+          return { data: { ses_child_ignored_opencode: { type: "idle" } } }
+        },
+        async messages() {
+          return {
+            data: [
+              {
+                info: {
+                  role: "assistant",
+                  time: { completed: Date.now() },
+                },
+                parts: [{ type: "text", text: "done" }],
+              },
+            ],
+          }
+        },
+        async abort() {
+          return {}
+        },
+      },
+    },
+    worktree: tmp.path,
+    directory: tmp.path,
+  })
+
+  const out = await plugin.tool.team.execute(
+    {
+      strategy: "parallel",
+      limit: 1,
+      tasks: [
+        {
+          id: "ignored-opencode",
+          prompt: "write worker output",
+          write: true,
+        },
+      ],
+    },
+    {
+      sessionID: "ses_parent",
+      messageID: "msg_parent",
+      agent: "implement",
+      directory: tmp.path,
+      worktree: tmp.path,
+      abort: AbortSignal.timeout(5000),
+      metadata() {},
+      ask() {
+        return undefined as never
+      },
+    },
+  )
+
+  expect(out).toContain("- ignored-opencode: done")
+  expect(box).toContain(path.join(".opencode", "team"))
+  expect(await Bun.file(path.join(tmp.path, "worker.txt")).text()).toBe("worker output\n")
+  expect(await Bun.file(path.join(tmp.path, ".opencode", "opencode.jsonc")).exists()).toBeTrue()
+})
+
+test("team merge tolerates uncommitted removal of the .opencode gitignore rule", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      await Bun.write(path.join(dir, ".gitignore"), ".opencode/\n")
+      await Bun.write(path.join(dir, "README.md"), "# test\n")
+      await mkdir(path.join(dir, ".opencode", "plugins"), { recursive: true })
+      await Bun.write(path.join(dir, ".opencode", "opencode.jsonc"), `{"plugin":["./plugins/team.ts"]}\n`)
+      await Bun.write(path.join(dir, ".opencode", "plugins", "team.ts"), "export default async function team() {}\n")
+      await Bun.$`git add .gitignore README.md`.cwd(dir).quiet()
+      await Bun.$`git commit -m "seed"`.cwd(dir).quiet()
+      await Bun.write(path.join(dir, ".gitignore"), "# temporarily removed during repair\n")
+    },
+  })
+
+  let box = ""
+  const plugin = await team({
+    client: {
+      permission: {
+        async list() {
+          return { data: [] }
+        },
+      },
+      question: {
+        async list() {
+          return { data: [] }
+        },
+      },
+      session: {
+        async get() {
+          return { data: { permission: [] } }
+        },
+        async create() {
+          return { data: { id: "ses_child_uncommitted_gitignore" } }
+        },
+        async promptAsync(input) {
+          box = input.query.directory
+          expect(await Bun.file(path.join(box, ".gitignore")).text()).toContain(".opencode/")
+          expect(await Bun.file(path.join(box, ".opencode", "opencode.jsonc")).text()).toContain("./plugins/team.ts")
+          await Bun.write(path.join(box, "worker-uncommitted.txt"), "worker output\n")
+        },
+        async prompt() {
+          return {}
+        },
+        async status() {
+          return { data: { ses_child_uncommitted_gitignore: { type: "idle" } } }
+        },
+        async messages() {
+          return {
+            data: [
+              {
+                info: {
+                  role: "assistant",
+                  time: { completed: Date.now() },
+                },
+                parts: [{ type: "text", text: "done" }],
+              },
+            ],
+          }
+        },
+        async abort() {
+          return {}
+        },
+      },
+    },
+    worktree: tmp.path,
+    directory: tmp.path,
+  })
+
+  const out = await plugin.tool.team.execute(
+    {
+      strategy: "parallel",
+      limit: 1,
+      tasks: [
+        {
+          id: "uncommitted-gitignore",
+          prompt: "write worker output",
+          write: true,
+        },
+      ],
+    },
+    {
+      sessionID: "ses_parent",
+      messageID: "msg_parent",
+      agent: "implement",
+      directory: tmp.path,
+      worktree: tmp.path,
+      abort: AbortSignal.timeout(5000),
+      metadata() {},
+      ask() {
+        return undefined as never
+      },
+    },
+  )
+
+  expect(out).toContain("- uncommitted-gitignore: done")
+  expect(box).toContain(path.join(".opencode", "team"))
+  expect(await Bun.file(path.join(tmp.path, "worker-uncommitted.txt")).text()).toBe("worker output\n")
+  expect(await Bun.file(path.join(tmp.path, ".gitignore")).text()).not.toContain(".opencode/")
+})
 
 test("background success clears the parallel implementation gate", async () => {
   await using tmp = await tmpdir({ git: true })


### PR DESCRIPTION
## Summary

- builds on PR #173's gitignored `.opencode` carry fix
- rewrites parent repository absolute paths in team worker prompts to the isolated worker worktree
- always removes worker worktrees, including no-patch and merge-failure paths
- adds a regression test for the absolute-path leak that produced `no_patch=true`

## Root Cause

Workers were correctly launched in isolated git worktrees, but task prompts often contained absolute paths from the parent repository. The worker followed those absolute paths, so edits happened outside the isolated worktree or never produced a worker diff. The parent merge then saw no files from `git ls-files --modified --deleted --others --exclude-standard`, recorded `no_patch=true`, and reported the task as done.

## Validation

- `bun test test/plugin/team.test.ts`
- `bun test test/plugin/team.test.ts test/plugin/trigger.test.ts test/plugin/workspace-adaptor.test.ts test/config/plugin.test.ts`
- `bun typecheck`
- pre-push hook: `bun turbo typecheck`
- local CLI boot with guardrails profile: `OPENCODE_CONFIG_DIR=/tmp/opencode-team-session-fix/packages/guardrails/profile bun run --cwd packages/opencode --conditions=browser src/index.ts --help`
- local guardrails profile load: `OPENCODE_CONFIG_DIR=/tmp/opencode-team-session-fix/packages/guardrails/profile bun run --cwd packages/opencode --conditions=browser src/index.ts agent list`
