### PR TITLE
feat(core): models.devのreasoning optionsを反映

### DIFF
--- a/packages/core/src/models-dev.ts
+++ b/packages/core/src/models-dev.ts
@@ -41,6 +41,21 @@ const Cost = Schema.Struct({
   ),
 })
 
+const ReasoningOption = Schema.Union([
+  Schema.Struct({
+    type: Schema.Literal("effort"),
+    values: Schema.Array(Schema.NullOr(Schema.String)),
+  }),
+  Schema.Struct({
+    type: Schema.Literal("toggle"),
+  }),
+  Schema.Struct({
+    type: Schema.Literal("budget_tokens"),
+    min: Schema.optional(Schema.Finite),
+    max: Schema.optional(Schema.Finite),
+  }),
+])
+
 export const Model = Schema.Struct({
   id: Schema.String,
   name: Schema.String,
@@ -48,6 +63,7 @@ export const Model = Schema.Struct({
   release_date: Schema.String,
   attachment: Schema.Boolean,
   reasoning: Schema.Boolean,
+  reasoning_options: Schema.optional(Schema.Array(ReasoningOption)),
   temperature: Schema.Boolean,
   tool_call: Schema.Boolean,
   interleaved: Schema.optional(

--- a/packages/core/src/plugin/models-dev.ts
+++ b/packages/core/src/plugin/models-dev.ts
@@ -38,12 +38,29 @@ function cost(input: ModelsDev.Model["cost"]) {
   ]
 }
 
-function variants(model: ModelsDev.Model) {
-  return Object.entries(model.experimental?.modes ?? {}).map(([id, item]) => ({
+function variants(model: ModelsDev.Model, packageName?: string) {
+  const modes = Object.entries(model.experimental?.modes ?? {})
+  if (modes.length === 0) return reasoningOptionVariants(model, packageName)
+  return modes.map(([id, item]) => ({
     id: ModelV2.VariantID.make(id),
     headers: { ...(item.provider?.headers ?? {}) },
     body: { ...(item.provider?.body ?? {}) },
   }))
+}
+
+function reasoningOptionVariants(model: ModelsDev.Model, packageName?: string) {
+  const effort = model.reasoning_options?.find((item) => item.type === "effort")
+  if (!effort || packageName !== "@ai-sdk/openai-compatible") return []
+  return effort.values.flatMap((value) => {
+    if (typeof value !== "string") return []
+    return [
+      {
+        id: ModelV2.VariantID.make(value),
+        headers: {},
+        body: { reasoningEffort: value },
+      },
+    ]
+  })
 }
 
 export const ModelsDevPlugin = PluginV2.define({
@@ -98,7 +115,7 @@ export const ModelsDevPlugin = PluginV2.define({
                 input: [...(model.modalities?.input ?? [])],
                 output: [...(model.modalities?.output ?? [])],
               }
-              draft.variants = variants(model)
+              draft.variants = variants(model, model.provider?.npm ?? item.npm)
               draft.time.released = released(model.release_date)
               draft.cost = cost(model.cost)
               draft.status = model.status ?? "active"

--- a/packages/core/test/plugin/fixtures/models-dev.json
+++ b/packages/core/test/plugin/fixtures/models-dev.json
@@ -1,0 +1,81 @@
+{
+  "acme": {
+    "id": "acme",
+    "name": "Acme",
+    "env": ["ACME_API_KEY"],
+    "models": {}
+  },
+  "local": {
+    "id": "local",
+    "name": "Local",
+    "env": [],
+    "models": {}
+  },
+  "zai-coding-plan": {
+    "id": "zai-coding-plan",
+    "name": "Z.AI Coding Plan",
+    "env": [],
+    "npm": "@ai-sdk/openai-compatible",
+    "api": "https://api.z.ai/api/coding/paas/v4",
+    "models": {
+      "glm-5.2": {
+        "id": "glm-5.2",
+        "name": "GLM-5.2",
+        "family": "glm",
+        "release_date": "2026-06-13",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["high", "max"]
+          }
+        ],
+        "temperature": true,
+        "tool_call": true,
+        "limit": {
+          "context": 1000000,
+          "output": 131072
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        }
+      },
+      "mode-priority": {
+        "id": "mode-priority",
+        "name": "Mode Priority",
+        "family": "glm",
+        "release_date": "2026-06-13",
+        "attachment": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["high", "max"]
+          }
+        ],
+        "temperature": true,
+        "tool_call": true,
+        "experimental": {
+          "modes": {
+            "custom": {
+              "provider": {
+                "body": {
+                  "reasoningEffort": "high"
+                },
+                "headers": {
+                  "x-model-mode": "custom"
+                }
+              }
+            }
+          }
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 131072
+        }
+      }
+    }
+  }
+}

--- a/packages/core/test/plugin/models-dev.test.ts
+++ b/packages/core/test/plugin/models-dev.test.ts
@@ -1,0 +1,83 @@
+import path from "path"
+import { describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { Catalog } from "@opencode-ai/core/catalog"
+import { EventV2 } from "@opencode-ai/core/event"
+import { Flag } from "@opencode-ai/core/flag/flag"
+import { Location } from "@opencode-ai/core/location"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { ModelsDev } from "@opencode-ai/core/models-dev"
+import { ModelsDevPlugin } from "@opencode-ai/core/plugin/models-dev"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { location } from "../fixture/location"
+import { testEffect } from "../lib/effect"
+
+const locationLayer = Layer.succeed(
+  Location.Service,
+  Location.Service.of(location({ directory: AbsolutePath.make(import.meta.dir) })),
+)
+const it = testEffect(
+  Catalog.locationLayer.pipe(Layer.provideMerge(EventV2.defaultLayer), Layer.provideMerge(locationLayer)),
+)
+
+function withModelsDevFixture<A, E, R>(effect: Effect.Effect<A, E, R>) {
+  return Effect.acquireUseRelease(
+    Effect.sync(() => {
+      const previous = {
+        path: Flag.OPENCODE_MODELS_PATH,
+        disabled: Flag.OPENCODE_DISABLE_MODELS_FETCH,
+      }
+      Flag.OPENCODE_MODELS_PATH = path.join(import.meta.dir, "fixtures", "models-dev.json")
+      Flag.OPENCODE_DISABLE_MODELS_FETCH = true
+      return previous
+    }),
+    () => effect.pipe(Effect.provide(ModelsDev.defaultLayer)),
+    (previous) =>
+      Effect.sync(() => {
+        Flag.OPENCODE_MODELS_PATH = previous.path
+        Flag.OPENCODE_DISABLE_MODELS_FETCH = previous.disabled
+      }),
+  )
+}
+
+describe("ModelsDevPlugin", () => {
+  it.effect("synthesizes effort reasoning option variants", () =>
+    withModelsDevFixture(
+      Effect.gen(function* () {
+        yield* ModelsDevPlugin.effect
+        const catalog = yield* Catalog.Service
+        const model = yield* catalog.model.get(ProviderV2.ID.make("zai-coding-plan"), ModelV2.ID.make("glm-5.2"))
+        expect(model.variants).toEqual([
+          {
+            id: ModelV2.VariantID.make("high"),
+            headers: {},
+            body: { reasoningEffort: "high" },
+          },
+          {
+            id: ModelV2.VariantID.make("max"),
+            headers: {},
+            body: { reasoningEffort: "max" },
+          },
+        ])
+      }),
+    ),
+  )
+
+  it.effect("keeps experimental modes higher priority than reasoning options", () =>
+    withModelsDevFixture(
+      Effect.gen(function* () {
+        yield* ModelsDevPlugin.effect
+        const catalog = yield* Catalog.Service
+        const model = yield* catalog.model.get(ProviderV2.ID.make("zai-coding-plan"), ModelV2.ID.make("mode-priority"))
+        expect(model.variants).toEqual([
+          {
+            id: ModelV2.VariantID.make("custom"),
+            headers: { "x-model-mode": "custom" },
+            body: { reasoningEffort: "high" },
+          },
+        ])
+      }),
+    ),
+  )
+})


### PR DESCRIPTION
## ① なぜ

models.dev が `reasoning_options` を公開し始め、Z.AI Coding Plan の `glm-5.2` でも `high` / `max` の effort variant がカタログ情報として表現されるようになりました。

既存の `experimental.modes` だけを見る実装のままだと、この新しいカタログ表現を opencode 側の model variant として露出できません。

## ② どう実装したか

- `models.dev` の model schema に `reasoning_options` を追加しました。
- `@ai-sdk/openai-compatible` では `effort` の文字列値を `reasoningEffort` body として deterministic に variant 化します。
- `toggle` / `budget_tokens` は wire shape を推測せず、schema で受け入れるだけにしています。
- 既存の `experimental.modes` がある場合は従来通りそちらを優先します。

## ③ 特にレビューしてほしい点

- unknown provider では `reasoningEffort` を推測して追加せず、openai-compatible の既存処理に限定している点。
- `experimental.modes` の優先順位を維持したまま、新しい `reasoning_options` を補助的に扱えている点。
- `effort.values` に `null` が含まれる models.dev 現行データを受け入れつつ、variant 化は文字列値だけに限定する方針。

## ④ テスト内容・確認方法

- `packages/core`: `bun test test/plugin/models-dev.test.ts` → 2 pass
- `packages/core`: `bun typecheck` → pass
- `packages/opencode`: `bun test test/provider/transform.test.ts test/plugin/trigger.test.ts --timeout 30000` → 250 pass
- `packages/opencode`: `bun typecheck` → pass
- push hook: `bun turbo typecheck` → 22 successful
