### PR TITLE
[codex] Fix team worker model routing

### DIFF
--- a/packages/guardrails/managed/opencode.json
+++ b/packages/guardrails/managed/opencode.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
+  "model": "zai-coding-plan/glm-5.1",
   "enabled_providers": [
     "zai",
     "zai-coding-plan",
@@ -37,8 +38,8 @@
     },
     "openai": {
       "whitelist": [
-        "gpt-5.4",
-        "gpt-5.4-mini",
+        "gpt-5.5",
+        "gpt-5.5-mini",
         "gpt-5.3-codex",
         "gpt-5.2",
         "gpt-5.2-codex",
@@ -66,8 +67,8 @@
         "openai/gpt-5.2",
         "openai/gpt-5.2-codex",
         "openai/gpt-5.3-codex",
-        "openai/gpt-5.4",
-        "openai/gpt-5.4-mini",
+        "openai/gpt-5.5",
+        "openai/gpt-5.5-mini",
         "qwen/qwen3-coder"
       ]
     }

--- a/packages/guardrails/profile/agents/provider-eval.md
+++ b/packages/guardrails/profile/agents/provider-eval.md
@@ -1,7 +1,7 @@
 ---
 description: Evaluate admitted OpenRouter-backed candidates without widening the default confidential-code lane.
 mode: subagent
-model: openrouter/openai/gpt-5.4-mini
+model: openrouter/openai/gpt-5.5-mini
 permission:
   "*": deny
   read: allow

--- a/packages/guardrails/profile/opencode.json
+++ b/packages/guardrails/profile/opencode.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
+  "model": "zai-coding-plan/glm-5.1",
   "instructions": ["AGENTS.md"],
   "default_agent": "implement",
   "plugin": ["./plugins/guardrail.ts", "./plugins/team.ts"],
@@ -46,8 +47,8 @@
     },
     "openai": {
       "whitelist": [
-        "gpt-5.4",
-        "gpt-5.4-mini",
+        "gpt-5.5",
+        "gpt-5.5-mini",
         "gpt-5.3-codex",
         "gpt-5.2",
         "gpt-5.2-codex",
@@ -75,8 +76,8 @@
         "openai/gpt-5.2",
         "openai/gpt-5.2-codex",
         "openai/gpt-5.3-codex",
-        "openai/gpt-5.4",
-        "openai/gpt-5.4-mini",
+        "openai/gpt-5.5",
+        "openai/gpt-5.5-mini",
         "qwen/qwen3-coder"
       ]
     }

--- a/packages/guardrails/profile/plugins/guardrail-context.ts
+++ b/packages/guardrails/profile/plugins/guardrail-context.ts
@@ -236,6 +236,7 @@ export async function createContext(input: GuardrailInput, opts?: Record<string,
   function deny(file: string, kind: "read" | "edit") {
     const item = rel(input.worktree, file)
     if (kind === "read" && has(item, sec)) return "secret material is outside the allowed read surface"
+    if (kind === "read" && /^\.opencode\/guardrails\/team-runs\/[^/]+\.json$/i.test(item)) return
     if (hidden(file)) return "guardrail runtime state is plugin-owned"
     if (kind === "edit" && has(item, cfg)) return "linter or formatter configuration is policy-protected"
   }

--- a/packages/guardrails/profile/plugins/guardrail-context.ts
+++ b/packages/guardrails/profile/plugins/guardrail-context.ts
@@ -134,7 +134,7 @@ export async function createContext(input: GuardrailInput, opts?: Record<string,
     "e2e-runner": "standard",
   }
   const tierModels: Record<string, string[]> = {
-    high: ["glm-5.1", "glm-5", "gpt-5.4", "gpt-5.3-codex", "gpt-5.2-codex"],
+    high: ["glm-5.1", "glm-5", "gpt-5.5", "gpt-5.3-codex", "gpt-5.2-codex"],
     standard: ["glm-4.7", "glm-4.6", "gpt-5.2", "gpt-5.1-codex", "gpt-5.1-codex-mini"],
     low: ["glm-4.5-flash", "glm-4.5-air", "gpt-5-mini", "gpt-5-nano"],
   }

--- a/packages/guardrails/profile/plugins/guardrail-patterns.ts
+++ b/packages/guardrails/profile/plugins/guardrail-patterns.ts
@@ -83,8 +83,8 @@ export const paid: Record<string, Set<string>> = {
     "gpt-5.2",
     "gpt-5.2-codex",
     "gpt-5.3-codex",
-    "gpt-5.4",
-    "gpt-5.4-mini",
+    "gpt-5.5",
+    "gpt-5.5-mini",
   ]),
 }
 

