### PR TITLE
feat(guardrails): add standalone git-guard plugin

### DIFF
--- a/packages/guardrails/profile/plugins/git-guard.ts
+++ b/packages/guardrails/profile/plugins/git-guard.ts
@@ -1,0 +1,107 @@
+// git-guard: 保護ブランチへの直接 push・merge を禁止する OpenCode plugin。
+//
+// 単層構造:
+//   tool.execute.before hook: 実行時にブランチ名を見て main/master/develop/dev への
+//   push/merge をブロック。例外を投げて tool 実行を停止する。
+//
+// 注: config hook による permission.bash の mutation は機能しない。
+//   permission system は plugin load 前に config から Ruleset を構築するため、
+//   config hook での cfg.permission.bash への書き込みは評価に反映されない。
+//   bash permission は opencode.jsonc の permission.bash セクションで直接管理すること。
+//
+// 補完関係:
+//   guardrail-git.ts が包括的な保護 (CI gate, review gate, PR merge block 等) を
+//   提供する。本プラグインは guardrail.ts がロードされない環境での最低限の
+//   保護として機能する。両方がロードされた場合、二重ガードとなる (先に
+//   実行された hook の throw が tool 実行を停止するため、後続 hook は未到達)。
+//
+// 既知の限界: サブエージェント/MCP 経由のツール呼び出しには発火しない
+//   (sst/opencode #5894, #2319)。
+
+import type { PluginInput } from "@opencode-ai/plugin"
+
+const PROTECTED = ["main", "master", "develop", "dev"]
+
+// git subcommand を安全に検出 (git -C ... や git -c ... 等の引数をスキップ)
+const shellWord = `(?:"[^"]+"|'[^']+'|\\S+)`
+const gitSubcommand =
+  (name: string) =>
+  (cmd: string): boolean =>
+    new RegExp(
+      `\\bgit(?:\\s+-C\\s+${shellWord}|\\s+-c\\s+${shellWord}|\\s+--(?:git-dir|work-tree|namespace)=${shellWord}|\\s+--(?:git-dir|work-tree|namespace)\\s+${shellWord})*\\s+${name}\\b`,
+      "i",
+    ).test(cmd)
+
+const isPush = gitSubcommand("push")
+const isMerge = gitSubcommand("merge")
+
+// 明示的な ref 指定から保護ブランチを検出
+// "origin main" / "origin/main" / "HEAD:main" 等を検出
+// feat/develop-x 等は除外
+const explicitRefTargetsProtected = (cmd: string): boolean => {
+  // "git push origin main" / "git push origin HEAD:main"
+  const pushRef = cmd.match(
+    /\bgit\s+push\s+(?:(?:-\w+|--[\w-]+)\s+)*\S+\s+(?:HEAD:)?(\S+)/i,
+  )
+  if (pushRef && PROTECTED.includes(pushRef[1])) return true
+
+  // "HEAD:main" style refspec
+  const refspec = new RegExp(`HEAD:(${PROTECTED.join("|")})(?:\\s|$)`, "i")
+  if (refspec.test(cmd)) return true
+
+  return false
+}
+
+export default async function gitGuard(input: PluginInput) {
+  const { $ } = input
+
+  return {
+    // ---------------------------------------------------------------
+    // tool.execute.before: 保護ブランチへの push/merge をブロック
+    // ---------------------------------------------------------------
+    "tool.execute.before": async (
+      input: { tool: string },
+      output: { args: Record<string, unknown> },
+    ) => {
+      if (input.tool !== "bash") return
+      const cmd = String(output.args?.command ?? "")
+      if (!cmd) return
+
+      const pushes = isPush(cmd)
+      const merges = isMerge(cmd)
+      if (!pushes && !merges) return
+
+      // bash コマンドの workdir を取得して正しい branch を判定
+      const workdir = typeof output.args?.workdir === "string" ? output.args.workdir : undefined
+      const gitArgs = workdir ? ["-C", workdir] : []
+
+      let current = ""
+      try {
+        const result = await Bun.spawn(["git", ...gitArgs, "branch", "--show-current"], {
+          stdout: "pipe",
+          stderr: "pipe",
+        })
+        const [out] = await Promise.all([new Response(result.stdout).text(), result.exited])
+        current = out.trim()
+      } catch {
+        current = ""
+      }
+      const onProtected = PROTECTED.includes(current)
+
+      // merge: 保護ブランチ上での直接マージを禁止（PR 経由を強制）
+      if (merges && onProtected) {
+        throw new Error(
+          `保護ブランチ '${current}' への直接 merge は禁止です。PR 経由でマージしてください。`,
+        )
+      }
+
+      // push: 保護ブランチを対象にした push を禁止（force / 非force 問わず）
+      if (pushes && (explicitRefTargetsProtected(cmd) || onProtected)) {
+        throw new Error(
+          `保護ブランチ(${PROTECTED.join("/")})への直接 push は禁止です。` +
+            `feature ブランチで作業し PR を出してください。`,
+        )
+      }
+    },
+  }
+}


### PR DESCRIPTION
## Summary

Replaces the previous config-hook-based `git-guard.ts` with a corrected implementation based on upstream plugin API analysis.

## Key Changes

1. **Remove ineffective config hook** — upstream analysis confirmed that permission Rulesets are pre-parsed from config *before* plugins load. Mutating `cfg.permission.bash` in a plugin has no effect on permission evaluation. Bash permissions should be managed directly in `opencode.jsonc`.

2. **Fix workdir bug** — the old plugin used `$\`git rev-parse --abbrev-ref HEAD\`` which resolves against the session CWD, not the bash command `workdir` parameter. This caused false positives when operating across multiple git repos in one session. New version reads `output.args.workdir` and passes it to `git -C <dir> branch --show-current`.

3. **Improve git subcommand detection** — flag-aware regex (handles `git -C`, `git -c`, `--git-dir`, etc.) matching upstream `guardrail-git.ts` patterns, reducing false positives on commands that embed git strings in code.

4. **Add `dev` to protected branches** — matches upstream `guardrail-git.ts` protected list.

5. **Document complementary relationship** — this plugin is a safety net for environments where `guardrail.ts` is not loaded. When both are loaded, the first hook to throw blocks execution (belt-and-suspenders).

## Verification

```
6/6 automated tests passed:
  PASS: merge on develop blocked (workdir)
  PASS: explicit main push blocked
  PASS: git status on develop allowed
  PASS: git commit on develop allowed
  PASS: push on develop blocked (implicit)
  PASS: push on feature branch allowed
```

## Files Changed

- `packages/guardrails/profile/plugins/git-guard.ts` — new standalone plugin (replaces `~/.config/opencode/plugins/git-guard.ts`)