### PR TITLE
[codex] fix team worker completion detection

### DIFF
--- a/packages/guardrails/profile/plugins/team.ts
+++ b/packages/guardrails/profile/plugins/team.ts
@@ -337,6 +337,7 @@ function direct(text: string) {
 - Prefer file inspection tools such as Glob, Read, and Grep over bash for repository discovery whenever possible.
 - Use bash only when the non-shell tools cannot answer the question or complete the step.
 - Do not invoke nested OpenCode slash commands from inside this team worker.
+- Do not create git branches, clones, nested repositories, or nested worktrees. The team tool already created the isolated worktree; edit files in the current directory directly.
 - If you are running in an isolated worktree, operate only on files inside the current worktree directory. Do not read from or write to the parent repository path directly.
 
 ${next}`
@@ -764,7 +765,6 @@ async function idle(client: Client, id: string, dir: string, abort: AbortSignal)
     const item = stat.data?.[id]
     if (!item) {
       if (hit.idle.has(id)) return
-      if (seen) return
       await Bun.sleep(gap)
       continue
     }

--- a/packages/opencode/test/plugin/team.test.ts
+++ b/packages/opencode/test/plugin/team.test.ts
@@ -567,3 +567,61 @@ test("team worktrees carry root node_modules into isolated write tasks", async (
   expect(result).toContain("state: done")
   expect(result).toContain("no_patch=true")
 })
+
+test("team does not finish on non-completed progress when child status disappears", async () => {
+  await using tmp = await tmpdir()
+  let turn = 0
+  const abort = new AbortController()
+  const plugin = await createPlugin(tmp.path, tmp.path, {
+    async status() {
+      turn += 1
+      if (turn === 1) return { data: { ses_child: { type: "busy" } } }
+      return { data: {} as Record<string, { type: string }> }
+    },
+    async messages() {
+      return {
+        data: [
+          {
+            info: {
+              role: "assistant",
+            },
+            parts: [{ type: "text", text: "Inspecting the repository before editing." }],
+          },
+        ],
+      }
+    },
+  })
+
+  setTimeout(() => abort.abort(), 1100)
+
+  await expect(
+    plugin.tool.team.execute(
+      {
+        strategy: "parallel",
+        limit: 1,
+        tasks: [
+          {
+            id: "verify",
+            prompt: "check repo facts",
+            write: false,
+            worktree: false,
+          },
+        ],
+      },
+      {
+        sessionID: "ses_parent",
+        messageID: "msg_parent",
+        agent: "implement",
+        directory: tmp.path,
+        worktree: tmp.path,
+        abort: abort.signal,
+        metadata() {},
+        ask() {
+          return undefined as never
+        },
+      },
+    ),
+  ).rejects.toThrow("Aborted")
+
+  expect(turn).toBeGreaterThanOrEqual(2)
+})


### PR DESCRIPTION
## Summary

- keep team workers running when their status entry temporarily disappears without a completed assistant message
- add worker guidance to avoid creating nested branches, repositories, or worktrees inside the team worktree
- add a regression test for non-completed progress text followed by missing child status

## Root Cause

The team plugin treated a missing child status after prior activity as completion. If the child had only emitted an in-progress assistant message, the parent could fan in early, see no patch, and report `no_patch=true`.

## Validation

- `bun test test/plugin/team.test.ts`
- `bun run --cwd packages/opencode typecheck`
- pre-push hook: `bun turbo typecheck`
