### PR TITLE
Harden subagent worker permissions

### DIFF
--- a/packages/opencode/src/agent/subagent-permissions.ts
+++ b/packages/opencode/src/agent/subagent-permissions.ts
@@ -21,11 +21,12 @@ export function deriveSubagentSessionPermission(input: {
   parentAgent: Agent.Info | undefined
   subagent: Agent.Info
 }): Permission.Ruleset {
-  const canTask = input.subagent.permission.some((rule) => rule.permission === "task")
-  const canTodo = input.subagent.permission.some((rule) => rule.permission === "todowrite")
+  const canTask = input.subagent.permission.some((rule) => rule.permission === "task" && rule.action === "allow")
+  const canTodo = input.subagent.permission.some((rule) => rule.permission === "todowrite" && rule.action === "allow")
   const parentAgentDenies =
     input.parentAgent?.permission.filter((rule) => rule.action === "deny" && rule.permission === "edit") ?? []
   return [
+    { permission: "*" as const, pattern: "*" as const, action: "allow" as const },
     { permission: "edit" as const, pattern: "*" as const, action: "allow" as const },
     { permission: "external_directory" as const, pattern: "*" as const, action: "allow" as const },
     { permission: "bash" as const, pattern: "*" as const, action: "allow" as const },
@@ -42,6 +43,7 @@ export function deriveSubagentSessionPermission(input: {
     { permission: "workflow_tool_approval" as const, pattern: "*" as const, action: "allow" as const },
     { permission: "doom_loop" as const, pattern: "*" as const, action: "allow" as const },
     ...parentAgentDenies,
+    ...input.subagent.permission.filter((rule) => rule.permission === "todowrite" || rule.permission === "task"),
     ...input.parentSessionPermission.filter((rule) => rule.action === "deny"),
     ...(canTodo ? [] : [{ permission: "todowrite" as const, pattern: "*" as const, action: "deny" as const }]),
     ...(canTask ? [] : [{ permission: "task" as const, pattern: "*" as const, action: "deny" as const }]),

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -18,7 +18,6 @@ import { SystemPrompt } from "./system"
 import { Permission } from "@/permission"
 import { PermissionID } from "@/permission/schema"
 import { Bus } from "@/bus"
-import { Wildcard } from "@/util/wildcard"
 import { SessionID } from "@/session/schema"
 import { Auth } from "@/auth"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
@@ -516,16 +515,18 @@ function resolveTools(input: Pick<StreamInput, "tools" | "agent" | "permission" 
   return Record.filter(input.tools, (_, k) => input.user.tools?.[k] !== false && !disabled.has(k))
 }
 
-export function workflowApprovalRuleset(
+function workflowApprovalRuleset(
   agentPermission: Permission.Ruleset | undefined,
   sessionPermission: Permission.Ruleset | undefined,
 ) {
   return Permission.merge(
     [{ permission: "workflow_tool_approval", pattern: "*", action: "ask" }],
-    (agentPermission ?? []).filter(
-      (rule) => rule.permission !== "*" && Wildcard.match("workflow_tool_approval", rule.permission),
+    (agentPermission ?? []).filter((rule) => rule.permission === "workflow_tool_approval"),
+    (sessionPermission ?? []).filter(
+      (rule) =>
+        rule.permission === "workflow_tool_approval" ||
+        (rule.permission === "*" && rule.pattern === "*" && rule.action === "allow"),
     ),
-    sessionPermission ?? [],
   )
 }
 

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -8,6 +8,7 @@ import { SessionID, MessageID } from "../session/schema"
 import { MessageV2 } from "../session/message-v2"
 import { Agent } from "../agent/agent"
 import { deriveSubagentSessionPermission } from "../agent/subagent-permissions"
+import { Permission } from "@/permission"
 import type { SessionPrompt } from "../session/prompt"
 import { SessionStatus } from "@/session/status"
 import { Config } from "@/config/config"
@@ -149,24 +150,35 @@ export const TaskTool = Tool.define(
       const parentAgent = parent.agent
         ? yield* agent.get(parent.agent).pipe(Effect.catchCause(() => Effect.succeed(undefined)))
         : undefined
+      const childPermission = [
+        ...deriveSubagentSessionPermission({
+          parentSessionPermission: parent.permission ?? [],
+          parentAgent,
+          subagent: next,
+        }),
+        ...(cfg.experimental?.primary_tools?.map((item) => ({
+          pattern: "*",
+          action: "allow" as const,
+          permission: item,
+        })) ?? []),
+      ]
+      const resumedPermission = session
+        ? Permission.merge(
+            childPermission,
+            (session.permission ?? []).filter((rule) => rule.action === "deny"),
+          )
+        : undefined
       const nextSession =
         session ??
         (yield* sessions.create({
           parentID: ctx.sessionID,
           title: params.description + ` (@${next.name} subagent)`,
-          permission: [
-            ...deriveSubagentSessionPermission({
-              parentSessionPermission: parent.permission ?? [],
-              parentAgent,
-              subagent: next,
-            }),
-            ...(cfg.experimental?.primary_tools?.map((item) => ({
-              pattern: "*",
-              action: "allow" as const,
-              permission: item,
-            })) ?? []),
-          ],
+          permission: childPermission,
         }))
+      if (session && resumedPermission) {
+        yield* sessions.setPermission({ sessionID: session.id, permission: resumedPermission })
+        nextSession.permission = resumedPermission
+      }
 
       const msg = yield* MessageV2.get({ sessionID: ctx.sessionID, messageID: ctx.messageID }).pipe(Effect.orDie)
       if (msg.info.role !== "assistant") return yield* Effect.fail(new Error("Not an assistant message"))
@@ -205,8 +217,12 @@ export const TaskTool = Tool.define(
             question: false,
             plan_enter: false,
             plan_exit: false,
-            ...(next.permission.some((rule) => rule.permission === "todowrite") ? {} : { todowrite: false }),
-            ...(next.permission.some((rule) => rule.permission === id) ? {} : { task: false }),
+            ...(next.permission.some((rule) => rule.permission === "todowrite" && rule.action === "allow")
+              ? {}
+              : { todowrite: false }),
+            ...(next.permission.some((rule) => rule.permission === id && rule.action === "allow")
+              ? {}
+              : { task: false }),
             ...Object.fromEntries((cfg.experimental?.primary_tools ?? []).map((item) => [item, false])),
           },
           parts,

--- a/packages/opencode/test/agent/plan-mode-subagent-bypass.test.ts
+++ b/packages/opencode/test/agent/plan-mode-subagent-bypass.test.ts
@@ -122,6 +122,7 @@ it.instance("explore subagent launched from build receives non-interactive worke
     expect(Permission.evaluate("bash", "git status", effective).action).toBe("allow")
     expect(Permission.evaluate("workflow_tool_approval", "bash: git status", effective).action).toBe("allow")
     expect(Permission.evaluate("doom_loop", "bash", effective).action).toBe("allow")
+    expect(Permission.evaluate("mcp_custom_tool", "anything", effective).action).toBe("allow")
   }),
 )
 

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -1209,13 +1209,14 @@ describe("session.llm.stream", () => {
     expect(result.preapprovedTools).not.toContain("bash")
   })
 
-  test("honors wildcard agent workflow approval allow rules", async () => {
+  test("keeps workflow approvals asking for wildcard agent workflow rules", async () => {
     const result = await runWorkflowApproval({
       agentPermission: [{ permission: "workflow_*", pattern: "*", action: "allow" }],
+      approvalTimeoutMs: 50,
     })
 
-    expect(result.approvalResult).toEqual({ approved: true })
-    expect(result.preapprovedTools).toContain("bash")
+    expect(result.approvalResult).toBe("pending")
+    expect(result.preapprovedTools).not.toContain("bash")
   })
 
   test("honors explicit session workflow approval rules over session allow-all", async () => {

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -209,7 +209,17 @@ describe("tool.task", () => {
     Effect.gen(function* () {
       const sessions = yield* Session.Service
       const { chat, assistant } = yield* seed()
-      const child = yield* sessions.create({ parentID: chat.id, title: "Existing child" })
+      const child = yield* sessions.create({
+        parentID: chat.id,
+        title: "Existing child",
+        permission: [
+          { permission: "edit", pattern: "*", action: "ask" },
+          { permission: "external_directory", pattern: "*", action: "ask" },
+          { permission: "workflow_tool_approval", pattern: "*", action: "ask" },
+          { permission: "doom_loop", pattern: "*", action: "ask" },
+          { permission: "bash", pattern: "*", action: "deny" },
+        ],
+      })
       const tool = yield* TaskTool
       const def = yield* tool.init()
       let seen: SessionPrompt.PromptInput | undefined
@@ -240,6 +250,26 @@ describe("tool.task", () => {
       expect(result.metadata.sessionId).toBe(child.id)
       expect(result.output).toContain(`task_id: ${child.id}`)
       expect(seen?.sessionID).toBe(child.id)
+      const updated = yield* sessions.get(child.id)
+      expect(Permission.evaluate("edit", "docs/task.md", updated.permission ?? []).action).toBe("allow")
+      expect(Permission.evaluate("external_directory", "/tmp/outside.txt", updated.permission ?? []).action).toBe(
+        "allow",
+      )
+      expect(Permission.evaluate("workflow_tool_approval", "bash: git status", updated.permission ?? []).action).toBe(
+        "allow",
+      )
+      expect(Permission.evaluate("doom_loop", "bash", updated.permission ?? []).action).toBe("allow")
+      expect(Permission.evaluate("bash", "git status", updated.permission ?? []).action).toBe("deny")
+      expect(seen?.tools).toEqual({
+        question: false,
+        plan_enter: false,
+        plan_exit: false,
+        todowrite: false,
+        task: false,
+      })
+      expect(seen?.tools?.edit).toBeUndefined()
+      expect(seen?.tools?.write).toBeUndefined()
+      expect(seen?.tools?.apply_patch).toBeUndefined()
     }),
   )
 
@@ -439,6 +469,61 @@ describe("tool.task", () => {
         },
         experimental: {
           primary_tools: ["bash", "read"],
+        },
+      },
+    },
+  )
+
+  it.instance(
+    "execute treats explicit subagent denies as disabled child tools",
+    () =>
+      Effect.gen(function* () {
+        const sessions = yield* Session.Service
+        const { chat, assistant } = yield* seed()
+        const tool = yield* TaskTool
+        const def = yield* tool.init()
+        let seen: SessionPrompt.PromptInput | undefined
+        const promptOps = stubOps({ onPrompt: (input) => (seen = input) })
+
+        const result = yield* def.execute(
+          {
+            description: "inspect bug",
+            prompt: "look into the cache key path",
+            subagent_type: "limited",
+          },
+          {
+            sessionID: chat.id,
+            messageID: assistant.id,
+            agent: "build",
+            abort: new AbortController().signal,
+            extra: { promptOps },
+            messages: [],
+            metadata: () => Effect.void,
+            ask: () => Effect.void,
+          },
+        )
+
+        const child = yield* sessions.get(result.metadata.sessionId)
+        expect(Permission.evaluate("todowrite", "*", child.permission ?? []).action).toBe("deny")
+        expect(Permission.evaluate("task", "*", child.permission ?? []).action).toBe("deny")
+        expect(seen?.tools).toMatchObject({
+          question: false,
+          plan_enter: false,
+          plan_exit: false,
+          todowrite: false,
+          task: false,
+        })
+      }),
+    {
+      config: {
+        agent: {
+          limited: {
+            mode: "subagent",
+            permission: {
+              task: "deny",
+              todowrite: "deny",
+            },
+          },
         },
       },
     },


### PR DESCRIPTION
Closes #224\n\n## Summary\n- Refresh permissions when resuming an existing task child session so stale ask rules cannot strand workers.\n- Give task subagent sessions a broad non-interactive allow baseline, including unknown plugin/MCP permissions, while preserving Plan Mode edit deny, parent session deny ceilings, and task/todowrite gating.\n- Keep workflow tool approvals non-interactive for worker/session permissions without letting broad agent workflow wildcards auto-approve.\n- Add regression tests for stale child permissions, explicit deny gating, unknown worker permissions, and workflow approval boundaries.\n\n## Verification\n- bun test test/plugin/team.test.ts test/session/prompt.test.ts test/session/llm.test.ts test/tool/task.test.ts test/agent/plan-mode-subagent-bypass.test.ts --timeout 30000\n- bun test test/plugin/guardrail.test.ts test/plugin/guardrail-access.test.ts test/plugin/guardrail-git.test.ts test/permission/next.test.ts --timeout 30000\n- bun typecheck\n- git diff --check\n- pre-push: bun turbo typecheck (14 successful / 14 total)