### PR TITLE
[codex] Mask secrets in guardrail bash output

### DIFF
--- a/packages/guardrails/profile/plugins/guardrail-context.ts
+++ b/packages/guardrails/profile/plugins/guardrail-context.ts
@@ -313,7 +313,7 @@ export async function createContext(input: GuardrailInput, opts?: Record<string,
     log,
     state,
     allow,
-    hasCodexMcp: false,
+    hasCodexMcp: false as boolean,
     maxParallelTasks,
     maxSessionCost,
     agentModelTier,
@@ -336,4 +336,3 @@ export async function createContext(input: GuardrailInput, opts?: Record<string,
     gate,
   } satisfies GuardrailContext
 }
-

--- a/packages/guardrails/profile/plugins/guardrail.ts
+++ b/packages/guardrails/profile/plugins/guardrail.ts
@@ -336,6 +336,36 @@ export default async function guardrail(
 
       await review.handleCodexDetection(item, out)
       await review.handleExternalReviewDetection(item, out)
+
+      if (item.tool === "bash") {
+        const secretPatterns: [RegExp, string][] = [
+          [/AIzaSy[A-Za-z0-9_-]{33}/g, "google-api-key"],
+          [/AKIA[A-Z0-9]{16}/g, "aws-access-key"],
+          [/sk-[a-zA-Z0-9]{20,}/g, "openai-key"],
+          [/ghp_[a-zA-Z0-9]{36}/g, "github-token"],
+          [/gho_[a-zA-Z0-9]{36}/g, "github-oauth"],
+          [/ghs_[a-zA-Z0-9]{36}/g, "github-app"],
+          [/glpat-[a-zA-Z0-9-]{20,}/g, "gitlab-token"],
+          [/xox[bprs]-[a-zA-Z0-9-]+/g, "slack-token"],
+          [/npm_[a-zA-Z0-9]{36}/g, "npm-token"],
+          [/-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----/g, "private-key"],
+          [/\b[A-Z_]*(?:KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL|PRIVATE)[A-Z_]*\s*=\s*["']?[A-Za-z0-9_\-+/=]{10,}["']?/gi, "env-secret"],
+        ]
+        let output = str(out.output)
+        let maskedCount = 0
+        for (const [pattern, label] of secretPatterns) {
+          const matches = output.match(pattern)
+          if (matches && matches.length > 0) {
+            output = output.replace(pattern, `[REDACTED:${label}]`)
+            maskedCount += matches.length
+          }
+        }
+        if (maskedCount > 0) {
+          out.output = output
+          await ctx.seen("secret_masked", { count: maskedCount })
+        }
+      }
+
       await gitHandlers.bashAfterGit(item, out, data)
 
       if (item.tool === "bash") {

--- a/packages/opencode/test/plugin/guardrail-secret-mask.test.ts
+++ b/packages/opencode/test/plugin/guardrail-secret-mask.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "bun:test"
+import guardrail from "../../../../packages/guardrails/profile/plugins/guardrail"
+import { tmpdir } from "../fixture/fixture"
+
+test("guardrail masks secrets from bash output", async () => {
+  await using tmp = await tmpdir()
+  const plugin = await guardrail(
+    {
+      client: {
+        session: {
+          async create() {
+            return { data: { id: "unused" } }
+          },
+          async promptAsync() {
+            return {}
+          },
+          async prompt() {
+            return {}
+          },
+          async status() {
+            return { data: {} }
+          },
+          async messages() {
+            return { data: [] }
+          },
+          async abort() {
+            return {}
+          },
+        },
+      },
+      directory: tmp.path,
+      worktree: tmp.path,
+    },
+    {},
+  )
+
+  const out = {
+    title: "bash",
+    output: [
+      "AWS_ACCESS_KEY_ID=AKIA1234567890ABCDEF",
+      "OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyz",
+      "safe output",
+    ].join("\n"),
+    metadata: { exitCode: 0 },
+  }
+
+  await plugin["tool.execute.after"](
+    { tool: "bash", args: { command: "echo secrets" } },
+    out,
+  )
+
+  expect(out.output).toContain("[REDACTED:aws-access-key]")
+  expect(out.output).toContain("[REDACTED:openai-key]")
+  expect(out.output).toContain("safe output")
+  expect(out.output).not.toContain("AKIA1234567890ABCDEF")
+  expect(out.output).not.toContain("sk-abcdefghijklmnopqrstuvwxyz")
+  expect(await Bun.file(`${tmp.path}/.opencode/guardrails/events.jsonl`).text()).toContain("secret_masked")
+})


### PR DESCRIPTION
## Summary
- mask common secret formats from guardrail-managed bash output before later hooks process it
- record a secret_masked event when redaction happens
- add a direct hook regression test for AWS/OpenAI-style output redaction
- widen hasCodexMcp inference so the mutable guardrail context typechecks cleanly

## Validation
- bun test test/plugin/guardrail-secret-mask.test.ts test/plugin/guardrail-review.test.ts test/plugin/guardrail-access.test.ts (from packages/opencode)
- bun typecheck (from packages/opencode)
- git diff --check
- opencode --version
- node packages/guardrails/bin/opencode-guardrails --version
- local symlink check for ~/.config/opencode/plugins/guardrail.ts
- push hook: bun turbo typecheck