--- a/packages/guardrails/profile/plugins/team.ts
+++ b/packages/guardrails/profile/plugins/team.ts
@@ -36,6 +36,7 @@ type Note = {
 type Msg = {
   info: {
     role: string
+    finish?: string
     time?: {
       completed?: number
     }
@@ -239,7 +240,8 @@ function summary(parts: Note[]) {
 function pick(list: Msg[], completedOnly = false) {
   const items = [...list].reverse().filter((item) => item.info.role === "assistant")
   if (!items.length) return
-  return items.find((item) => typeof item.info.time?.completed === "number") ?? (completedOnly ? undefined : items[0])
+  const done = items.find((item) => typeof item.info.time?.completed === "number" && item.info.finish !== "tool-calls")
+  return done ?? (completedOnly ? undefined : items[0])
 }
 
 function scrub(cmd: string) {
@@ -411,6 +413,7 @@ function workerTools(push: boolean) {
 function permit(base: Rule[]) {
   return [
     ...base,
+    { permission: "bash", pattern: "*", action: "allow" as const },
     { permission: "bash", pattern: "pwd", action: "allow" as const },
     { permission: "bash", pattern: "ls", action: "allow" as const },
     { permission: "bash", pattern: "ls *", action: "allow" as const },
@@ -422,6 +425,7 @@ function permit(base: Rule[]) {
     { permission: "bash", pattern: "tail *", action: "allow" as const },
     { permission: "bash", pattern: "git status*", action: "allow" as const },
     { permission: "bash", pattern: "git diff*", action: "allow" as const },
+    { permission: "bash", pattern: "git branch*", action: "allow" as const },
     { permission: "bash", pattern: "git log*", action: "allow" as const },
     { permission: "bash", pattern: "git rev-parse*", action: "allow" as const },
     { permission: "bash", pattern: "git ls-tree*", action: "allow" as const },
@@ -429,7 +433,10 @@ function permit(base: Rule[]) {
     { permission: "bash", pattern: "git ls-files*", action: "allow" as const },
     { permission: "bash", pattern: "git grep *", action: "allow" as const },
     { permission: "bash", pattern: "git restore *", action: "allow" as const },
+    { permission: "bash", pattern: "git worktree list*", action: "allow" as const },
+    { permission: "bash", pattern: "git checkout *", action: "allow" as const },
     { permission: "bash", pattern: "git checkout -- *", action: "allow" as const },
+    { permission: "bash", pattern: "git switch *", action: "allow" as const },
     { permission: "bash", pattern: "git rebase origin/develop", action: "allow" as const },
     { permission: "bash", pattern: "git rebase develop", action: "allow" as const },
     { permission: "bash", pattern: "git rebase origin/main", action: "allow" as const },
@@ -437,6 +444,12 @@ function permit(base: Rule[]) {
     { permission: "bash", pattern: "git rebase --continue", action: "allow" as const },
     { permission: "bash", pattern: "git rebase --skip", action: "allow" as const },
     { permission: "bash", pattern: "git cherry-pick *", action: "allow" as const },
+    { permission: "bash", pattern: "rm -rf *", action: "deny" as const },
+    { permission: "bash", pattern: "sudo *", action: "deny" as const },
+    { permission: "bash", pattern: "git reset --hard*", action: "deny" as const },
+    { permission: "bash", pattern: "git merge *", action: "deny" as const },
+    { permission: "bash", pattern: "curl * | sh*", action: "deny" as const },
+    { permission: "bash", pattern: "curl * | bash*", action: "deny" as const },
     { permission: "bash", pattern: "opencode *", action: "deny" as const },
     { permission: "bash", pattern: "claude *", action: "deny" as const },
     { permission: "bash", pattern: "codex *", action: "deny" as const },
@@ -514,6 +527,7 @@ function worktreeHint(text: string) {
     /(?:git\s+)?worktree[\s\S]{0,120}?(?:at|path|directory|dir|:|：)[\s\S]{0,40}?`([^`\n]+)`/i,
     /(?:ワークツリー|作業ツリー)[\s\S]{0,120}?`([^`\n]+)`/i,
     /`(\/[^`\n]*\/\.worktrees\/[^`\n]+)`/i,
+    /`(\/[^`\n]*\/\.opencode\/worktrees\/[^`\n]+)`/i,
   ]
   for (const rule of direct) {
     const match = text.match(rule)
@@ -1246,6 +1260,7 @@ export default async function team(input: { client: Client; worktree: string; di
       const target = repoRoot && push ? await externalWorktree(repoRoot, item.prompt) : undefined
       const useExistingWorktree = push && item.worktree && !!target
       useWorktree = push && item.worktree && !!repoRoot && !useExistingWorktree
+      const mergeWorktree = push && item.worktree && !!repoRoot
 
       if (useExistingWorktree && target) {
         box = target
@@ -1253,7 +1268,7 @@ export default async function team(input: { client: Client; worktree: string; di
         box = await yardadd(repoRoot, `${run.id}-${item.id}`)
         kept = await carry(repoRoot, ctx.directory, box)
       }
-      const prompt = direct(useWorktree && repoRoot ? rebaseForWorktree(item.prompt, repoRoot, box) : item.prompt, push)
+      const prompt = direct(mergeWorktree && repoRoot ? rebaseForWorktree(item.prompt, repoRoot, box) : item.prompt, push)
 
       if (process.env.DEBUG_TEAM) console.log("job.start", run.id, item.id)
       todo(run, item.id, {
@@ -1315,7 +1330,7 @@ export default async function team(input: { client: Client; worktree: string; di
       let err = out.error
       // [Phase6] Classify failure stage for abort reason tracking
       let failure_stage: Step["failure_stage"] = undefined
-      if (!err && useWorktree && repoRoot && box !== ctx.directory) {
+      if (!err && mergeWorktree && repoRoot && box !== ctx.directory) {
         const merged = await merge(repoRoot, box, run.id, item.id, kept)
         patchfile = merged.patch
         if (!merged.merged) {
@@ -1331,7 +1346,7 @@ export default async function team(input: { client: Client; worktree: string; di
       todo(run, item.id, {
         state: err ? "error" : "done",
         patch: patchfile,
-        no_patch: !err && item.write && useWorktree && patchfile === "",
+        no_patch: !err && item.write && mergeWorktree && patchfile === "",
         output: out.text,
         error: err,
         failure_stage: err ? failure_stage : undefined,

--- a/packages/guardrails/profile/plugins/team.ts
+++ b/packages/guardrails/profile/plugins/team.ts
@@ -12,6 +12,7 @@ const need = new Map<string, Need>()
 const live = new Map<string, Run>()
 const seen = new WeakMap<object, Seen>()
 const sweeping = new Map<string, Promise<void>>()
+const models = new Map<string, Lane>()
 
 type Need = {
   done: boolean
@@ -55,6 +56,12 @@ type Rule = {
   permission: string
   pattern: string
   action: "allow" | "deny" | "ask"
+}
+
+type Lane = {
+  provider: string
+  model: string
+  variant: string
 }
 
 type Client = {
@@ -152,7 +159,15 @@ type Step = {
   no_patch: boolean
   allow_no_patch: boolean
   updated_at?: string
-  failure_stage?: "worktree_setup" | "session_create" | "execution" | "merge_back" | "aborted" | "timeout" | "blocked"
+  failure_stage?:
+    | "worktree_setup"
+    | "session_create"
+    | "llm_unavailable"
+    | "execution"
+    | "merge_back"
+    | "aborted"
+    | "timeout"
+    | "blocked"
 }
 
 type Run = {
@@ -428,25 +443,30 @@ function permit(base: Rule[]) {
   ]
 }
 
-function lane(item: Pick<Step, "id" | "description" | "agent" | "prompt" | "depends">) {
-  const text = [item.id, item.description, item.agent, item.prompt, ...item.depends].join("\n")
-  const large =
-    big(text) ||
-    item.depends.length > 1 ||
-    /(leader|integrat|review|coord|arch|design|migration|cross|wide|large|broad|major|critical|fan-?in|全体|統合|横断|設計|移行|大規模)/i.test(
-      text,
-    )
-  if (large) {
-    return {
-      provider: "openai",
-      model: "gpt-5.4",
-      variant: "high",
-    }
-  }
+function recordModel(
+  sessionID: string,
+  model?: { providerID?: unknown; modelID?: unknown; id?: unknown },
+  variant?: unknown,
+) {
+  const provider = typeof model?.providerID === "string" ? model.providerID : ""
+  const id = typeof model?.modelID === "string" ? model.modelID : typeof model?.id === "string" ? model.id : ""
+  if (!sessionID || !provider || !id) return
+  models.set(sessionID, {
+    provider,
+    model: id,
+    variant: typeof variant === "string" ? variant : "",
+  })
+}
+
+function currentLane(sessionID: string) {
+  return models.get(sessionID) ?? { provider: "zai-coding-plan", model: "glm-5.1", variant: "" }
+}
+
+function lane(_item: Pick<Step, "id" | "description" | "agent" | "prompt" | "depends">, current: Lane) {
   return {
-    provider: "zai-coding-plan",
-    model: "glm-5.1",
-    variant: "",
+    provider: current.provider,
+    model: current.model,
+    variant: current.variant,
   }
 }
 
@@ -945,13 +965,17 @@ async function snap(client: Client, id: string, dir: string, completedOnly = fal
 }
 
 function stage(err: string): Step["failure_stage"] {
-  return /blocked on (permission|question)/i.test(err)
-    ? "blocked"
-    : /abort/i.test(err)
-      ? "aborted"
-      : /timeout/i.test(err)
-        ? "timeout"
-        : "execution"
+  return /(model not found|api key|apikey|auth|unauthorized|forbidden|provider|llm|language model|no such model|invalid model|quota|rate limit)/i.test(
+    err,
+  )
+    ? "llm_unavailable"
+    : /blocked on (permission|question)/i.test(err)
+      ? "blocked"
+      : /abort/i.test(err)
+        ? "aborted"
+        : /timeout/i.test(err)
+          ? "timeout"
+          : "execution"
 }
 
 function why(item: Step | undefined, err: string): Step["failure_stage"] {
@@ -1383,13 +1407,16 @@ export default async function team(input: { client: Client; worktree: string; di
         created_at: now(),
         updated_at: now(),
         tasks: args.tasks.map((item) => {
-          const pick = lane({
-            id: item.id,
-            description: item.description || item.id,
-            prompt: item.prompt,
-            depends: item.depends ?? [],
-            agent: item.agent || "",
-          })
+          const pick = lane(
+            {
+              id: item.id,
+              description: item.description || item.id,
+              prompt: item.prompt,
+              depends: item.depends ?? [],
+              agent: item.agent || "",
+            },
+            currentLane(ctx.sessionID),
+          )
           return {
             id: item.id,
             description: item.description || item.id,
@@ -1507,13 +1534,6 @@ export default async function team(input: { client: Client; worktree: string; di
         agent: args.agent || "",
         write: write(args.prompt, args.write),
         worktree: canIsolate && args.worktree !== false,
-        ...lane({
-          id: slug(args.description || args.agent || "worker") || "worker",
-          description: args.description || "background worker",
-          prompt: args.prompt,
-          depends: [],
-          agent: args.agent || "",
-        }),
         state: "pending",
         dir: "",
         session: "",
@@ -1522,6 +1542,16 @@ export default async function team(input: { client: Client; worktree: string; di
         allow_no_patch: operationOnly(args.prompt),
         output: "",
         error: "",
+        ...lane(
+          {
+            id: slug(args.description || args.agent || "worker") || "worker",
+            description: args.description || "background worker",
+            prompt: args.prompt,
+            depends: [],
+            agent: args.agent || "",
+          },
+          currentLane(ctx.sessionID),
+        ),
       }
       const run: Run = {
         id: crypto.randomUUID(),
@@ -1620,6 +1650,11 @@ export default async function team(input: { client: Client; worktree: string; di
       item: {
         sessionID: string
         agent?: string
+        model?: {
+          providerID: string
+          modelID: string
+        }
+        variant?: string
       },
       out: {
         message: {
@@ -1631,6 +1666,7 @@ export default async function team(input: { client: Client; worktree: string; di
       },
     ) => {
       void sweep(input.client, inputRoot)
+      recordModel(item.sessionID, item.model, item.variant)
       if (out.message.role !== "user") return
       if (kids.has(item.sessionID)) return
       if (item.agent && /(review|technical-writer|doc-updater)/i.test(item.agent)) return
@@ -1664,6 +1700,13 @@ export default async function team(input: { client: Client; worktree: string; di
         type: "text",
         text: "Parallel implementation policy is active for this request. Before any edit, write, apply_patch, or mutating bash call, you MUST call the `team` tool and fan out at least one worker task. Mark tasks that should edit code with `write: true`; those tasks will be isolated in git worktrees and merged back when possible. Use `background` only for side work that should keep running after this turn.",
       })
+    },
+    "chat.params": async (item: {
+      sessionID: string
+      model: { providerID?: unknown; modelID?: unknown; id?: unknown }
+      message: { model?: { variant?: unknown } }
+    }) => {
+      recordModel(item.sessionID, item.model, item.message.model?.variant)
     },
     "tool.execute.before": async (
       item: {

--- a/packages/opencode/src/plugin/codex.ts
+++ b/packages/opencode/src/plugin/codex.ts
@@ -372,8 +372,8 @@ export async function CodexAuthPlugin(input: PluginInput): Promise<Hooks> {
           "gpt-5.2",
           "gpt-5.2-codex",
           "gpt-5.3-codex",
-          "gpt-5.4",
-          "gpt-5.4-mini",
+          "gpt-5.5",
+          "gpt-5.5-mini",
         ])
         for (const [modelId, model] of Object.entries(provider.models)) {
           if (modelId.includes("codex")) continue

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1322,8 +1322,9 @@ NOTE: At any point in time through this workflow you should feel free to ask the
           permissions.push({ permission: t, action: enabled ? "allow" : "deny", pattern: "*" })
         }
         if (permissions.length > 0) {
-          session.permission = permissions
-          yield* sessions.setPermission({ sessionID: session.id, permission: permissions })
+          const next = Permission.merge(session.permission ?? [], permissions)
+          session.permission = next
+          yield* sessions.setPermission({ sessionID: session.id, permission: next })
         }
 
         if (input.noReply === true) return message

--- a/packages/opencode/test/plugin/guardrail-access.test.ts
+++ b/packages/opencode/test/plugin/guardrail-access.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { createAccessHandlers } from "../../../../packages/guardrails/profile/plugins/guardrail-access"
 import type { GuardrailContext } from "../../../../packages/guardrails/profile/plugins/guardrail-context"
 
-function context() {
+function context(deny?: GuardrailContext["deny"]) {
   const marks: Record<string, unknown>[] = []
   const ctx: GuardrailContext = {
     input: {
@@ -49,9 +49,7 @@ function context() {
     compact() {
       return ""
     },
-    deny() {
-      return undefined
-    },
+    deny: deny ?? (() => undefined),
     baseline() {
       return undefined
     },
@@ -69,6 +67,43 @@ function context() {
 }
 
 describe("guardrail-access", () => {
+  test("allows read tool access to team run metadata json", async () => {
+    const { ctx, marks } = context((file, kind) => {
+      const rel = file.replace("/tmp/project/", "")
+      if (kind === "read" && /^\.opencode\/guardrails\/team-runs\/[^/]+\.json$/i.test(rel)) return
+      if (rel.startsWith(".opencode/guardrails/")) return "guardrail runtime state is plugin-owned"
+    })
+    const access = createAccessHandlers(ctx)
+
+    await expect(
+      access.toolBeforeAccess(
+        { tool: "read", args: { filePath: "/tmp/project/.opencode/guardrails/team-runs/run-1.json" } },
+        { args: { filePath: "/tmp/project/.opencode/guardrails/team-runs/run-1.json" } },
+      ),
+    ).resolves.toBeUndefined()
+
+    expect(marks).toHaveLength(0)
+  })
+
+  test("blocks read tool access to other guardrail runtime state", async () => {
+    const { ctx, marks } = context((file) => {
+      if (file.replace("/tmp/project/", "").startsWith(".opencode/guardrails/")) {
+        return "guardrail runtime state is plugin-owned"
+      }
+    })
+    const access = createAccessHandlers(ctx)
+
+    await expect(
+      access.toolBeforeAccess(
+        { tool: "read", args: { filePath: "/tmp/project/.opencode/guardrails/state.json" } },
+        { args: { filePath: "/tmp/project/.opencode/guardrails/state.json" } },
+      ),
+    ).rejects.toThrow("guardrail runtime state is plugin-owned")
+
+    expect(marks).toHaveLength(1)
+    expect(marks[0]?.last_reason).toBe("guardrail runtime state is plugin-owned")
+  })
+
   test("allows read-only shell access to .opencode/guardrails", async () => {
     const { ctx, marks } = context()
     const access = createAccessHandlers(ctx)

--- a/packages/opencode/test/plugin/team.test.ts
+++ b/packages/opencode/test/plugin/team.test.ts
@@ -809,7 +809,7 @@ test("team classifies model routing failures as llm_unavailable", async () => {
           }
         },
         async promptAsync() {
-          throw new Error("Model not found: openai/gpt-5.4")
+          throw new Error("Model not found: openai/gpt-5.5")
         },
         async prompt() {
           return {}
@@ -853,7 +853,7 @@ test("team classifies model routing failures as llm_unavailable", async () => {
         metadata() {},
       },
     ),
-  ).rejects.toThrow("Model not found: openai/gpt-5.4")
+  ).rejects.toThrow("Model not found: openai/gpt-5.5")
 
   const runs = await fs.readdir(path.join(tmp.path, ".opencode", "guardrails", "team-runs"))
   const saved = JSON.parse(await Bun.file(path.join(tmp.path, ".opencode", "guardrails", "team-runs", runs[0]!)).text())
@@ -2768,7 +2768,7 @@ test("team_status reconciles stale running runs from completed child messages", 
                 write: false,
                 worktree: false,
                 provider: "openai",
-                model: "gpt-5.4",
+                model: "gpt-5.5",
                 variant: "high",
                 state: "running",
                 dir,
@@ -2903,7 +2903,7 @@ test("team execute sweeps stale running runs before launching new work", async (
                 write: false,
                 worktree: false,
                 provider: "openai",
-                model: "gpt-5.4",
+                model: "gpt-5.5",
                 variant: "high",
                 state: "running",
                 dir,
@@ -3070,7 +3070,7 @@ test("team startup sweep reconciles stale runs without explicit tool use", async
                 write: false,
                 worktree: false,
                 provider: "openai",
-                model: "gpt-5.4",
+                model: "gpt-5.5",
                 variant: "high",
                 state: "running",
                 dir,
@@ -3193,7 +3193,7 @@ test("chat.message hook also sweeps stale runs during normal lifecycle", async (
                 write: false,
                 worktree: false,
                 provider: "openai",
-                model: "gpt-5.4",
+                model: "gpt-5.5",
                 variant: "high",
                 state: "running",
                 dir,

--- a/packages/opencode/test/plugin/team.test.ts
+++ b/packages/opencode/test/plugin/team.test.ts
@@ -100,6 +100,138 @@ test("team uses default limit when caller omits limit", async () => {
   expect(out).toContain("default-limit: done")
 })
 
+test("team worker model inherits the parent session model", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      await Bun.write(path.join(dir, "README.md"), "# test\n")
+      await Bun.$`git add README.md`.cwd(dir).quiet()
+      await Bun.$`git commit -m "seed"`.cwd(dir).quiet()
+    },
+  })
+
+  let model:
+    | {
+        providerID: string
+        modelID: string
+      }
+    | undefined
+
+  const plugin = await team({
+    client: {
+      permission: {
+        async list() {
+          return { data: [] }
+        },
+      },
+      question: {
+        async list() {
+          return { data: [] }
+        },
+      },
+      session: {
+        async get() {
+          return { data: { permission: [] } }
+        },
+        async create() {
+          return { data: { id: "ses_child_inherit_model" } }
+        },
+        async promptAsync(input) {
+          model = input.body.model
+          return {}
+        },
+        async prompt() {
+          return {}
+        },
+        async status() {
+          return {
+            data: {
+              ses_child_inherit_model: {
+                type: "idle",
+              },
+            },
+          }
+        },
+        async messages() {
+          return {
+            data: [
+              {
+                info: {
+                  role: "assistant",
+                  time: { completed: Date.now() },
+                },
+                parts: [
+                  {
+                    type: "text",
+                    text: "done",
+                  },
+                ],
+              },
+            ],
+          }
+        },
+        async abort() {
+          return {}
+        },
+      },
+    },
+    worktree: tmp.path,
+    directory: tmp.path,
+  })
+
+  await plugin["chat.message"]?.(
+    {
+      sessionID: "ses_parent_model",
+      agent: "implement",
+      model: {
+        providerID: "zai-coding-plan",
+        modelID: "glm-5.1",
+      },
+    },
+    {
+      message: {
+        id: "msg_parent_model",
+        sessionID: "ses_parent_model",
+        role: "user",
+      },
+      parts: [
+        {
+          type: "text",
+          text: "Inspect the repository model routing before the team worker runs.",
+        },
+      ],
+    },
+  )
+
+  const out = await plugin.tool.team.execute(
+    {
+      tasks: [
+        {
+          id: "inherit-model",
+          prompt: `${"Implement coordinated fixes across packages/guardrails with tests. ".repeat(12)}Check routing only.`,
+          write: false,
+        },
+      ],
+    } as unknown as Parameters<typeof plugin.tool.team.execute>[0],
+    {
+      sessionID: "ses_parent_model",
+      messageID: "msg_parent_model",
+      agent: "implement",
+      directory: tmp.path,
+      worktree: tmp.path,
+      abort: new AbortController().signal,
+      ask: async () => {},
+      metadata() {},
+    },
+  )
+
+  expect(out).toContain("model=zai-coding-plan/glm-5.1")
+  expect(model).toEqual({
+    providerID: "zai-coding-plan",
+    modelID: "glm-5.1",
+  })
+})
+
 test("team carries local .opencode files into worker worktrees and inherits parent permission", async () => {
   await using tmp = await tmpdir({
     git: true,
@@ -641,6 +773,91 @@ test("team fails isolated write tasks that produce no patch", async () => {
       },
     ),
   ).rejects.toThrow("Write task completed without producing a patch")
+})
+
+test("team classifies model routing failures as llm_unavailable", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      await Bun.write(path.join(dir, "README.md"), "# test\n")
+      await Bun.$`git add README.md`.cwd(dir).quiet()
+      await Bun.$`git commit -m "seed"`.cwd(dir).quiet()
+    },
+  })
+
+  const plugin = await team({
+    client: {
+      permission: {
+        async list() {
+          return { data: [] }
+        },
+      },
+      question: {
+        async list() {
+          return { data: [] }
+        },
+      },
+      session: {
+        async get() {
+          return { data: { permission: [] } }
+        },
+        async create() {
+          return {
+            data: {
+              id: "ses_child_model_missing",
+            },
+          }
+        },
+        async promptAsync() {
+          throw new Error("Model not found: openai/gpt-5.4")
+        },
+        async prompt() {
+          return {}
+        },
+        async status() {
+          return { data: {} }
+        },
+        async messages() {
+          return { data: [] }
+        },
+        async abort() {
+          return {}
+        },
+      },
+    },
+    worktree: tmp.path,
+    directory: tmp.path,
+  })
+
+  await expect(
+    plugin.tool.team.execute(
+      {
+        strategy: "parallel",
+        limit: 1,
+        tasks: [
+          {
+            id: "model-missing",
+            prompt: "write a note file",
+            write: true,
+          },
+        ],
+      },
+      {
+        sessionID: "ses_parent",
+        messageID: "msg_parent",
+        agent: "implement",
+        directory: tmp.path,
+        worktree: tmp.path,
+        abort: new AbortController().signal,
+        ask: async () => {},
+        metadata() {},
+      },
+    ),
+  ).rejects.toThrow("Model not found: openai/gpt-5.4")
+
+  const runs = await fs.readdir(path.join(tmp.path, ".opencode", "guardrails", "team-runs"))
+  const saved = JSON.parse(await Bun.file(path.join(tmp.path, ".opencode", "guardrails", "team-runs", runs[0]!)).text())
+  expect(saved.tasks[0].failure_stage).toBe("llm_unavailable")
 })
 
 test("team allows explicit no_patch write tasks for operation-only work", async () => {

--- a/packages/opencode/test/plugin/team.test.ts
+++ b/packages/opencode/test/plugin/team.test.ts
@@ -2,6 +2,7 @@ import { afterEach, expect, test } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
 import team from "../../../../packages/guardrails/profile/plugins/team"
+import { evaluate } from "../../src/permission/evaluate"
 import { Instance } from "../../src/project/instance"
 import { tmpdir } from "../fixture/fixture"
 
@@ -319,7 +320,7 @@ alwaysApply: true
         permission?: {
           permission: string
           pattern: string
-          action: string
+          action: "allow" | "ask" | "deny"
         }[]
       }
     | undefined
@@ -436,9 +437,15 @@ alwaysApply: true
   expect(body?.permission?.slice(0, perm.length)).toEqual(perm)
   expect(body?.permission).toContainEqual({ permission: "bash", pattern: "rg *", action: "allow" })
   expect(body?.permission).toContainEqual({ permission: "bash", pattern: "git ls-tree*", action: "allow" })
+  expect(body?.permission).toContainEqual({ permission: "bash", pattern: "git worktree list*", action: "allow" })
+  expect(body?.permission).toContainEqual({ permission: "bash", pattern: "git checkout *", action: "allow" })
   expect(body?.permission).toContainEqual({ permission: "bash", pattern: "git rebase origin/develop", action: "allow" })
   expect(body?.permission).toContainEqual({ permission: "bash", pattern: "git checkout -- *", action: "allow" })
   expect(body?.permission).toContainEqual({ permission: "bash", pattern: "git cherry-pick *", action: "allow" })
+  expect(evaluate("bash", "git worktree list", body?.permission ?? []).action).toBe("allow")
+  expect(evaluate("bash", "git checkout feat/alpha-quality-gates", body?.permission ?? []).action).toBe("allow")
+  expect(evaluate("bash", "opencode run /init", body?.permission ?? []).action).toBe("deny")
+  expect(evaluate("bash", "rm -rf .opencode", body?.permission ?? []).action).toBe("deny")
   expect(body?.permission).toContainEqual({ permission: "bash", pattern: "opencode *", action: "deny" })
   expect(box).toContain(path.join(".opencode", "team"))
 })
@@ -2638,6 +2645,134 @@ test("team treats completed assistant messages as completion even when status st
   expect(out).toContain("output=finished from completed message")
 })
 
+test("team waits past completed tool-call assistant messages", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      await Bun.write(path.join(dir, "README.md"), "# test\n")
+      await Bun.$`git add README.md`.cwd(dir).quiet()
+      await Bun.$`git commit -m "seed"`.cwd(dir).quiet()
+    },
+  })
+
+  let messages = 0
+  const plugin = await team({
+    client: {
+      permission: {
+        async list() {
+          return { data: [] }
+        },
+      },
+      question: {
+        async list() {
+          return { data: [] }
+        },
+      },
+      session: {
+        async get() {
+          return { data: { permission: [] } }
+        },
+        async create() {
+          return {
+            data: {
+              id: "ses_child_tool_calls_then_done",
+            },
+          }
+        },
+        async promptAsync() {
+          return {}
+        },
+        async prompt() {
+          return {}
+        },
+        async status() {
+          return {
+            data: {
+              ses_child_tool_calls_then_done: {
+                type: "busy",
+              },
+            },
+          }
+        },
+        async messages() {
+          messages += 1
+          return {
+            data: [
+              messages < 2
+                ? {
+                    info: {
+                      role: "assistant",
+                      finish: "tool-calls",
+                      time: {
+                        completed: Date.now(),
+                      },
+                    },
+                    parts: [
+                      {
+                        type: "tool",
+                        state: {
+                          status: "completed",
+                          output: "git worktree list output",
+                        },
+                      },
+                    ],
+                  }
+                : {
+                    info: {
+                      role: "assistant",
+                      time: {
+                        completed: Date.now(),
+                      },
+                    },
+                    parts: [
+                      {
+                        type: "text",
+                        text: "finished after tool call",
+                      },
+                    ],
+                  },
+            ],
+          }
+        },
+        async abort() {
+          return {}
+        },
+      },
+    },
+    worktree: tmp.path,
+    directory: tmp.path,
+  })
+
+  const out = await plugin.tool.team.execute(
+    {
+      strategy: "parallel",
+      limit: 1,
+      tasks: [
+        {
+          id: "verify",
+          prompt: "check repo facts",
+          write: false,
+          worktree: false,
+        },
+      ],
+    },
+    {
+      sessionID: "ses_parent",
+      messageID: "msg_parent",
+      agent: "implement",
+      directory: tmp.path,
+      worktree: tmp.path,
+      abort: new AbortController().signal,
+      ask: async () => {},
+      metadata() {},
+    },
+  )
+
+  expect(messages).toBeGreaterThanOrEqual(2)
+  expect(out).toContain("- verify: done")
+  expect(out).toContain("output=finished after tool call")
+})
+
 test("team retries event subscriptions before consuming session.idle", async () => {
   await using tmp = await tmpdir({
     git: true,
@@ -3786,6 +3921,123 @@ test("team uses an existing sibling git worktree mentioned in the task prompt", 
       .quiet()
       .catch(() => undefined)
     await fs.rm(target, { recursive: true, force: true })
+  }
+})
+
+test("team merges changes from an existing .opencode worktree mentioned in the task prompt", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      await Bun.write(path.join(dir, "README.md"), "# test\n")
+      await Bun.$`git add README.md`.cwd(dir).quiet()
+      await Bun.$`git commit -m "seed"`.cwd(dir).quiet()
+    },
+  })
+
+  const target = path.join(path.dirname(tmp.path), ".opencode", "worktrees", `team-shared-${crypto.randomUUID()}`)
+  await fs.mkdir(path.dirname(target), { recursive: true })
+  await Bun.$`git worktree add --detach ${target} HEAD`.cwd(tmp.path).quiet()
+
+  let box = ""
+  try {
+    const plugin = await team({
+      client: {
+        permission: {
+          async list() {
+            return { data: [] }
+          },
+        },
+        question: {
+          async list() {
+            return { data: [] }
+          },
+        },
+        session: {
+          async get() {
+            return { data: { permission: [] } }
+          },
+          async create() {
+            return {
+              data: {
+                id: "ses_existing_opencode_worktree",
+              },
+            }
+          },
+          async promptAsync(input) {
+            box = input.query.directory
+            expect(box).toBe(target)
+            await Bun.write(path.join(target, "shared-worker.txt"), "shared worker output\n")
+          },
+          async prompt() {
+            return {}
+          },
+          async status() {
+            return {
+              data: {
+                ses_existing_opencode_worktree: {
+                  type: "idle",
+                },
+              },
+            }
+          },
+          async messages() {
+            return {
+              data: [
+                {
+                  info: {
+                    role: "assistant",
+                    time: { completed: Date.now() },
+                  },
+                  parts: [
+                    {
+                      type: "text",
+                      text: "done",
+                    },
+                  ],
+                },
+              ],
+            }
+          },
+          async abort() {
+            return {}
+          },
+        },
+      },
+      worktree: tmp.path,
+      directory: tmp.path,
+    })
+
+    const out = await plugin.tool.team.execute(
+      {
+        strategy: "parallel",
+        limit: 1,
+        tasks: [
+          {
+            id: "shared-worktree",
+            prompt: `You are working in a **git worktree** at:\n\`${target}\`\n\nModify shared-worker.txt.`,
+            write: true,
+            worktree: true,
+          },
+        ],
+      },
+      {
+        sessionID: "ses_parent",
+        messageID: "msg_parent",
+        agent: "implement",
+        directory: tmp.path,
+        worktree: tmp.path,
+        abort: new AbortController().signal,
+        ask: async () => {},
+        metadata() {},
+      },
+    )
+
+    expect(out).toContain("shared-worktree: done")
+    expect(out).toContain("patch=")
+    expect(await Bun.file(path.join(tmp.path, "shared-worker.txt")).text()).toBe("shared worker output\n")
+  } finally {
+    await Bun.$`git worktree remove --force ${target}`.cwd(tmp.path).quiet().catch(() => {})
+    await fs.rm(path.dirname(target), { recursive: true, force: true }).catch(() => {})
   }
 })
 

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -369,6 +369,36 @@ it.live("loop calls LLM and returns assistant message", () =>
   ),
 )
 
+it.live("prompt tools merge with existing session permissions", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({
+        title: "Pinned",
+        permission: [{ permission: "bash", pattern: "*", action: "allow" }],
+      })
+
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        noReply: true,
+        tools: {
+          task: false,
+          team: false,
+        },
+        parts: [{ type: "text", text: "hello" }],
+      })
+
+      const updated = yield* sessions.get(chat.id)
+      expect(Permission.evaluate("bash", "git worktree list", updated.permission ?? []).action).toBe("allow")
+      expect(Permission.evaluate("task", "build", updated.permission ?? []).action).toBe("deny")
+      expect(Permission.evaluate("team", "*", updated.permission ?? []).action).toBe("deny")
+    }),
+    { git: true, config: providerCfg },
+  ),
+)
+
 it.live("static loop returns assistant text through local provider", () =>
   provideTmpdirServer(
     Effect.fnUntraced(function* ({ llm }) {


### PR DESCRIPTION
## Summary

- Remove hardcoded OpenAI routing from guardrail team workers and inherit the parent session model captured from chat hooks.
- Preserve child session permissions when `prompt_async` also supplies tool enable/deny flags, so team/background worker bash grants are not overwritten.
- Relax non-interactive team/background worker bash permissions for delegated tasks while retaining explicit denies for destructive recursion and dangerous shell patterns.
- Wait past intermediate `finish: "tool-calls"` assistant messages before collecting worker output or merging patches.
- Merge changes back from isolated and existing `.opencode/worktrees/*` worktrees.
- Classify model/auth/provider failures as `llm_unavailable` instead of generic execution failures.
- Allow read-only `Read` access to `.opencode/guardrails/team-runs/*.json` while keeping other guardrail runtime state protected.
- Set the guardrail profile/managed default model to `zai-coding-plan/glm-5.1`.
- Replace guardrail long/high-tier GPT-5.4 references with GPT-5.5, including OpenAI/OpenRouter whitelists and Codex OAuth admission.

## Local Config Applied

Updated the local machine config at `~/.config/opencode/opencode.jsonc`:

- `model`: `zai-coding-plan/glm-5.1`
- `small_model`: `openai/gpt-5.5-mini`
- OpenRouter whitelist entries: `openai/gpt-5.5`, `openai/gpt-5.5-mini`

Built and deployed the local CLI cache:

- `opencode --version` -> `0.0.0-codex-fix-team-provider-routing-202604250747`

## Validation

- `bun test test/session/prompt.test.ts test/plugin/team.test.ts test/plugin/guardrail-access.test.ts` from `packages/opencode` -> 86 pass
- `bun typecheck` from `packages/opencode` -> pass
- pre-push `bun turbo typecheck` -> pass
- `bun run build` from `packages/opencode` -> pass; local binary smoke passed during build
- Local CLI smoke without `--dangerously-skip-permissions`:
  - started as `build · glm-5.1`
  - ran a real `write: true`, `worktree: true` team worker
  - worker executed `git worktree list`
  - worker executed `git checkout feat/alpha-quality-gates`
  - worker wrote `bash-smoke.txt`
  - run metadata: `state: "done"`, `provider: "zai-coding-plan"`, `model: "glm-5.1"`, `patch` populated

Temporary smoke repositories were removed after validation.
