### PR TITLE
[codex] Expose Gemini 3.5 Flash in OpenRouter config

### DIFF
--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -53,7 +53,39 @@
         "x-ai/grok-4.20-multi-agent",
         "x-ai/grok-4.3"
       ],
-      "models": {}
+      "models": {
+        "google/gemini-3.5-flash": {
+          "name": "Gemini 3.5 Flash",
+          "family": "gemini-flash",
+          "release_date": "2026-05-19",
+          "attachment": true,
+          "reasoning": true,
+          "temperature": true,
+          "tool_call": true,
+          "cost": {
+            "input": 1.5,
+            "output": 9,
+            "cache_read": 0.15,
+            "cache_write": 0.08333333333333333
+          },
+          "limit": {
+            "context": 1048576,
+            "output": 65536
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        }
+      }
     }
   },
   "permission": {

--- a/packages/guardrails/managed/opencode.json
+++ b/packages/guardrails/managed/opencode.json
@@ -112,7 +112,40 @@
         "x-ai/grok-4.20",
         "x-ai/grok-4.20-multi-agent",
         "x-ai/grok-4.3"
-      ]
+      ],
+      "models": {
+        "google/gemini-3.5-flash": {
+          "name": "Gemini 3.5 Flash",
+          "family": "gemini-flash",
+          "release_date": "2026-05-19",
+          "attachment": true,
+          "reasoning": true,
+          "temperature": true,
+          "tool_call": true,
+          "cost": {
+            "input": 1.5,
+            "output": 9,
+            "cache_read": 0.15,
+            "cache_write": 0.08333333333333333
+          },
+          "limit": {
+            "context": 1048576,
+            "output": 65536
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        }
+      }
     }
   },
   "permission": {

--- a/packages/guardrails/profile/opencode.json
+++ b/packages/guardrails/profile/opencode.json
@@ -138,7 +138,40 @@
         "x-ai/grok-4.20",
         "x-ai/grok-4.20-multi-agent",
         "x-ai/grok-4.3"
-      ]
+      ],
+      "models": {
+        "google/gemini-3.5-flash": {
+          "name": "Gemini 3.5 Flash",
+          "family": "gemini-flash",
+          "release_date": "2026-05-19",
+          "attachment": true,
+          "reasoning": true,
+          "temperature": true,
+          "tool_call": true,
+          "cost": {
+            "input": 1.5,
+            "output": 9,
+            "cache_read": 0.15,
+            "cache_write": 0.08333333333333333
+          },
+          "limit": {
+            "context": 1048576,
+            "output": 65536
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "audio",
+              "video",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        }
+      }
     }
   },
   "permission": {


### PR DESCRIPTION
## Summary

- Add an explicit OpenRouter config model for `google/gemini-3.5-flash` in the root, managed, and guardrails profile configs.
- Keep the existing OpenRouter whitelist entry, but provide the model metadata needed while `models.dev` has not yet added this ID.

## Root Cause

PR #207 added `google/gemini-3.5-flash` to the OpenRouter allowlists, but OpenCode creates selectable model objects from `models.dev`. The current OpenRouter API includes `google/gemini-3.5-flash`; the current `models.dev/api.json` does not. A whitelist-only change therefore left the model absent from the selector.

## Validation

- `https://openrouter.ai/api/v1/models` includes `google/gemini-3.5-flash`.
- `https://models.dev/api.json` does not include `openrouter.models["google/gemini-3.5-flash"]` as of May 20, 2026.
- `opencode models openrouter` from `/Users/teradakousuke/Developer/persona-village-v2` now includes `openrouter/google/gemini-3.5-flash`.
- `bun typecheck` from `packages/opencode`.
- `bun test test/plugin` from `packages/opencode` (`149 pass`, `0 fail`).
- pre-push `bun turbo typecheck` (`14 successful`, `14 total`).
- `bun run local:deploy`.
- `bun run local:check` confirms the live wrapper enters the guardrails profile and the profile includes `/auto` and `/plan`.

Closes #208