### PR TITLE
[codex] Fix external review guardrail detection

### DIFF
--- a/packages/guardrails/profile/plugins/guardrail-review.ts
+++ b/packages/guardrails/profile/plugins/guardrail-review.ts
@@ -181,6 +181,43 @@ export function createReviewPipeline(ctx: GuardrailContext) {
     await ctx.seen("codex_review.completed", { critical: findings.critical, high: findings.high })
   }
 
+  async function handleExternalReviewDetection(
+    item: { tool: string; args?: Record<string, unknown> },
+    out: { output: string; metadata?: Record<string, unknown> },
+  ) {
+    if (item.tool !== "bash") return
+    const cmd = str(item.args?.command)
+    const isOpenCodeReview = /\bopencode\s+run\b[\s\S]*\b(\/review|review|code-review|code-reviewer)\b/i.test(cmd)
+    const isClaudeReviewer = /\bclaude\b[\s\S]*(--agent(?:=|\s+)code-reviewer|--agent(?:=|\s+)review)\b/i.test(cmd)
+    if (!isOpenCodeReview && !isClaudeReviewer) return
+    if (typeof out.metadata?.exitCode === "number" && out.metadata.exitCode !== 0) {
+      await ctx.seen("external_review.failed", { command: cmd, exit_code: out.metadata.exitCode })
+      return
+    }
+    const output = str(out.output).trim()
+    if (!output || output.length < 20 || /Tool execution aborted/i.test(output)) {
+      await ctx.seen("external_review.empty_or_aborted", { command: cmd, length: output.length })
+      return
+    }
+    const findings = parseFindings(output)
+    await ctx.mark({
+      reviewed: true,
+      review_at: new Date().toISOString(),
+      review_agent: isClaudeReviewer ? "claude:code-reviewer" : "opencode:review",
+      review_glm_state: "done",
+      review_glm_at: new Date().toISOString(),
+      edits_since_review: 0,
+      review_critical_count: findings.critical,
+      review_high_count: findings.high,
+    })
+    await syncReviewState()
+    await ctx.seen("external_review.completed", {
+      agent: isClaudeReviewer ? "claude:code-reviewer" : "opencode:review",
+      critical: findings.critical,
+      high: findings.high,
+    })
+  }
+
   return {
     autoReview,
     checklist,
@@ -189,6 +226,6 @@ export function createReviewPipeline(ctx: GuardrailContext) {
     syncReviewState,
     handleAutoReviewTrigger,
     handleCodexDetection,
+    handleExternalReviewDetection,
   }
 }
-

--- a/packages/guardrails/profile/plugins/guardrail.ts
+++ b/packages/guardrails/profile/plugins/guardrail.ts
@@ -335,6 +335,7 @@ export default async function guardrail(
       }
 
       await review.handleCodexDetection(item, out)
