### PR TITLE
Allow guardrails webfetch without blocking

### DIFF
--- a/packages/guardrails/managed/opencode.json
+++ b/packages/guardrails/managed/opencode.json
@@ -151,7 +151,7 @@
   "permission": {
     "edit": "ask",
     "task": "ask",
-    "webfetch": "ask",
+    "webfetch": "allow",
     "external_directory": "ask",
     "bash": {
       "*": "ask",

--- a/packages/guardrails/profile/agents/provider-eval.md
+++ b/packages/guardrails/profile/agents/provider-eval.md
@@ -10,7 +10,7 @@ permission:
   list: allow
   lsp: allow
   skill: allow
-  webfetch: ask
+  webfetch: allow
   bash:
     "*": deny
     "git diff *": allow

--- a/packages/guardrails/profile/agents/review.md
+++ b/packages/guardrails/profile/agents/review.md
@@ -9,7 +9,7 @@ permission:
   list: allow
   lsp: allow
   skill: allow
-  webfetch: ask
+  webfetch: allow
   bash:
     "*": deny
     "git diff *": allow

--- a/packages/guardrails/profile/opencode.json
+++ b/packages/guardrails/profile/opencode.json
@@ -177,7 +177,7 @@
   "permission": {
     "edit": "ask",
     "task": "ask",
-    "webfetch": "ask",
+    "webfetch": "allow",
     "external_directory": "ask",
     "bash": {
       "*": "ask",

--- a/packages/opencode/src/cli/cmd/run/footer.permission.tsx
+++ b/packages/opencode/src/cli/cmd/run/footer.permission.tsx
@@ -19,6 +19,7 @@ import {
   createPermissionBodyState,
   permissionAlwaysLines,
   permissionCancel,
+  permissionCtrlC,
   permissionEscape,
   permissionHover,
   permissionInfo,
@@ -71,6 +72,7 @@ function RejectField(props: {
   onChange: (text: string) => void
   onConfirm: () => void
   onCancel: () => void
+  onExitRequest?: () => boolean
 }) {
   let area: TextareaRenderable | undefined
 
@@ -114,6 +116,13 @@ function RejectField(props: {
         props.onChange(area.plainText)
       }}
       onKeyDown={(event) => {
+        if (permissionCtrlC(event)) {
+          if (props.onExitRequest?.()) {
+            event.preventDefault()
+          }
+          return
+        }
+
         if (event.name === "escape") {
           event.preventDefault()
           props.onCancel()
@@ -138,6 +147,7 @@ export function RunPermissionBody(props: {
   block: RunBlockTheme
   diffStyle?: RunDiffStyle
   onReply: (input: PermissionReply) => void | Promise<void>
+  onExitRequest?: () => boolean
 }) {
   const dims = useTerminalDimensions()
   const [state, setState] = createSignal(createPermissionBodyState(props.request.id))
@@ -215,6 +225,13 @@ export function RunPermissionBody(props: {
   }
 
   useKeyboard((event) => {
+    if (permissionCtrlC(event)) {
+      if (props.onExitRequest?.()) {
+        event.preventDefault()
+      }
+      return
+    }
+
     const cur = state()
     if (cur.stage === "reject") {
       return
@@ -324,6 +341,7 @@ export function RunPermissionBody(props: {
                   }}
                   onConfirm={reject}
                   onCancel={cancelReject}
+                  onExitRequest={props.onExitRequest}
                 />
               </box>
               <Show

--- a/packages/opencode/src/cli/cmd/run/footer.view.tsx
+++ b/packages/opencode/src/cli/cmd/run/footer.view.tsx
@@ -463,6 +463,7 @@ export function RunFooterView(props: RunFooterViewProps) {
                         block={block()}
                         diffStyle={props.diffStyle}
                         onReply={props.onPermissionReply}
+                        onExitRequest={props.onExitRequest}
                       />
                     </Match>
                     <Match when={active().type === "question"}>

--- a/packages/opencode/src/cli/cmd/run/permission.shared.ts
+++ b/packages/opencode/src/cli/cmd/run/permission.shared.ts
@@ -171,6 +171,16 @@ export function permissionHover(state: PermissionBodyState, option: PermissionOp
   }
 }
 
+export function permissionCtrlC(event: {
+  name: string
+  ctrl?: boolean
+  meta?: boolean
+  shift?: boolean
+  super?: boolean
+}): boolean {
+  return event.name === "c" && !!event.ctrl && !event.meta && !event.shift && !event.super
+}
+
 export function permissionRun(state: PermissionBodyState, requestID: string, option: PermissionOption): PermissionStep {
   if (state.submitting) {
     return { state }

--- a/packages/opencode/test/cli/run/permission.shared.test.ts
+++ b/packages/opencode/test/cli/run/permission.shared.test.ts
@@ -4,6 +4,7 @@ import {
   createPermissionBodyState,
   permissionAlwaysLines,
   permissionCancel,
+  permissionCtrlC,
   permissionEscape,
   permissionInfo,
   permissionReject,
@@ -74,6 +75,13 @@ describe("run permission shared", () => {
       stage: "permission",
       selected: "always",
     })
+  })
+
+  test("detects ctrl-c for permission exit handling", () => {
+    expect(permissionCtrlC({ name: "c", ctrl: true })).toBe(true)
+    expect(permissionCtrlC({ name: "c", ctrl: true, shift: true })).toBe(false)
+    expect(permissionCtrlC({ name: "C", ctrl: true })).toBe(false)
+    expect(permissionCtrlC({ name: "escape" })).toBe(false)
   })
 
   test("maps supported permission types into display info", () => {


### PR DESCRIPTION
Closes #210

## Summary

- Change guardrails profile and managed profile `webfetch` permission from `ask` to `allow` so public evidence fetches do not block autonomous team runs.
- Align `provider-eval` and `review` agent frontmatter with the guardrails default.
- Route `Ctrl+C` from the direct-mode permission reject textarea into the existing exit request path so focused reject input cannot trap the user.

## Verification

- `bun typecheck` from `packages/opencode`
- `bun test test/plugin test/cli/run/permission.shared.test.ts test/agent/agent.test.ts` from `packages/opencode`: 196 pass / 0 fail
- pre-push `bun turbo typecheck`: 14 successful / 14 total
- `bun run local:deploy` with Node 20 PATH: deployed `0.0.0-codex-allow-guardrails-webfetch-202605200556`
- `bun run local:check`: wrapper/profile/binary all OK
- Deployed `opencode --version` from `/Users/teradakousuke/Developer/persona-village-v2`: `0.0.0-codex-allow-guardrails-webfetch-202605200556`
- Guardrails permission evaluation for `webfetch` on `https://github.com/NousResearch/hermes-agent-self-evolution`: `allow`
- Direct interactive demo: entered permission reject textarea and verified `Ctrl+C` exits instead of trapping the session
- `opencode models openrouter | rg 'google/gemini-3.5-flash'`: present