### PR TITLE
Fix team worktree setup failure reporting

### DIFF
--- a/packages/guardrails/profile/plugins/team.ts
+++ b/packages/guardrails/profile/plugins/team.ts
@@ -1190,14 +1190,16 @@ export default async function team(input: { client: Client; worktree: string; di
     const runRoot = projectRoot(ctx.directory, ctx.worktree)
     const repoRoot = ctx.worktree && ctx.worktree !== "/" ? ctx.worktree : undefined
     const push = write(item.prompt, item.write)
-    const target = repoRoot && push ? await externalWorktree(repoRoot, item.prompt) : undefined
-    const useExistingWorktree = push && item.worktree && !!target
-    const useWorktree = push && item.worktree && !!repoRoot && !useExistingWorktree
+    let useWorktree = false
     let box = ctx.directory
     let kept: string[] = []
     let child = ""
 
     try {
+      const target = repoRoot && push ? await externalWorktree(repoRoot, item.prompt) : undefined
+      const useExistingWorktree = push && item.worktree && !!target
+      useWorktree = push && item.worktree && !!repoRoot && !useExistingWorktree
+
       if (useExistingWorktree && target) {
         box = target
       } else if (useWorktree && repoRoot) {
@@ -1299,6 +1301,18 @@ export default async function team(input: { client: Client; worktree: string; di
       await save(runRoot, run)
       if (err) throw new Error(err)
       return out.text
+    } catch (err) {
+      const text = err instanceof Error ? err.message : String(err)
+      const current = run.tasks.find((step) => step.id === item.id)
+      if (current && current.state !== "error") {
+        todo(run, item.id, {
+          state: "error",
+          error: text,
+          failure_stage: current.failure_stage || why(current, text),
+        })
+        await save(runRoot, run).catch(() => undefined)
+      }
+      throw err
     } finally {
       if (useWorktree && repoRoot && box !== ctx.directory) {
         await yardrm(repoRoot, box).catch(() => {})
@@ -1388,10 +1402,13 @@ export default async function team(input: { client: Client; worktree: string; di
       const active = new Map<string, Promise<void>>()
 
       const launch = (item: Step) => {
-        const task = job(req, run, item).then(() => {
-          done.add(item.id)
-          active.delete(item.id)
-        })
+        const task = job(req, run, item)
+          .then(() => {
+            done.add(item.id)
+          })
+          .finally(() => {
+            active.delete(item.id)
+          })
         active.set(item.id, task)
         return task
       }

--- a/packages/opencode/test/plugin/team.test.ts
+++ b/packages/opencode/test/plugin/team.test.ts
@@ -656,6 +656,101 @@ test("team allows explicit no_patch write tasks for operation-only work", async 
   expect(out).toContain("no_patch=true")
 })
 
+test("team reports worktree setup failures instead of dependency deadlocks", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      await Bun.write(path.join(dir, "README.md"), "# test\n")
+      await Bun.$`git add README.md`.cwd(dir).quiet()
+      await Bun.$`git commit -m "seed"`.cwd(dir).quiet()
+      await fs.mkdir(path.join(dir, ".opencode"), { recursive: true })
+      await Bun.write(path.join(dir, ".opencode", "team"), "not a directory\n")
+    },
+  })
+
+  const plugin = await team({
+    client: {
+      permission: {
+        async list() {
+          return { data: [] }
+        },
+      },
+      question: {
+        async list() {
+          return { data: [] }
+        },
+      },
+      session: {
+        async get() {
+          return { data: { permission: [] } }
+        },
+        async create() {
+          throw new Error("session create should not run")
+        },
+        async promptAsync() {
+          throw new Error("prompt should not run")
+        },
+        async prompt() {
+          return {}
+        },
+        async status() {
+          return { data: {} }
+        },
+        async messages() {
+          return { data: [] }
+        },
+        async abort() {
+          return {}
+        },
+      },
+    },
+    worktree: tmp.path,
+    directory: tmp.path,
+  })
+
+  let thrown = ""
+  try {
+    await plugin.tool.team.execute(
+      {
+        strategy: "parallel",
+        limit: 1,
+        tasks: [
+          {
+            id: "setup-fails",
+            prompt: "write a worker file",
+            write: true,
+            worktree: true,
+          },
+        ],
+      },
+      {
+        sessionID: "ses_parent",
+        messageID: "msg_parent",
+        agent: "implement",
+        directory: tmp.path,
+        worktree: tmp.path,
+        abort: new AbortController().signal,
+        ask: async () => {},
+        metadata() {},
+      },
+    )
+  } catch (error) {
+    thrown = error instanceof Error ? error.message : String(error)
+  }
+
+  expect(thrown).not.toBe("")
+  expect(thrown).not.toContain("Dependency deadlock")
+
+  const runs = await fs.readdir(path.join(tmp.path, ".opencode", "guardrails", "team-runs"))
+  const saved = JSON.parse(await Bun.file(path.join(tmp.path, ".opencode", "guardrails", "team-runs", runs[0]!)).text())
+  expect(saved.state).toBe("error")
+  expect(saved.tasks[0].state).toBe("error")
+  expect(saved.tasks[0].dir).toBe("")
+  expect(saved.tasks[0].session).toBe("")
+  expect(saved.tasks[0].failure_stage).toBe("worktree_setup")
+  expect(saved.tasks[0].error).not.toContain("Dependency deadlock")
+})
+
 test("team removes worktree when session create fails", async () => {
   await using tmp = await tmpdir({
     git: true,


### PR DESCRIPTION
## Summary
- move team worker worktree selection and setup under the job error handler
- persist actual setup errors on the task before rethrowing
- always remove tasks from the active map after worker completion or failure
- add a regression test ensuring setup failures are reported as worktree_setup instead of Dependency deadlock

## Verification
- bunx prettier --write packages/guardrails/profile/plugins/team.ts packages/opencode/test/plugin/team.test.ts
- bun test test/plugin/team.test.ts
- bun run typecheck
- bun run build
- opencode --version
- ~/.local/bin/opencode --version
- opencode serve --hostname 127.0.0.1 --port 4101 + curl http://127.0.0.1:4101/
- pre-push bun turbo typecheck