+      await review.handleExternalReviewDetection(item, out)
       await gitHandlers.bashAfterGit(item, out, data)
 
       if (item.tool === "bash") {

--- a/packages/opencode/test/plugin/guardrail-review.test.ts
+++ b/packages/opencode/test/plugin/guardrail-review.test.ts
@@ -1,0 +1,127 @@
+import { expect, test } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { createReviewPipeline } from "../../../../packages/guardrails/profile/plugins/guardrail-review"
+import type { GuardrailContext } from "../../../../packages/guardrails/profile/plugins/guardrail-context"
+import { tmpdir } from "../fixture/fixture"
+
+async function context(state: string) {
+  const events: Record<string, unknown>[] = []
+  const ctx: GuardrailContext = {
+    input: {
+      client: {} as GuardrailContext["input"]["client"],
+      directory: path.dirname(path.dirname(state)),
+      worktree: path.dirname(path.dirname(state)),
+    },
+    mode: "enforced",
+    root: path.dirname(state),
+    log: path.join(path.dirname(state), "events.jsonl"),
+    state,
+    allow: {},
+    hasCodexMcp: true,
+    maxParallelTasks: 5,
+    maxSessionCost: 10,
+    agentModelTier: {},
+    tierModels: {},
+    domainDirs: {},
+    async mark(data) {
+      await Bun.write(state, JSON.stringify({ ...await Bun.file(state).json().catch(() => ({})), ...data }, null, 2))
+    },
+    async seen(type, data) {
+      events.push({ type, ...data })
+    },
+    note() {
+      return { sessionID: undefined, permission: undefined, patterns: undefined }
+    },
+    hidden() {
+      return false
+    },
+    code() {
+      return false
+    },
+    fact() {
+      return false
+    },
+    stale() {
+      return false
+    },
+    factLine() {
+      return ""
+    },
+    reviewLine() {
+      return ""
+    },
+    compact() {
+      return ""
+    },
+    deny() {
+      return undefined
+    },
+    baseline() {
+      return undefined
+    },
+    async version() {
+      return undefined
+    },
+    async budget() {
+      return 0
+    },
+    gate() {
+      return undefined
+    },
+  }
+  return { ctx, events }
+}
+
+test("external opencode review marks GLM review done", async () => {
+  await using tmp = await tmpdir()
+  const state = path.join(tmp.path, ".opencode", "guardrails", "state.json")
+  await fs.mkdir(path.dirname(state), { recursive: true })
+  await Bun.write(state, JSON.stringify({ review_codex_state: "done" }))
+  const { ctx, events } = await context(state)
+
+  await createReviewPipeline(ctx).handleExternalReviewDetection(
+    { tool: "bash", args: { command: "opencode run /review" } },
+    { output: "Review completed. No critical or high issues found.", metadata: { exitCode: 0 } },
+  )
+
+  const data = await Bun.file(state).json()
+  expect(data.review_glm_state).toBe("done")
+  expect(data.review_state).toBe("done")
+  expect(data.review_agent).toBe("opencode:review")
+  expect(events.some((item) => item.type === "external_review.completed")).toBe(true)
+})
+
+test("external claude code-reviewer marks GLM review done", async () => {
+  await using tmp = await tmpdir()
+  const state = path.join(tmp.path, ".opencode", "guardrails", "state.json")
+  await fs.mkdir(path.dirname(state), { recursive: true })
+  await Bun.write(state, JSON.stringify({ review_codex_state: "done" }))
+  const { ctx } = await context(state)
+
+  await createReviewPipeline(ctx).handleExternalReviewDetection(
+    { tool: "bash", args: { command: "claude --agent code-reviewer review this PR" } },
+    { output: "Approve. No CRITICAL or HIGH findings were identified.", metadata: { exitCode: 0 } },
+  )
+
+  const data = await Bun.file(state).json()
+  expect(data.review_glm_state).toBe("done")
+  expect(data.review_agent).toBe("claude:code-reviewer")
+})
+
+test("external review abort output does not mark review done", async () => {
+  await using tmp = await tmpdir()
+  const state = path.join(tmp.path, ".opencode", "guardrails", "state.json")
+  await fs.mkdir(path.dirname(state), { recursive: true })
+  await Bun.write(state, JSON.stringify({ review_codex_state: "done" }))
+  const { ctx, events } = await context(state)
+
+  await createReviewPipeline(ctx).handleExternalReviewDetection(
+    { tool: "bash", args: { command: "opencode run /review" } },
+    { output: "Tool execution aborted", metadata: { exitCode: 0 } },
+  )
+
+  const data = await Bun.file(state).json()
+  expect(data.review_glm_state).toBeUndefined()
+  expect(events.some((item) => item.type === "external_review.empty_or_aborted")).toBe(true)
+})


### PR DESCRIPTION
## Summary
- recognize successful external review commands as completing the GLM/code-reviewer merge gate
- support opencode run review and claude --agent code-reviewer review paths
- avoid marking aborted, empty, or non-zero review commands as complete
- add regression tests for opencode review, claude code-reviewer, and aborted output

## Root Cause
The guardrail only marked review_glm_state=done after successful Task tool review executions. In local workflows where Task/team review routes abort or the code-reviewer subagent is unavailable, successful review via opencode run or claude --agent code-reviewer did not update guardrail state, leaving gh pr merge blocked on pending GLM code-reviewer.

## Validation
- bun test test/plugin/guardrail-review.test.ts test/plugin/guardrail-access.test.ts (from packages/opencode)
- bun typecheck (from packages/opencode)
- git diff --check
- opencode --version
- node packages/guardrails/bin/opencode-guardrails --version
- push hook: bun turbo typecheck