### PR TITLE
Prevent worker permission stalls

### DIFF
--- a/packages/guardrails/profile/plugins/team.ts
+++ b/packages/guardrails/profile/plugins/team.ts
@@ -285,6 +285,8 @@ function workerTools() {
     team: false,
     background: false,
     team_status: false,
+    question: false,
+    plan_exit: false,
   }
 }
 

--- a/packages/opencode/src/agent/subagent-permissions.ts
+++ b/packages/opencode/src/agent/subagent-permissions.ts
@@ -5,13 +5,15 @@ import type { Agent } from "./agent"
  * Build the `permission` ruleset for a subagent's session when it's spawned
  * via the task tool. Combines:
  *
- * 1. The parent **agent's** edit-class deny rules — Plan Mode's file-edit
+ * 1. A permissive session baseline so subagents don't stop on interactive
+ *    permission asks after the parent already chose to delegate the task.
+ * 2. The parent **agent's** edit-class deny rules — Plan Mode's file-edit
  *    restriction lives on the agent ruleset, not on the session, so a
  *    subagent that only inherited the parent SESSION's permission would
  *    silently bypass it. (#26514)
- * 2. The parent **session's** deny rules and external_directory rules —
- *    same forwarding the original code already did.
- * 3. Default `todowrite` and `task` denies if the subagent's own ruleset
+ * 3. The parent **session's** deny rules as hard ceilings while dropping
+ *    inherited `ask` rules that would strand the child without the parent UI.
+ * 4. Default `todowrite` and `task` denies if the subagent's own ruleset
  *    doesn't already permit them.
  */
 export function deriveSubagentSessionPermission(input: {
@@ -24,10 +26,23 @@ export function deriveSubagentSessionPermission(input: {
   const parentAgentDenies =
     input.parentAgent?.permission.filter((rule) => rule.action === "deny" && rule.permission === "edit") ?? []
   return [
+    { permission: "edit" as const, pattern: "*" as const, action: "allow" as const },
+    { permission: "external_directory" as const, pattern: "*" as const, action: "allow" as const },
+    { permission: "bash" as const, pattern: "*" as const, action: "allow" as const },
+    { permission: "read" as const, pattern: "*" as const, action: "allow" as const },
+    { permission: "glob" as const, pattern: "*" as const, action: "allow" as const },
+    { permission: "grep" as const, pattern: "*" as const, action: "allow" as const },
+    { permission: "list" as const, pattern: "*" as const, action: "allow" as const },
+    { permission: "webfetch" as const, pattern: "*" as const, action: "allow" as const },
+    { permission: "websearch" as const, pattern: "*" as const, action: "allow" as const },
+    { permission: "repo_clone" as const, pattern: "*" as const, action: "allow" as const },
+    { permission: "repo_overview" as const, pattern: "*" as const, action: "allow" as const },
+    { permission: "lsp_diagnostics" as const, pattern: "*" as const, action: "allow" as const },
+    { permission: "lsp_hover" as const, pattern: "*" as const, action: "allow" as const },
+    { permission: "workflow_tool_approval" as const, pattern: "*" as const, action: "allow" as const },
+    { permission: "doom_loop" as const, pattern: "*" as const, action: "allow" as const },
     ...parentAgentDenies,
-    ...input.parentSessionPermission.filter(
-      (rule) => rule.permission === "external_directory" || rule.action === "deny",
-    ),
+    ...input.parentSessionPermission.filter((rule) => rule.action === "deny"),
     ...(canTodo ? [] : [{ permission: "todowrite" as const, pattern: "*" as const, action: "deny" as const }]),
     ...(canTask ? [] : [{ permission: "task" as const, pattern: "*" as const, action: "deny" as const }]),
   ]

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -257,10 +257,9 @@ const live: Layer.Layer<
           }
         }
 
-        const ruleset = Permission.merge(input.agent.permission ?? [], input.permission ?? [])
+        const approvalRuleset = workflowApprovalRuleset(input.agent.permission, input.permission)
         workflowModel.sessionPreapprovedTools = Object.keys(sortedTools).filter((name) => {
-          const match = ruleset.findLast((rule) => Wildcard.match(name, rule.permission))
-          return !match || match.action !== "ask"
+          return Permission.evaluate("workflow_tool_approval", name, approvalRuleset).action === "allow"
         })
 
         const bridge = yield* EffectBridge.make()
@@ -297,7 +296,7 @@ const live: Layer.Layer<
                 patterns: uniquePatterns,
                 metadata: { tools: approvalTools },
                 always: uniquePatterns,
-                ruleset: [],
+                ruleset: approvalRuleset,
               }),
             )
             for (const name of uniqueNames) approvedToolsForSession.add(name)
@@ -515,6 +514,19 @@ function resolveTools(input: Pick<StreamInput, "tools" | "agent" | "permission" 
     Permission.merge(input.agent.permission, input.permission ?? []),
   )
   return Record.filter(input.tools, (_, k) => input.user.tools?.[k] !== false && !disabled.has(k))
+}
+
+export function workflowApprovalRuleset(
+  agentPermission: Permission.Ruleset | undefined,
+  sessionPermission: Permission.Ruleset | undefined,
+) {
+  return Permission.merge(
+    [{ permission: "workflow_tool_approval", pattern: "*", action: "ask" }],
+    (agentPermission ?? []).filter(
+      (rule) => rule.permission !== "*" && Wildcard.match("workflow_tool_approval", rule.permission),
+    ),
+    sessionPermission ?? [],
+  )
 }
 
 // Check if messages contain any tool-call content

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -74,6 +74,7 @@ type ToolCall = {
 interface ProcessorContext extends Input {
   toolcalls: Record<string, ToolCall>
   shouldBreak: boolean
+  permission?: Permission.Ruleset
   snapshot: string | undefined
   blocked: boolean
   needsCompaction: boolean
@@ -455,7 +456,7 @@ export const layer = Layer.effect(
               sessionID: ctx.assistantMessage.sessionID,
               metadata: { tool: value.name, input },
               always: [value.name],
-              ruleset: agent.permission,
+              ruleset: Permission.merge(agent.permission, ctx.permission ?? []),
             })
             return
           }
