### PR TITLE
Fix team operation-only gate deadlocks

### DIFF
--- a/packages/guardrails/profile/plugins/team.ts
+++ b/packages/guardrails/profile/plugins/team.ts
@@ -16,6 +16,7 @@ const sweeping = new Map<string, Promise<void>>()
 type Need = {
   done: boolean
   reason: string
+  fingerprint: string
   at: string
 }
 
@@ -149,6 +150,7 @@ type Step = {
   output: string
   error: string
   no_patch: boolean
+  allow_no_patch: boolean
   updated_at?: string
   failure_stage?: "worktree_setup" | "session_create" | "execution" | "merge_back" | "aborted" | "timeout" | "blocked"
 }
@@ -308,6 +310,7 @@ function mut(cmd: string) {
 function big(text: string) {
   const data = text.trim()
   if (!data) return false
+  if (operationOnly(data)) return false
   // Exempt read-only investigation requests that start with investigation verbs
   // and do NOT contain write-intent keywords
   const readOnly =
@@ -325,6 +328,22 @@ function big(text: string) {
     plan >= 3 ||
     /(packages\/|apps\/|services\/|複数|multi[- ]file|cross[- ]cutting|large plan|大きな実装|大規模)/i.test(data)
   return impl && wide
+}
+
+function fingerprint(text: string) {
+  return text.trim().replace(/\s+/g, " ").slice(0, 500)
+}
+
+function operationOnly(text: string) {
+  const data = text.trim()
+  if (!data) return false
+  const tail = data.slice(-900)
+  const operation =
+    /\b(gh\s+pr|pull\s+request|pr\s+(?:create|merge|ready|close|view|check|checks)|commit|push|merge|rebase|cherry-pick)\b|プルリク|PR\s*(?:作成|マージ)|コミット|プッシュ|マージ/i
+  if (!operation.test(tail)) return false
+  const implementation =
+    /\b(implement|implementation|build|add|fix|refactor|rewrite|patch|edit|write|modify|code)\b|修正|実装|追加|改修|編集/i
+  return !implementation.test(tail)
 }
 
 function write(text: string, flag?: boolean) {
@@ -434,6 +453,13 @@ function rebase(text: string, root: string, box: string) {
   const dst = path.resolve(box)
   if (src === dst) return text
   return text.split(src).join(dst)
+}
+
+function rebaseForWorktree(text: string, root: string, box: string) {
+  let next = rebase(text, root, box)
+  const hint = worktreeHint(text)
+  if (hint) next = next.split(path.resolve(hint)).join(path.resolve(box))
+  return next
 }
 
 function cleanHint(text: string) {
@@ -1178,7 +1204,7 @@ export default async function team(input: { client: Client; worktree: string; di
         box = await yardadd(repoRoot, `${run.id}-${item.id}`)
         kept = await carry(repoRoot, ctx.directory, box)
       }
-      const prompt = direct(useWorktree && repoRoot ? rebase(item.prompt, repoRoot, box) : item.prompt)
+      const prompt = direct(useWorktree && repoRoot ? rebaseForWorktree(item.prompt, repoRoot, box) : item.prompt)
 
       if (process.env.DEBUG_TEAM) console.log("job.start", run.id, item.id)
       todo(run, item.id, {
@@ -1254,7 +1280,7 @@ export default async function team(input: { client: Client; worktree: string; di
         if (!merged.merged) {
           err = merged.error || "Failed to merge worktree patch"
           failure_stage = "merge_back"
-        } else if (item.write && patchfile === "") {
+        } else if (item.write && patchfile === "" && !item.allow_no_patch) {
           err = "Write task completed without producing a patch"
           failure_stage = "execution"
         }
@@ -1295,6 +1321,7 @@ export default async function team(input: { client: Client; worktree: string; di
           depends: z.array(z.string()).optional(),
           write: z.boolean().optional(),
           worktree: z.boolean().optional(),
+          no_patch: z.boolean().optional(),
         }),
       ),
     },
@@ -1348,6 +1375,7 @@ export default async function team(input: { client: Client; worktree: string; di
             session: "",
             patch: "",
             no_patch: false,
+            allow_no_patch: item.no_patch === true || operationOnly(item.prompt),
             output: "",
             error: "",
           }
@@ -1409,6 +1437,7 @@ export default async function team(input: { client: Client; worktree: string; di
       need.set(ctx.sessionID, {
         done: true,
         reason: "team",
+        fingerprint: need.get(ctx.sessionID)?.fingerprint ?? "",
         at: now(),
       })
       return note(run)
@@ -1456,6 +1485,7 @@ export default async function team(input: { client: Client; worktree: string; di
         session: "",
         patch: "",
         no_patch: false,
+        allow_no_patch: operationOnly(args.prompt),
         output: "",
         error: "",
       }
@@ -1573,6 +1603,9 @@ export default async function team(input: { client: Client; worktree: string; di
       const text = body(out.parts)
       if (text.includes("under the guardrail profile.")) return
       if (!big(text)) return
+      const id = fingerprint(text)
+      const current = need.get(item.sessionID)
+      if (current?.done && current.fingerprint === id) return
       const headCheck = await git(input.worktree, ["rev-parse", "--verify", "HEAD"])
       if (headCheck.code !== 0) {
         out.parts.push({
@@ -1587,6 +1620,7 @@ export default async function team(input: { client: Client; worktree: string; di
       need.set(item.sessionID, {
         done: false,
         reason: clip(text, 240),
+        fingerprint: id,
         at: now(),
       })
       out.parts.push({
@@ -1629,9 +1663,11 @@ export default async function team(input: { client: Client; worktree: string; di
     ) => {
       void sweep(input.client, inputRoot)
       if (item.tool !== "team" && item.tool !== "background") return
+      const gate = need.get(item.sessionID)
       need.set(item.sessionID, {
         done: true,
         reason: item.tool,
+        fingerprint: gate?.fingerprint ?? "",
         at: now(),
       })
     },
@@ -1649,6 +1685,7 @@ export default async function team(input: { client: Client; worktree: string; di
       need.set(item.sessionID, {
         done: true,
         reason: `${item.tool}-failed`,
+        fingerprint: need.get(item.sessionID)?.fingerprint ?? "",
         at: now(),
       })
     },

--- a/packages/opencode/test/plugin/team.test.ts
+++ b/packages/opencode/test/plugin/team.test.ts
@@ -552,6 +552,110 @@ test("team fails isolated write tasks that produce no patch", async () => {
   ).rejects.toThrow("Write task completed without producing a patch")
 })
 
+test("team allows explicit no_patch write tasks for operation-only work", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      await Bun.write(path.join(dir, "README.md"), "# test\n")
+      await Bun.$`git add README.md`.cwd(dir).quiet()
+      await Bun.$`git commit -m "seed"`.cwd(dir).quiet()
+    },
+  })
+
+  const plugin = await team({
+    client: {
+      permission: {
+        async list() {
+          return { data: [] }
+        },
+      },
+      question: {
+        async list() {
+          return { data: [] }
+        },
+      },
+      session: {
+        async get() {
+          return { data: { permission: [] } }
+        },
+        async create() {
+          return {
+            data: {
+              id: "ses_child_no_patch_ok",
+            },
+          }
+        },
+        async promptAsync() {
+          return {}
+        },
+        async prompt() {
+          return {}
+        },
+        async status() {
+          return {
+            data: {
+              ses_child_no_patch_ok: {
+                type: "idle",
+              },
+            },
+          }
+        },
+        async messages() {
+          return {
+            data: [
+              {
+                info: {
+                  role: "assistant",
+                  time: { completed: Date.now() },
+                },
+                parts: [
+                  {
+                    type: "text",
+                    text: "created pull request",
+                  },
+                ],
+              },
+            ],
+          }
+        },
+        async abort() {
+          return {}
+        },
+      },
+    },
+    worktree: tmp.path,
+    directory: tmp.path,
+  })
+
+  const out = await plugin.tool.team.execute(
+    {
+      strategy: "parallel",
+      limit: 1,
+      tasks: [
+        {
+          id: "pr-only",
+          prompt: "Run gh pr create for the already committed branch, then report the PR URL.",
+          write: true,
+          no_patch: true,
+        },
+      ],
+    },
+    {
+      sessionID: "ses_parent",
+      messageID: "msg_parent",
+      agent: "implement",
+      directory: tmp.path,
+      worktree: tmp.path,
+      abort: new AbortController().signal,
+      ask: async () => {},
+      metadata() {},
+    },
+  )
+
+  expect(out).toContain("pr-only: done")
+  expect(out).toContain("no_patch=true")
+})
+
 test("team removes worktree when session create fails", async () => {
   await using tmp = await tmpdir({
     git: true,
@@ -2690,6 +2794,230 @@ test("chat.message hook also sweeps stale runs during normal lifecycle", async (
   throw new Error("chat.message sweep did not reconcile stale run")
 })
 
+test("parallel enforcement ignores operation-only commit push PR requests", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      await Bun.write(path.join(dir, "README.md"), "# test\n")
+      await Bun.$`git add README.md`.cwd(dir).quiet()
+      await Bun.$`git commit -m "seed"`.cwd(dir).quiet()
+    },
+  })
+
+  const plugin = await team({
+    client: {
+      permission: {
+        async list() {
+          return { data: [] }
+        },
+      },
+      question: {
+        async list() {
+          return { data: [] }
+        },
+      },
+      session: {
+        async get() {
+          return { data: { permission: [] } }
+        },
+        async create() {
+          return { data: { id: "unused" } }
+        },
+        async promptAsync() {
+          return {}
+        },
+        async prompt() {
+          return {}
+        },
+        async status() {
+          return { data: {} }
+        },
+        async messages() {
+          return { data: [] }
+        },
+        async abort() {
+          return {}
+        },
+      },
+    },
+    worktree: tmp.path,
+    directory: tmp.path,
+  })
+
+  const parts = [
+    {
+      type: "text",
+      text:
+        `${"Please review the completed local changes and summarize the current state. ".repeat(12)}\n` +
+        "Then commit the prepared changes, push the branch, and create the pull request with gh pr create.",
+    },
+  ]
+
+  await plugin["chat.message"]?.(
+    {
+      sessionID: "ses_operation_only",
+      agent: "implement",
+    },
+    {
+      message: {
+        id: "msg_operation_only",
+        sessionID: "ses_operation_only",
+        role: "user",
+      },
+      parts,
+    },
+  )
+
+  expect(parts.some((part) => part.text?.includes("Parallel implementation policy is active"))).toBe(false)
+  await expect(
+    plugin["tool.execute.before"]?.(
+      {
+        tool: "write",
+        sessionID: "ses_operation_only",
+      },
+      {
+        args: {
+          filePath: "completion.md",
+        },
+      },
+    ),
+  ).resolves.toBeUndefined()
+})
+
+test("parallel enforcement does not re-arm after team failure for the same user message", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      await Bun.write(path.join(dir, "README.md"), "# test\n")
+      await Bun.$`git add README.md`.cwd(dir).quiet()
+      await Bun.$`git commit -m "seed"`.cwd(dir).quiet()
+    },
+  })
+
+  const plugin = await team({
+    client: {
+      permission: {
+        async list() {
+          return { data: [] }
+        },
+      },
+      question: {
+        async list() {
+          return { data: [] }
+        },
+      },
+      session: {
+        async get() {
+          return { data: { permission: [] } }
+        },
+        async create() {
+          return { data: { id: "unused" } }
+        },
+        async promptAsync() {
+          return {}
+        },
+        async prompt() {
+          return {}
+        },
+        async status() {
+          return { data: {} }
+        },
+        async messages() {
+          return { data: [] }
+        },
+        async abort() {
+          return {}
+        },
+      },
+    },
+    worktree: tmp.path,
+    directory: tmp.path,
+  })
+
+  const text =
+    `${"Implement coordinated fixes across packages/guardrails and packages/opencode with tests. ".repeat(10)}\n` +
+    "This is a multi-file implementation and should use the team tool."
+
+  const makeParts = () => [
+    {
+      type: "text",
+      text,
+    },
+  ]
+
+  const first = makeParts()
+  await plugin["chat.message"]?.(
+    {
+      sessionID: "ses_rearm",
+      agent: "implement",
+    },
+    {
+      message: {
+        id: "msg_rearm_1",
+        sessionID: "ses_rearm",
+        role: "user",
+      },
+      parts: first,
+    },
+  )
+
+  expect(first.some((part) => part.text?.includes("Parallel implementation policy is active"))).toBe(true)
+  await expect(
+    plugin["tool.execute.before"]?.(
+      {
+        tool: "write",
+        sessionID: "ses_rearm",
+      },
+      {
+        args: {
+          filePath: "blocked.md",
+        },
+      },
+    ),
+  ).rejects.toThrow("Parallel implementation is enforced")
+
+  await plugin["tool.execute.error"]?.(
+    {
+      tool: "team",
+      sessionID: "ses_rearm",
+    },
+    {
+      error: new Error("team failed"),
+    },
+  )
+
+  const second = makeParts()
+  await plugin["chat.message"]?.(
+    {
+      sessionID: "ses_rearm",
+      agent: "implement",
+    },
+    {
+      message: {
+        id: "msg_rearm_2",
+        sessionID: "ses_rearm",
+        role: "user",
+      },
+      parts: second,
+    },
+  )
+
+  expect(second.some((part) => part.text?.includes("Parallel implementation policy is active"))).toBe(false)
+  await expect(
+    plugin["tool.execute.before"]?.(
+      {
+        tool: "write",
+        sessionID: "ses_rearm",
+      },
+      {
+        args: {
+          filePath: "allowed.md",
+        },
+      },
+    ),
+  ).resolves.toBeUndefined()
+})
+
 test("team merge excludes runtime artifacts and leaves unrelated parent edits untouched", async () => {
   await using tmp = await tmpdir({
     git: true,
@@ -2943,6 +3271,127 @@ test("team uses an existing sibling git worktree mentioned in the task prompt", 
       .quiet()
       .catch(() => undefined)
     await fs.rm(target, { recursive: true, force: true })
+  }
+})
+
+test("team rewrites invalid external worktree hints to the isolated worker worktree", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      await Bun.write(path.join(dir, "README.md"), "# test\n")
+      await Bun.$`git add README.md`.cwd(dir).quiet()
+      await Bun.$`git commit -m "seed"`.cwd(dir).quiet()
+    },
+  })
+
+  const invalid = path.join(path.dirname(tmp.path), ".worktrees", `other-${crypto.randomUUID()}`)
+  await fs.mkdir(invalid, { recursive: true })
+
+  let box = ""
+  try {
+    const plugin = await team({
+      client: {
+        permission: {
+          async list() {
+            return { data: [] }
+          },
+        },
+        question: {
+          async list() {
+            return { data: [] }
+          },
+        },
+        session: {
+          async get() {
+            return { data: { permission: [] } }
+          },
+          async create(input) {
+            box = input.query.directory
+            return {
+              data: {
+                id: "ses_invalid_worktree_hint",
+              },
+            }
+          },
+          async promptAsync(input) {
+            const text = input.body.parts[0]?.text ?? ""
+            expect(input.query.directory).toContain(path.join(".opencode", "team"))
+            expect(text).toContain(input.query.directory)
+            expect(text).not.toContain(invalid)
+            await Bun.write(path.join(input.query.directory, "worker.txt"), "worker output\n")
+            return {}
+          },
+          async prompt() {
+            return {}
+          },
+          async status() {
+            return {
+              data: {
+                ses_invalid_worktree_hint: {
+                  type: "idle",
+                },
+              },
+            }
+          },
+          async messages() {
+            return {
+              data: [
+                {
+                  info: {
+                    role: "assistant",
+                    time: {
+                      completed: Date.now(),
+                    },
+                  },
+                  parts: [
+                    {
+                      type: "text",
+                      text: "worker finished",
+                    },
+                  ],
+                },
+              ],
+            }
+          },
+          async abort() {
+            return {}
+          },
+        },
+      },
+      worktree: tmp.path,
+      directory: tmp.path,
+    })
+
+    const out = await plugin.tool.team.execute(
+      {
+        strategy: "parallel",
+        limit: 1,
+        tasks: [
+          {
+            id: "invalid-hint",
+            prompt: `You are working in a **git worktree** at:\n\`${invalid}\`\n\nModify worker.txt.`,
+            write: true,
+            worktree: true,
+          },
+        ],
+      },
+      {
+        sessionID: "ses_parent",
+        messageID: "msg_parent",
+        agent: "implement",
+        directory: tmp.path,
+        worktree: tmp.path,
+        abort: new AbortController().signal,
+        ask: async () => {},
+        metadata() {},
+      },
+    )
+
+    expect(box).toContain(path.join(".opencode", "team"))
+    expect(await Bun.file(path.join(tmp.path, "worker.txt")).text()).toBe("worker output\n")
+    expect(out).toContain("invalid-hint: done")
+  } finally {
+    await fs.rm(invalid, { recursive: true, force: true })
   }
 })
 


### PR DESCRIPTION
## Summary
- exempt commit/push/PR operation-only turns from parallel implementation enforcement
- preserve the completed team/background gate for repeated identical large messages
- allow explicit no_patch team tasks for operation-only work
- rewrite invalid external worktree hints to the isolated team worktree prompt

## Verification
- bunx prettier --write packages/guardrails/profile/plugins/team.ts packages/opencode/test/plugin/team.test.ts
- bun test test/plugin/team.test.ts
- bun run typecheck
- bun run build
- opencode --version
- ~/.local/bin/opencode --version
- opencode serve --hostname 127.0.0.1 --port 4100 + curl http://127.0.0.1:4100/
- pre-push bun turbo typecheck