### PR TITLE
Allow isolated team worker edits

### DIFF
--- a/packages/guardrails/profile/plugins/team.ts
+++ b/packages/guardrails/profile/plugins/team.ts
@@ -417,9 +417,15 @@ function workerTools(push: boolean) {
   }
 }
 
-function permit(base: Rule[]) {
+function workerWriteRule(rule: Rule) {
+  if (rule.action === "deny") return true
+  return rule.permission !== "edit" && rule.permission !== "*"
+}
+
+function permit(base: Rule[], isolatedWrite = false) {
   return [
-    ...base,
+    ...(isolatedWrite ? [{ permission: "edit", pattern: "*", action: "allow" as const }] : []),
+    ...(isolatedWrite ? base.filter(workerWriteRule) : base),
     { permission: "bash", pattern: "*", action: "allow" as const },
     { permission: "bash", pattern: "pwd", action: "allow" as const },
     { permission: "bash", pattern: "ls", action: "allow" as const },
@@ -1327,6 +1333,7 @@ export default async function team(input: { client: Client; worktree: string; di
         mergeWorktree && repoRoot ? rebaseForWorktree(item.prompt, repoRoot, box) : item.prompt,
         push,
       )
+      const isolatedWrite = push && mergeWorktree && box !== ctx.directory
 
       if (process.env.DEBUG_TEAM) console.log("job.start", run.id, item.id)
       todo(run, item.id, {
@@ -1340,7 +1347,7 @@ export default async function team(input: { client: Client; worktree: string; di
         body: {
           parentID: ctx.sessionID,
           title: item.description,
-          permission: permit(ctx.permission),
+          permission: permit(ctx.permission, isolatedWrite),
         },
         query: {
           directory: box,

--- a/packages/opencode/test/plugin/team.test.ts
+++ b/packages/opencode/test/plugin/team.test.ts
@@ -578,7 +578,9 @@ alwaysApply: true
 
   expect(out).toContain("run_id:")
   expect(body?.parentID).toBe("ses_parent")
-  expect(body?.permission?.slice(0, perm.length)).toEqual(perm)
+  expect(body?.permission).toContainEqual(perm[0])
+  expect(body?.permission).toContainEqual(perm[1])
+  expect(body?.permission).toContainEqual({ permission: "edit", pattern: "*", action: "allow" })
   expect(body?.permission).toContainEqual({ permission: "bash", pattern: "rg *", action: "allow" })
   expect(body?.permission).toContainEqual({ permission: "bash", pattern: "git ls-tree*", action: "allow" })
   expect(body?.permission).toContainEqual({ permission: "bash", pattern: "git worktree list*", action: "allow" })
@@ -592,6 +594,131 @@ alwaysApply: true
   expect(evaluate("bash", "rm -rf .opencode", body?.permission ?? []).action).toBe("deny")
   expect(body?.permission).toContainEqual({ permission: "bash", pattern: "opencode *", action: "deny" })
   expect(box).toContain(path.join(".opencode", "team"))
+})
+
+test("team allows isolated write workers to edit their worktree without prompting", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      await Bun.write(path.join(dir, "README.md"), "# test\n")
+      await Bun.$`git add README.md`.cwd(dir).quiet()
+      await Bun.$`git commit -m "seed"`.cwd(dir).quiet()
+    },
+  })
+
+  let body:
+    | {
+        permission?: {
+          permission: string
+          pattern: string
+          action: "allow" | "ask" | "deny"
+        }[]
+      }
+    | undefined
+
+  const plugin = await team({
+    client: {
+      permission: {
+        async list() {
+          return { data: [] }
+        },
+      },
+      question: {
+        async list() {
+          return { data: [] }
+        },
+      },
+      session: {
+        async get() {
+          return {
+            data: {
+              permission: [
+                { permission: "edit", pattern: "*", action: "ask" as const },
+                { permission: "edit", pattern: "secrets/*", action: "deny" as const },
+                { permission: "external_directory", pattern: "*", action: "ask" as const },
+              ],
+            },
+          }
+        },
+        async create(input) {
+          body = input.body
+          return {
+            data: {
+              id: "ses_child",
+            },
+          }
+        },
+        async promptAsync(input) {
+          await fs.mkdir(path.join(input.query.directory, "docs", "spikes"), { recursive: true })
+          await Bun.write(path.join(input.query.directory, "docs", "spikes", "worker.md"), "# worker\n")
+          return {}
+        },
+        async prompt() {
+          return {}
+        },
+        async status() {
+          return {
+            data: {
+              ses_child: {
+                type: "idle",
+              },
+            },
+          }
+        },
+        async messages() {
+          return {
+            data: [
+              {
+                info: {
+                  role: "assistant",
+                },
+                parts: [
+                  {
+                    type: "text",
+                    text: "done",
+                  },
+                ],
+              },
+            ],
+          }
+        },
+        async abort() {
+          return {}
+        },
+      },
+    },
+    worktree: tmp.path,
+    directory: tmp.path,
+  })
+
+  const out = await plugin.tool.team.execute(
+    {
+      strategy: "parallel",
+      limit: 1,
+      tasks: [
+        {
+          id: "write-doc",
+          prompt: "write docs/spikes/worker.md",
+          write: true,
+        },
+      ],
+    },
+    {
+      sessionID: "ses_parent",
+      messageID: "msg_parent",
+      agent: "implement",
+      directory: tmp.path,
+      worktree: tmp.path,
+      abort: new AbortController().signal,
+      ask: async () => undefined,
+      metadata() {},
+    },
+  )
+
+  expect(out).toContain("write-doc: done")
+  expect(evaluate("edit", "docs/spikes/worker.md", body?.permission ?? []).action).toBe("allow")
+  expect(evaluate("edit", "secrets/key.txt", body?.permission ?? []).action).toBe("deny")
+  expect(evaluate("external_directory", "../outside.txt", body?.permission ?? []).action).toBe("ask")
 })
 
 test("team carries local .opencode config even when the project gitignore ignores .opencode", async () => {


### PR DESCRIPTION
## Summary

Closes #216.

- Allow `edit:*` for `write: true` team/background workers only when they run in an isolated worker worktree.
- Drop inherited non-deny `edit`/`*` rules in that isolated write-worker session so guardrail profile `edit: ask` does not block normal worker output.
- Preserve inherited `edit: deny` and `external_directory` rules so protected paths and outside-worktree writes remain guarded.
- Add regression coverage for the stalled `docs/spikes/...` write-worker path.

## Root Cause

The guardrail profile has `edit: ask`. The `team` plugin inherited that into child sessions even for isolated `write: true` workers. As a result, ordinary edits inside `.opencode/team/<run>/...` asked the parent UI for permission and stopped the implementation flow.

## Validation

- `bun test test/plugin/team.test.ts test/plugin/guardrail.test.ts test/plugin/guardrail-access.test.ts test/plugin/guardrail-git.test.ts` -> 56 pass / 0 fail
- `bun typecheck` from `packages/opencode` -> pass
- `bun x oxlint packages/guardrails/profile/plugins/team.ts packages/opencode/test/plugin/team.test.ts` -> 0 errors, existing warnings only
- `git diff --check` -> pass
- pre-push `bun turbo typecheck` -> 14/14 successful