@@ -792,6 +793,7 @@ export const layer = Layer.effect(
         slog.info("process")
         ctx.needsCompaction = false
         ctx.shouldBreak = (yield* config.get()).experimental?.continue_loop_on_deny !== true
+        ctx.permission = streamInput.permission
 
         return yield* Effect.gen(function* () {
           yield* Effect.gen(function* () {

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -202,6 +202,9 @@ export const TaskTool = Tool.define(
           },
           agent: next.name,
           tools: {
+            question: false,
+            plan_enter: false,
+            plan_exit: false,
             ...(next.permission.some((rule) => rule.permission === "todowrite") ? {} : { todowrite: false }),
             ...(next.permission.some((rule) => rule.permission === id) ? {} : { task: false }),
             ...Object.fromEntries((cfg.experimental?.primary_tools ?? []).map((item) => [item, false])),

--- a/packages/opencode/test/agent/plan-mode-subagent-bypass.test.ts
+++ b/packages/opencode/test/agent/plan-mode-subagent-bypass.test.ts
@@ -101,6 +101,30 @@ it.instance("[#26514] explore subagent launched from plan mode also stays read-o
   }),
 )
 
+it.instance("explore subagent launched from build receives non-interactive worker permissions", () =>
+  Effect.gen(function* () {
+    const buildAgent = yield* Agent.Service.use((svc) => svc.get("build"))
+    const explore = yield* Agent.Service.use((svc) => svc.get("explore"))
+    expect(buildAgent).toBeDefined()
+    expect(explore).toBeDefined()
+
+    const effective = Permission.merge(
+      explore!.permission,
+      deriveSubagentSessionPermission({
+        parentSessionPermission: [],
+        parentAgent: buildAgent,
+        subagent: explore!,
+      }),
+    )
+
+    expect(Permission.evaluate("edit", "/x.ts", effective).action).toBe("allow")
+    expect(Permission.evaluate("external_directory", "/tmp/outside.txt", effective).action).toBe("allow")
+    expect(Permission.evaluate("bash", "git status", effective).action).toBe("allow")
+    expect(Permission.evaluate("workflow_tool_approval", "bash: git status", effective).action).toBe("allow")
+    expect(Permission.evaluate("doom_loop", "bash", effective).action).toBe("allow")
+  }),
+)
+
 it.instance(
   "[#26514] custom user subagent launched from plan mode bypasses Plan Mode read-only",
   // The most damaging case: a user-defined subagent with default
@@ -207,6 +231,32 @@ it.effect("subagent inherits parent session deny rules as hard runtime ceilings"
       }),
     )
 
+    expect(Permission.evaluate("bash", "git status", effective).action).toBe("deny")
+  }),
+)
+
+it.effect("subagent drops inherited ask rules that would strand background workers", () =>
+  Effect.sync(() => {
+    const executor = testAgent({
+      name: "executor",
+      mode: "subagent",
+      permission: {
+        bash: "allow",
+      },
+    })
+    const effective = Permission.merge(
+      executor.permission,
+      deriveSubagentSessionPermission({
+        parentSessionPermission: Permission.fromConfig({
+          external_directory: "ask",
+          bash: "deny",
+        }),
+        parentAgent: undefined,
+        subagent: executor,
+      }),
+    )
+
+    expect(Permission.evaluate("external_directory", "/tmp/outside.txt", effective).action).toBe("allow")
     expect(Permission.evaluate("bash", "git status", effective).action).toBe("deny")
   }),
 )

--- a/packages/opencode/test/plugin/team.test.ts
+++ b/packages/opencode/test/plugin/team.test.ts
@@ -2085,6 +2085,160 @@ test("background failure with notify false is persisted without sending parent p
   expect(status).toContain("Blocked on permission: bash (background deployment) :: deploy production")
 })
 
+test("background workers use permissive child permissions and keep write tools enabled", async () => {
+  await using tmp = await tmpdir({
+    git: true,
+    init: async (dir) => {
+      await Bun.write(path.join(dir, "README.md"), "# test\n")
+      await Bun.$`git add README.md`.cwd(dir).quiet()
+      await Bun.$`git commit -m "seed"`.cwd(dir).quiet()
+    },
+  })
+
+  let createBody:
+    | {
+        parentID: string
+        title: string
+        permission?: {
+          permission: string
+          pattern: string
+          action: "allow" | "ask" | "deny"
+        }[]
+      }
+    | undefined
+  let promptBody:
+    | {
+        tools?: Record<string, boolean>
+        parts: { type: "text"; text: string }[]
+      }
+    | undefined
+
+  const plugin = await team({
+    client: {
+      permission: {
+        async list() {
+          return { data: [] }
+        },
+      },
+      question: {
+        async list() {
+          return { data: [] }
+        },
+      },
+      session: {
+        async get() {
+          return {
+            data: {
+              permission: [
+                { permission: "edit", pattern: "*", action: "deny" as const },
+                { permission: "write", pattern: "*", action: "deny" as const },
+                { permission: "apply_patch", pattern: "*", action: "deny" as const },
+                { permission: "todowrite", pattern: "*", action: "deny" as const },
+              ],
+            },
+          }
+        },
+        async create(input) {
+          createBody = input.body
+          return {
+            data: {
+              id: "ses_child_background_permissions",
+            },
+          }
+        },
+        async promptAsync(input) {
+          promptBody = input.body
+          return {}
+        },
+        async prompt() {
+          return {}
+        },
+        async status() {
+          return {
+            data: {
+              ses_child_background_permissions: {
+                type: "idle",
+              },
+            },
+          }
+        },
+        async messages() {
+          return {
+            data: [
+              {
+                info: {
+                  role: "assistant",
+                },
+                parts: [
+                  {
+                    type: "text",
+                    text: "done",
+                  },
+                ],
+              },
+            ],
+          }
+        },
+        async abort() {
+          return {}
+        },
+      },
+    },
+    worktree: tmp.path,
+    directory: tmp.path,
+  })
+
+  const out = await plugin.tool.background.execute(
+    {
+      description: "background-permissions",
+      prompt: "write docs/background.md",
+      write: true,
+      worktree: false,
+      notify: false,
+    },
+    {
+      sessionID: "ses_parent",
+      messageID: "msg_parent",
+      agent: "implement",
+      directory: tmp.path,
+      worktree: tmp.path,
+      abort: new AbortController().signal,
+      ask: async () => undefined,
+      metadata() {},
+    },
+  )
+
+  await Background.wait(tmp.path)
+
+  expect(out).toContain("run_id:")
+  expect(createBody?.parentID).toBe("ses_parent")
+  expect(createBody?.title).toBe("background-permissions")
+  expect(createBody?.permission).toContainEqual({ permission: "*", pattern: "*", action: "allow" })
+  expect(createBody?.permission).toContainEqual({ permission: "edit", pattern: "*", action: "allow" })
+  expect(createBody?.permission).toContainEqual({ permission: "external_directory", pattern: "*", action: "allow" })
+  expect(createBody?.permission).toContainEqual({ permission: "bash", pattern: "*", action: "allow" })
+  expect(createBody?.permission?.filter((item) => item.action === "deny")).toEqual([])
+  expect(evaluate("bash", "git commit -am background", createBody?.permission ?? []).action).toBe("allow")
+  expect(evaluate("external_directory", "../outside.txt", createBody?.permission ?? []).action).toBe("allow")
+  expect(evaluate("edit", "docs/background.md", createBody?.permission ?? []).action).toBe("allow")
+  expect(evaluate("write", "docs/background.md", createBody?.permission ?? []).action).toBe("allow")
+  expect(evaluate("apply_patch", "docs/background.md", createBody?.permission ?? []).action).toBe("allow")
+  expect(evaluate("todowrite", "docs/background.md", createBody?.permission ?? []).action).toBe("allow")
+  expect(promptBody?.tools).toEqual({
+    task: false,
+    team: false,
+    background: false,
+    team_status: false,
+    question: false,
+    plan_exit: false,
+  })
+  expect(promptBody?.tools?.edit).toBeUndefined()
+  expect(promptBody?.tools?.write).toBeUndefined()
+  expect(promptBody?.tools?.apply_patch).toBeUndefined()
+  expect(promptBody?.tools?.todowrite).toBeUndefined()
+  expect(promptBody?.parts[0]?.text).toContain("This is a write task.")
+})
+
 test("team falls back to tool output when child returns no text", async () => {
   await using tmp = await tmpdir({
     git: true,
@@ -2296,7 +2450,13 @@ test("team keeps write tools enabled for read-only workers and disables recursiv
     team: false,
     background: false,
     team_status: false,
+    question: false,
+    plan_exit: false,
   })
+  expect(tools?.edit).toBeUndefined()
+  expect(tools?.write).toBeUndefined()
+  expect(tools?.apply_patch).toBeUndefined()
+  expect(tools?.todowrite).toBeUndefined()
 })
 
 test("team disables recursive orchestration tools for write workers", async () => {
@@ -2405,7 +2565,13 @@ test("team disables recursive orchestration tools for write workers", async () =
     team: false,
     background: false,
     team_status: false,
+    question: false,
+    plan_exit: false,
   })
+  expect(tools?.edit).toBeUndefined()
+  expect(tools?.write).toBeUndefined()
+  expect(tools?.apply_patch).toBeUndefined()
+  expect(tools?.todowrite).toBeUndefined()
 })
 
 test("team rewrites nested opencode init prompts to direct bootstrap work", async () => {
@@ -4145,19 +4311,24 @@ test("parallel enforcement is disabled for direct operation requests", async () 
   )
 
   expect(parts.some((part) => part.text?.includes("Parallel implementation policy is active"))).toBe(false)
-  await expect(
-    plugin["tool.execute.before"]?.(
-      {
-        tool: "write",
-        sessionID: "ses_operation_only",
-      },
-      {
-        args: {
-          filePath: "completion.md",
+  for (const item of [
+    { tool: "edit", args: { filePath: "completion.md", oldString: "before", newString: "after" } },
+    { tool: "write", args: { filePath: "completion.md" } },
+    { tool: "apply_patch", args: { patch: "*** Begin Patch\n*** End Patch\n" } },
+    { tool: "bash", args: { command: "git commit -am complete" } },
+  ]) {
+    await expect(
+      plugin["tool.execute.before"]?.(
+        {
+          tool: item.tool,
+          sessionID: "ses_operation_only",
         },
-      },
-    ),
-  ).resolves.toBeUndefined()
+        {
+          args: item.args,
+        },
+      ),
+    ).resolves.toBeUndefined()
+  }
 })
 
 test("parallel enforcement is disabled for direct implementation edits", async () => {
@@ -4238,19 +4409,24 @@ test("parallel enforcement is disabled for direct implementation edits", async (
   )
 
   expect(first.some((part) => part.text?.includes("Parallel implementation policy is active"))).toBe(false)
-  await expect(
-    plugin["tool.execute.before"]?.(
-      {
-        tool: "write",
-        sessionID: "ses_rearm",
-      },
-      {
-        args: {
-          filePath: "blocked.md",
+  for (const item of [
+    { tool: "edit", args: { filePath: "blocked.md", oldString: "before", newString: "after" } },
+    { tool: "write", args: { filePath: "blocked.md" } },
+    { tool: "apply_patch", args: { patch: "*** Begin Patch\n*** End Patch\n" } },
+    { tool: "bash", args: { command: "git commit -am blocked" } },
+  ]) {
+    await expect(
+      plugin["tool.execute.before"]?.(
+        {
+          tool: item.tool,
+          sessionID: "ses_rearm",
         },
-      },
-    ),
-  ).resolves.toBeUndefined()
+        {
+          args: item.args,
+        },
+      ),
+    ).resolves.toBeUndefined()
+  }
 
   await plugin["tool.execute.error"]?.(
     {
@@ -4279,19 +4455,24 @@ test("parallel enforcement is disabled for direct implementation edits", async (
   )
 
   expect(second.some((part) => part.text?.includes("Parallel implementation policy is active"))).toBe(false)
-  await expect(
-    plugin["tool.execute.before"]?.(
-      {
-        tool: "write",
-        sessionID: "ses_rearm",
-      },
-      {
-        args: {
-          filePath: "allowed.md",
+  for (const item of [
+    { tool: "edit", args: { filePath: "allowed.md", oldString: "before", newString: "after" } },
+    { tool: "write", args: { filePath: "allowed.md" } },
+    { tool: "apply_patch", args: { patch: "*** Begin Patch\n*** End Patch\n" } },
+    { tool: "bash", args: { command: "git commit -am allowed" } },
+  ]) {
+    await expect(
+      plugin["tool.execute.before"]?.(
+        {
+          tool: item.tool,
+          sessionID: "ses_rearm",
         },
-      },
-    ),
-  ).resolves.toBeUndefined()
+        {
+          args: item.args,
+        },
+      ),
+    ).resolves.toBeUndefined()
+  }
 })
 
 test("team merge excludes runtime artifacts and leaves unrelated parent edits untouched", async () => {

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -9,6 +9,8 @@ import { InstanceRef } from "../../src/effect/instance-ref"
 import { LLM } from "../../src/session/llm"
 import type { InstanceContext } from "../../src/project/instance-context"
 import { LLMClient, RequestExecutor } from "@opencode-ai/llm/route"
+import type { LanguageModelV3CallOptions, LanguageModelV3StreamPart, LanguageModelV3StreamResult } from "@ai-sdk/provider"
+import { GitLabWorkflowLanguageModel } from "gitlab-ai-provider"
 import { Auth } from "@/auth"
 import { Config } from "@/config/config"
 import { Provider } from "@/provider/provider"
@@ -704,6 +706,182 @@ function createEventResponse(chunks: unknown[], includeDone = false) {
   })
 }
 
+type WorkflowApprovalResult = Awaited<ReturnType<NonNullable<GitLabWorkflowLanguageModel["approvalHandler"]>>>
+type WorkflowApprovalTestResult = WorkflowApprovalResult | "pending"
+
+class TestGitLabWorkflowLanguageModel extends GitLabWorkflowLanguageModel {
+  approvalResult: WorkflowApprovalTestResult | undefined
+
+  constructor(
+    workDir: string,
+    private readonly approvalTimeoutMs?: number,
+  ) {
+    super(
+      "duo-workflow",
+      {
+        provider: "gitlab.workflow",
+        instanceUrl: "https://gitlab.example",
+        getHeaders: () => ({}),
+      },
+      { workingDirectory: workDir },
+    )
+  }
+
+  override async doStream(_options: LanguageModelV3CallOptions): Promise<LanguageModelV3StreamResult> {
+    const handler = this.approvalHandler
+    if (!handler) throw new Error("approval handler not configured")
+    const approval = handler([{ name: "bash", args: JSON.stringify({ title: "bun test" }) }])
+    this.approvalResult =
+      this.approvalTimeoutMs === undefined
+        ? await approval
+        : await Promise.race<WorkflowApprovalTestResult>([
+            approval,
+            new Promise((resolve) => setTimeout(() => resolve("pending"), this.approvalTimeoutMs)),
+          ])
+    return {
+      stream: new ReadableStream<LanguageModelV3StreamPart>({
+        start(controller) {
+          controller.enqueue({ type: "stream-start", warnings: [] })
+          controller.enqueue({
+            type: "finish",
+            finishReason: { unified: "stop", raw: "stop" },
+            usage: {
+              inputTokens: { total: 0, noCache: 0, cacheRead: undefined, cacheWrite: undefined },
+              outputTokens: { total: 0, text: 0, reasoning: undefined },
+            },
+          })
+          controller.close()
+        },
+      }),
+    }
+  }
+}
+
+async function runWorkflowApproval(input: {
+  agentPermission: Permission.Ruleset
+  sessionPermission?: Permission.Ruleset
+  approvalTimeoutMs?: number
+}) {
+  await using tmp = await tmpdir({ git: true })
+  const result = {} as {
+    approvalResult: WorkflowApprovalTestResult | undefined
+    preapprovedTools: string[]
+  }
+
+  await withTestInstance({
+    directory: tmp.path,
+    fn: async (ctx) => {
+      const workflowModel = new TestGitLabWorkflowLanguageModel(tmp.path, input.approvalTimeoutMs)
+      const model = workflowModelTestModel()
+      const layer = workflowApprovalTestLayer(workflowModel, model)
+      const sessionID = SessionID.make("session-test-workflow-approval")
+      const agent = {
+        name: "test",
+        mode: "primary",
+        options: {},
+        permission: input.agentPermission,
+      } satisfies Agent.Info
+      const user = {
+        id: MessageID.make("msg_user-workflow-approval"),
+        sessionID,
+        role: "user",
+        time: { created: Date.now() },
+        agent: agent.name,
+        model: { providerID: ProviderID.gitlab, modelID: model.id },
+      } satisfies MessageV2.User
+
+      await drainWith(
+        layer,
+        {
+          user,
+          sessionID,
+          model,
+          agent,
+          permission: input.sessionPermission,
+          system: ["You are a helpful assistant."],
+          messages: [{ role: "user", content: "Hello" }],
+          tools: {
+            bash: tool({
+              description: "Run a command",
+              inputSchema: z.object({}),
+              execute: async () => ({ output: "" }),
+            }),
+          },
+        },
+        ctx,
+      )
+
+      result.approvalResult = workflowModel.approvalResult
+      result.preapprovedTools = [...workflowModel.sessionPreapprovedTools]
+    },
+  })
+
+  return result
+}
+
+function workflowModelTestModel() {
+  return {
+    id: ModelID.make("duo-workflow-test"),
+    providerID: ProviderID.gitlab,
+    api: { id: "duo-workflow-test", url: "https://gitlab.example", npm: "gitlab-ai-provider" },
+    name: "GitLab Workflow Test",
+    capabilities: {
+      temperature: true,
+      reasoning: false,
+      attachment: false,
+      toolcall: true,
+      input: { text: true, image: false, audio: false, video: false, pdf: false },
+      output: { text: true, image: false, audio: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+    limit: { context: 100_000, output: 8_192 },
+    status: "active",
+    options: {},
+    headers: {},
+    release_date: "2026-01-01",
+  } satisfies Provider.Model
+}
+
+function workflowApprovalTestLayer(workflowModel: TestGitLabWorkflowLanguageModel, model: Provider.Model) {
+  return LLM.layer.pipe(
+    Layer.provide(
+      Layer.mock(Auth.Service)({
+        get: () => Effect.succeed(undefined),
+      }),
+    ),
+    Layer.provide(
+      Layer.mock(Config.Service)({
+        get: () => Effect.succeed({} as Config.Info),
+      }),
+    ),
+    Layer.provide(
+      Layer.mock(Provider.Service)({
+        getProvider: () =>
+          Effect.succeed({
+            id: ProviderID.gitlab,
+            name: "GitLab",
+            source: "config",
+            env: [],
+            options: {},
+            models: { [model.id]: model },
+          } satisfies Provider.Info),
+        getLanguage: () => Effect.succeed(workflowModel),
+      }),
+    ),
+    Layer.provide(
+      Layer.mock(Plugin.Service)({
+        trigger: <Name extends string, Input, Output>(_name: Name, _input: Input, output: Output) =>
+          Effect.succeed(output),
+        list: () => Effect.succeed([]),
+        init: () => Effect.void,
+      }),
+    ),
+    Layer.provide(LLMClient.layer.pipe(Layer.provide(RequestExecutor.defaultLayer))),
+    Layer.provide(RuntimeFlags.layer({})),
+  )
+}
+
 describe("session.llm.stream", () => {
   test("sends temperature, tokens, and reasoning options for openai-compatible models", async () => {
     const server = state.server
@@ -971,6 +1149,86 @@ describe("session.llm.stream", () => {
         expect(tools?.some((item) => item.function?.name === "question")).toBe(true)
       },
     })
+  })
+
+  test("keeps workflow approvals asking when only agent default allows all", async () => {
+    const result = await runWorkflowApproval({
+      agentPermission: [{ permission: "*", pattern: "*", action: "allow" }],
+      approvalTimeoutMs: 50,
+    })
+
+    expect(result.approvalResult).toBe("pending")
+    expect(result.preapprovedTools).not.toContain("bash")
+  })
+
+  test("lets session allow-all override workflow approvals for worker sessions", async () => {
+    const result = await runWorkflowApproval({
+      agentPermission: [{ permission: "*", pattern: "*", action: "allow" }],
+      sessionPermission: [{ permission: "*", pattern: "*", action: "allow" }],
+    })
+
+    expect(result.approvalResult).toEqual({ approved: true })
+    expect(result.preapprovedTools).toContain("bash")
+  })
+
+  test("lets worker session allow-all override explicit agent workflow asks", async () => {
+    const result = await runWorkflowApproval({
+      agentPermission: [{ permission: "workflow_tool_approval", pattern: "*", action: "ask" }],
+      sessionPermission: [{ permission: "*", pattern: "*", action: "allow" }],
+    })
+
+    expect(result.approvalResult).toEqual({ approved: true })
+    expect(result.preapprovedTools).toContain("bash")
+  })
+
+  test("honors explicit agent workflow approval allow rules", async () => {
+    const result = await runWorkflowApproval({
+      agentPermission: [{ permission: "workflow_tool_approval", pattern: "*", action: "allow" }],
+    })
+
+    expect(result.approvalResult).toEqual({ approved: true })
+    expect(result.preapprovedTools).toContain("bash")
+  })
+
+  test("honors explicit agent workflow approval ask rules", async () => {
+    const result = await runWorkflowApproval({
+      agentPermission: [{ permission: "workflow_tool_approval", pattern: "*", action: "ask" }],
+      approvalTimeoutMs: 50,
+    })
+
+    expect(result.approvalResult).toBe("pending")
+    expect(result.preapprovedTools).not.toContain("bash")
+  })
+
+  test("honors explicit agent workflow approval deny rules", async () => {
+    const result = await runWorkflowApproval({
+      agentPermission: [{ permission: "workflow_tool_approval", pattern: "*", action: "deny" }],
+    })
+
+    expect(result.approvalResult).toEqual({ approved: false })
+    expect(result.preapprovedTools).not.toContain("bash")
+  })
+
+  test("honors wildcard agent workflow approval allow rules", async () => {
+    const result = await runWorkflowApproval({
+      agentPermission: [{ permission: "workflow_*", pattern: "*", action: "allow" }],
+    })
+
+    expect(result.approvalResult).toEqual({ approved: true })
+    expect(result.preapprovedTools).toContain("bash")
+  })
+
+  test("honors explicit session workflow approval rules over session allow-all", async () => {
+    const result = await runWorkflowApproval({
+      agentPermission: [{ permission: "*", pattern: "*", action: "allow" }],
+      sessionPermission: [
+        { permission: "*", pattern: "*", action: "allow" },
+        { permission: "workflow_tool_approval", pattern: "*", action: "deny" },
+      ],
+    })
+
+    expect(result.approvalResult).toEqual({ approved: false })
+    expect(result.preapprovedTools).not.toContain("bash")
   })
 
   test("sends responses API payload for OpenAI models", async () => {

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -51,7 +51,7 @@ import { Reference } from "../../src/reference/reference"
 import { RepositoryCache } from "../../src/reference/repository-cache"
 import { TestInstance } from "../fixture/fixture"
 import { awaitWithTimeout, pollWithTimeout, testEffect } from "../lib/effect"
-import { reply, TestLLMServer } from "../lib/llm-server"
+import { raw, reply, TestLLMServer } from "../lib/llm-server"
 import { SyncEvent } from "@/sync"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { EventV2Bridge } from "@/event-v2-bridge"
@@ -439,6 +439,52 @@ const boot = Effect.fn("test.boot")(function* (input?: { title?: string }) {
   return { prompt, run, sessions, chat }
 })
 
+const expectNoPermissionPrompt = Effect.fn("test.expectNoPermissionPrompt")(function* (input: {
+  sessionID: SessionID
+  permission: string
+  patterns: string[]
+  ruleset: Permission.Ruleset
+}) {
+  const permission = yield* Permission.Service
+  yield* awaitWithTimeout(
+    permission.ask({
+      sessionID: input.sessionID,
+      permission: input.permission,
+      patterns: input.patterns,
+      always: ["*"],
+      metadata: {},
+      ruleset: input.ruleset,
+    }),
+    `${input.permission} permission unexpectedly prompted`,
+  )
+  expect(yield* permission.list()).toEqual([])
+})
+
+const expectPermissionDenied = Effect.fn("test.expectPermissionDenied")(function* (input: {
+  sessionID: SessionID
+  permission: string
+  patterns: string[]
+  ruleset: Permission.Ruleset
+}) {
+  const permission = yield* Permission.Service
+  const exit = yield* awaitWithTimeout(
+    permission
+      .ask({
+        sessionID: input.sessionID,
+        permission: input.permission,
+        patterns: input.patterns,
+        always: ["*"],
+        metadata: {},
+        ruleset: input.ruleset,
+      })
+      .pipe(Effect.exit),
+    `${input.permission} permission unexpectedly prompted`,
+  )
+  expect(Exit.isFailure(exit)).toBe(true)
+  if (Exit.isFailure(exit)) expect(Cause.squash(exit.cause)).toBeInstanceOf(Permission.DeniedError)
+  expect(yield* permission.list()).toEqual([])
+})
+
 // Loop semantics
 
 noLLMServer.instance(
@@ -528,7 +574,6 @@ noLLMServer.instance(
   () =>
     Effect.gen(function* () {
       const prompt = yield* SessionPrompt.Service
-      const permission = yield* Permission.Service
       const sessions = yield* Session.Service
       const chat = yield* sessions.create({
         title: "Worker",
@@ -563,23 +608,18 @@ noLLMServer.instance(
       expect(Permission.evaluate("background", "*", updated.permission ?? []).action).toBe("deny")
       expect(Permission.evaluate("task", "*", updated.permission ?? []).action).toBe("deny")
       expect(Permission.evaluate("bash", "rm -rf .opencode", updated.permission ?? []).action).toBe("deny")
-      yield* permission.ask({
+      yield* expectNoPermissionPrompt({
         sessionID: chat.id,
         permission: "edit",
         patterns: ["docs/spikes/live-adapter-options.md"],
-        always: ["*"],
-        metadata: {},
         ruleset: updated.permission ?? [],
       })
-      yield* permission.ask({
+      yield* expectNoPermissionPrompt({
         sessionID: chat.id,
         permission: "external_directory",
         patterns: ["/Users/example/project/file.txt"],
-        always: ["*"],
-        metadata: {},
         ruleset: updated.permission ?? [],
       })
-      expect(yield* permission.list()).toEqual([])
     }),
   { config: cfg },
 )
@@ -589,7 +629,6 @@ noLLMServer.instance(
   () =>
     Effect.gen(function* () {
       const prompt = yield* SessionPrompt.Service
-      const permission = yield* Permission.Service
       const sessions = yield* Session.Service
       const chat = yield* sessions.create({
         title: "Worker",
@@ -618,17 +657,141 @@ noLLMServer.instance(
       expect(Permission.evaluate("bash", "gh pr merge 150", updated.permission ?? []).action).toBe("allow")
       expect(Permission.evaluate("bash", "rm -rf .opencode", updated.permission ?? []).action).toBe("allow")
       expect(Permission.evaluate("team", "*", updated.permission ?? []).action).toBe("deny")
-      yield* permission.ask({
+      yield* expectNoPermissionPrompt({
         sessionID: chat.id,
         permission: "bash",
         patterns: ["opencode run /init", "gh pr merge 150", "rm -rf .opencode"],
-        always: ["*"],
-        metadata: {},
         ruleset: updated.permission ?? [],
       })
-      expect(yield* permission.list()).toEqual([])
     }),
   { config: cfg },
+)
+
+noLLMServer.instance(
+  "prompt tool toggles keep recursive worker tool denies effective",
+  () =>
+    Effect.gen(function* () {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({
+        title: "Worker",
+        permission: [
+          { permission: "*", pattern: "*", action: "allow" },
+          { permission: "edit", pattern: "*", action: "allow" },
+          { permission: "external_directory", pattern: "*", action: "allow" },
+          { permission: "bash", pattern: "*", action: "allow" },
+          { permission: "bash", pattern: "gh pr merge *", action: "deny" },
+        ],
+      })
+
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        noReply: true,
+        parts: [{ type: "text", text: "run without recursively spawning workers" }],
+        tools: {
+          team: false,
+          background: false,
+          task: false,
+        },
+      })
+
+      const updated = yield* sessions.get(chat.id)
+      const ruleset = updated.permission ?? []
+      expect(Permission.evaluate("bash", "bun test", ruleset).action).toBe("allow")
+      expect(Permission.evaluate("edit", "packages/opencode/test/session/prompt.test.ts", ruleset).action).toBe(
+        "allow",
+      )
+      expect(Permission.evaluate("external_directory", "/tmp/opencode-worker/file.txt", ruleset).action).toBe("allow")
+      expect(Permission.evaluate("bash", "gh pr merge 150", ruleset).action).toBe("deny")
+      expect(Permission.evaluate("team", "*", ruleset).action).toBe("deny")
+      expect(Permission.evaluate("background", "*", ruleset).action).toBe("deny")
+      expect(Permission.evaluate("task", "*", ruleset).action).toBe("deny")
+
+      yield* expectNoPermissionPrompt({
+        sessionID: chat.id,
+        permission: "bash",
+        patterns: ["bun test"],
+        ruleset,
+      })
+      yield* expectNoPermissionPrompt({
+        sessionID: chat.id,
+        permission: "edit",
+        patterns: ["packages/opencode/test/session/prompt.test.ts"],
+        ruleset,
+      })
+      yield* expectNoPermissionPrompt({
+        sessionID: chat.id,
+        permission: "external_directory",
+        patterns: ["/tmp/opencode-worker/file.txt"],
+        ruleset,
+      })
+      yield* expectPermissionDenied({
+        sessionID: chat.id,
+        permission: "team",
+        patterns: ["*"],
+        ruleset,
+      })
+      yield* expectPermissionDenied({
+        sessionID: chat.id,
+        permission: "background",
+        patterns: ["*"],
+        ruleset,
+      })
+      yield* expectPermissionDenied({
+        sessionID: chat.id,
+        permission: "task",
+        patterns: ["*"],
+        ruleset,
+      })
+    }),
+  { config: cfg },
+)
+
+it.instance("prompt tool toggles preserve external directory permission for actual read tool calls", () =>
+  Effect.gen(function* () {
+    const { dir, llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const permission = yield* Permission.Service
+    const sessions = yield* Session.Service
+    const external = path.join(path.dirname(dir), "toggle-external.txt")
+    const chat = yield* sessions.create({
+      title: "Worker",
+      permission: [
+        { permission: "*", pattern: "*", action: "allow" },
+        { permission: "external_directory", pattern: "*", action: "allow" },
+      ],
+    })
+    yield* writeText(external, "external toggle")
+
+    yield* prompt.prompt({
+      sessionID: chat.id,
+      agent: "build",
+      noReply: true,
+      parts: [{ type: "text", text: "read an external file" }],
+      tools: {
+        team: false,
+        background: false,
+        task: false,
+      },
+    })
+    yield* llm.tool("read", { filePath: external })
+    yield* llm.text("done")
+
+    const result = yield* awaitWithTimeout(
+      prompt.loop({ sessionID: chat.id }),
+      "external_directory permission ask blocked actual read tool call",
+    )
+
+    expect(result.info.role).toBe("assistant")
+    expect(result.parts.some((part) => part.type === "text" && part.text === "done")).toBe(true)
+    const tool = (yield* MessageV2.filterCompactedEffect(chat.id))
+      .flatMap((message) => message.parts)
+      .find((part): part is MessageV2.ToolPart => part.type === "tool" && part.tool === "read")
+    expect(tool?.state.status).toBe("completed")
+    if (tool?.state.status === "completed") expect(tool.state.output).toContain("external toggle")
+    expect(yield* permission.list()).toEqual([])
+  }),
 )
 
 it.instance("static loop returns assistant text through local provider", () =>
@@ -724,6 +887,71 @@ it.instance("loop continues when finish is tool-calls", () =>
       expect(result.parts.some((part) => part.type === "text" && part.text === "second")).toBe(true)
       expect(result.info.finish).toBe("stop")
     }
+  }),
+)
+
+it.instance("session allow-all prevents doom_loop prompts for repeated tool calls", () =>
+  Effect.gen(function* () {
+    const { dir, llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const permission = yield* Permission.Service
+    const sessions = yield* Session.Service
+    const session = yield* sessions.create({
+      title: "Doom loop permission",
+      permission: [{ permission: "*", pattern: "*", action: "allow" }],
+    })
+    const file = path.join(dir, "loop.txt")
+    const input = { filePath: file }
+    yield* writeText(file, "repeat")
+
+    yield* prompt.prompt({
+      sessionID: session.id,
+      agent: "build",
+      noReply: true,
+      parts: [{ type: "text", text: "read the same file repeatedly" }],
+    })
+    yield* llm.push(
+      raw({
+        chunks: [
+          { choices: [{ delta: { role: "assistant" } }] },
+          {
+            choices: [
+              {
+                delta: {
+                  tool_calls: [0, 1, 2].map((index) => ({
+                    index,
+                    id: `call_${index + 1}`,
+                    type: "function",
+                    function: { name: "read", arguments: "" },
+                  })),
+                },
+              },
+            ],
+          },
+          ...[0, 1, 2].map((index) => ({
+            choices: [{ delta: { tool_calls: [{ index, function: { arguments: JSON.stringify(input) } }] } }],
+          })),
+          { choices: [{ delta: {}, finish_reason: "tool_calls" }] },
+        ],
+      }),
+    )
+    yield* llm.text("done")
+
+    const result = yield* awaitWithTimeout(
+      prompt.loop({ sessionID: session.id }),
+      "doom_loop permission ask blocked repeated tool calls",
+    )
+
+    expect(result.info.role).toBe("assistant")
+    expect(result.parts.some((part) => part.type === "text" && part.text === "done")).toBe(true)
+    const assistant = (yield* MessageV2.filterCompactedEffect(session.id)).find(
+      (message) =>
+        message.info.role === "assistant" &&
+        message.parts.filter((part) => part.type === "tool" && part.tool === "read").length === 3,
+    )
+    expect(assistant).toBeDefined()
+    expect(yield* llm.calls).toBe(2)
+    expect(yield* permission.list()).toEqual([])
   }),
 )
 

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -12,6 +12,7 @@ import { MessageID, PartID, SessionID } from "../../src/session/schema"
 import { SessionRunState } from "@/session/run-state"
 import { SessionStatus } from "@/session/status"
 import { ModelID, ProviderID } from "../../src/provider/schema"
+import { Permission } from "@/permission"
 import { TaskTool, type TaskPromptOps } from "../../src/tool/task"
 import { Truncate } from "@/tool/truncate"
 import { ToolRegistry } from "@/tool/registry"
@@ -407,24 +408,20 @@ describe("tool.task", () => {
 
         const child = yield* sessions.get(result.metadata.sessionId)
         expect(child.parentID).toBe(chat.id)
-        expect(child.permission).toEqual([
-          {
-            permission: "todowrite",
-            pattern: "*",
-            action: "deny",
-          },
-          {
-            permission: "bash",
-            pattern: "*",
-            action: "allow",
-          },
-          {
-            permission: "read",
-            pattern: "*",
-            action: "allow",
-          },
-        ])
+        expect(Permission.evaluate("edit", "docs/task.md", child.permission ?? []).action).toBe("allow")
+        expect(Permission.evaluate("external_directory", "/tmp/outside.txt", child.permission ?? []).action).toBe(
+          "allow",
+        )
+        expect(Permission.evaluate("bash", "git status", child.permission ?? []).action).toBe("allow")
+        expect(Permission.evaluate("workflow_tool_approval", "bash: git status", child.permission ?? []).action).toBe(
+          "allow",
+        )
+        expect(Permission.evaluate("doom_loop", "bash", child.permission ?? []).action).toBe("allow")
+        expect(Permission.evaluate("todowrite", "*", child.permission ?? []).action).toBe("deny")
         expect(seen?.tools).toEqual({
+          question: false,
+          plan_enter: false,
+          plan_exit: false,
           todowrite: false,
           bash: false,
           read: false,

--- a/scripts/local-dev-deploy.sh
+++ b/scripts/local-dev-deploy.sh
@@ -8,6 +8,11 @@ GUARDRAILS_PROFILE="$ROOT/packages/guardrails/profile"
 ALLOWED_WRITE_ROOT="$HOME/.local/bin"
 ENTRYPOINT="${OPENCODE_LOCAL_ENTRYPOINT:-$ALLOWED_WRITE_ROOT/opencode}"
 LIVE_WRAPPER="${OPENCODE_LOCAL_WRAPPER:-$ALLOWED_WRITE_ROOT/opencode-live-guardrails-wrapper}"
+BUN_BIN="${BUN_BIN:-$(command -v bun 2>/dev/null || true)}"
+if [[ -z "$BUN_BIN" && -x "$HOME/.bun/bin/bun" ]]; then
+  BUN_BIN="$HOME/.bun/bin/bun"
+fi
+BUN_BIN="${BUN_BIN:-bun}"
 
 # HIGH fix (review #205, codex): enforce write boundary. Both ENTRYPOINT and
 # LIVE_WRAPPER must resolve under $HOME/.local/bin so user-supplied env vars
@@ -97,6 +102,45 @@ mark() {
   fi
 }
 
+guardrails_profile_has_team_plugin() {
+  "$BUN_BIN" --eval '
+    const config = await Bun.file(process.argv[1]).json()
+    if (!Array.isArray(config.plugin) || !config.plugin.includes("./plugins/team.ts")) {
+      console.error("missing ./plugins/team.ts in guardrails profile plugin list")
+      process.exit(1)
+    }
+  ' "$GUARDRAILS_PROFILE/opencode.json" >/dev/null
+}
+
+guardrails_team_plugin_loads() {
+  "$BUN_BIN" --conditions=browser --eval '
+    const { mkdtemp, rm } = await import("node:fs/promises")
+    const { tmpdir } = await import("node:os")
+    const { join, resolve } = await import("node:path")
+    const { pathToFileURL } = await import("node:url")
+    const config = await Bun.file(process.argv[1]).json()
+    const entry = Array.isArray(config.plugin) ? config.plugin.find((item) => item === "./plugins/team.ts") : undefined
+    if (!entry) {
+      console.error("missing ./plugins/team.ts in guardrails profile plugin list")
+      process.exit(1)
+    }
+    const dir = await mkdtemp(join(tmpdir(), "opencode-local-check-"))
+    try {
+      const mod = await import(pathToFileURL(resolve(process.argv[2], entry)).href)
+      const plugin = await mod.default({ client: {}, worktree: dir, directory: dir })
+      const missing = ["team", "background", "team_status"].filter(
+        (name) => typeof plugin?.tool?.[name]?.execute !== "function",
+      )
+      if (missing.length) {
+        console.error(`missing guardrails team tools: ${missing.join(", ")}`)
+        process.exit(1)
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  ' "$GUARDRAILS_PROFILE/opencode.json" "$GUARDRAILS_PROFILE" >/dev/null
+}
+
 repair_links() {
   mkdir -p "$ALLOWED_WRITE_ROOT" "$PACKAGE/bin"
 
@@ -128,7 +172,7 @@ EOF
 }
 
 if [[ "$mode" == "deploy" ]]; then
-  (cd "$PACKAGE" && bun run build)
+  (cd "$PACKAGE" && "$BUN_BIN" run build)
   repair_links
 elif [[ "$mode" == "fix" ]]; then
   repair_links
@@ -138,6 +182,8 @@ mark "$([[ -x "$GUARDRAILS_BIN" ]] && echo ok || echo fail)" "guardrails wrapper
 mark "$(grep -Fq "OPENCODE_CONFIG_DIR" "$GUARDRAILS_BIN" 2>/dev/null && echo ok || echo fail)" "guardrails wrapper sets OPENCODE_CONFIG_DIR"
 mark "$([[ -f "$GUARDRAILS_PROFILE/commands/auto.md" ]] && echo ok || echo fail)" "guardrails profile includes /auto"
 mark "$([[ -f "$GUARDRAILS_PROFILE/commands/plan.md" ]] && echo ok || echo fail)" "guardrails profile includes /plan"
+mark "$(guardrails_profile_has_team_plugin && echo ok || echo fail)" "guardrails profile enables team plugin"
+mark "$(guardrails_team_plugin_loads && echo ok || echo fail)" "guardrails team plugin loads team/background/team_status"
 
 entry_target="$(readlink "$ENTRYPOINT" 2>/dev/null || true)"
 mark "$([[ "$entry_target" == "$LIVE_WRAPPER" ]] && echo ok || echo fail)" "entrypoint is fixed: $ENTRYPOINT -> $LIVE_WRAPPER"


### PR DESCRIPTION
## Summary
- keep team/background worker sessions permissive while disabling recursive UI-blocking worker tools
- carry session permissions into doom-loop and workflow approval paths so workers do not stop on asks
- make normal TaskTool subagents/explorers non-interactive for delegated work while preserving Plan Mode edit-deny and parent session explicit deny ceilings
- remove remaining direct-mutation policy blockage coverage and extend local deploy smoke checks for guardrails team plugin loading

Closes #222

## Verification
- `bun test test/plugin/team.test.ts test/session/prompt.test.ts test/session/llm.test.ts test/tool/task.test.ts test/agent/plan-mode-subagent-bypass.test.ts --timeout 30000` -> 158 pass
- `bun test test/plugin/guardrail.test.ts test/plugin/guardrail-access.test.ts test/plugin/guardrail-git.test.ts test/permission/next.test.ts --timeout 30000` -> 92 pass
- `bun typecheck` from `packages/opencode` -> pass
- pre-push `bun turbo typecheck` -> 14/14 successful
- `bun x oxlint ...` -> 0 errors (warnings only)
- `bun run local:deploy` with Node 20 PATH -> build + smoke passed, local entrypoint version `0.0.0-codex-team-worker-autonomy-audit-202605201253`
- `bun run local:check` -> guardrails team plugin loading and wrapper checks passed