### PR TITLE
fix(guardrails): fork以外のPR作成を防止

### DIFF
--- a/packages/guardrails/profile/plugins/git-guard.ts
+++ b/packages/guardrails/profile/plugins/git-guard.ts
@@ -21,6 +21,9 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 
 const PROTECTED = ["main", "master", "develop", "dev"]
+const OPENCODE_FORK_REPO = "Cor-Incorporated/opencode"
+const OPENCODE_UPSTREAM_REPO = "anomalyco/opencode"
+const OPENCODE_BASE = "dev"
 
 // git subcommand を安全に検出 (git -C ... や git -c ... 等の引数をスキップ)
 const shellWord = `(?:"[^"]+"|'[^']+'|\\S+)`
@@ -35,14 +38,25 @@ const gitSubcommand =
 const isPush = gitSubcommand("push")
 const isMerge = gitSubcommand("merge")
 
+const shellValue = (value: string) => value.replace(/^["']|["']$/g, "")
+
+const optionValue = (cmd: string, long: string, short: string) => {
+  const escaped = long.replaceAll("-", "\\-")
+  return (
+    cmd.match(new RegExp(`(?:^|\\s)${escaped}=([^\\s]+)`))?.[1] ??
+    cmd.match(new RegExp(`(?:^|\\s)${escaped}\\s+([^\\s]+)`))?.[1] ??
+    cmd.match(new RegExp(`(?:^|\\s)${short}\\s+([^\\s]+)`))?.[1] ??
+    cmd.match(new RegExp(`(?:^|\\s)${short}([^\\s]+)`))?.[1] ??
+    ""
+  )
+}
+
 // 明示的な ref 指定から保護ブランチを検出
 // "origin main" / "origin/main" / "HEAD:main" 等を検出
 // feat/develop-x 等は除外
 const explicitRefTargetsProtected = (cmd: string): boolean => {
   // "git push origin main" / "git push origin HEAD:main"
-  const pushRef = cmd.match(
-    /\bgit\s+push\s+(?:(?:-\w+|--[\w-]+)\s+)*\S+\s+(?:HEAD:)?(\S+)/i,
-  )
+  const pushRef = cmd.match(/\bgit\s+push\s+(?:(?:-\w+|--[\w-]+)\s+)*\S+\s+(?:HEAD:)?(\S+)/i)
   if (pushRef && PROTECTED.includes(pushRef[1])) return true
 
   // "HEAD:main" style refspec
@@ -52,32 +66,80 @@ const explicitRefTargetsProtected = (cmd: string): boolean => {
   return false
 }
 
-export default async function gitGuard(input: PluginInput) {
-  const { $ } = input
+const gitArgs = (workdir: string | undefined) => (workdir ? ["-C", workdir] : [])
 
+const isOpencodeWorktree = async (workdir: string | undefined) => {
+  try {
+    const result = await Bun.spawn(["git", ...gitArgs(workdir), "remote", "-v"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const [out, code] = await Promise.all([new Response(result.stdout).text(), result.exited])
+    return code === 0 && /github\.com[:/](Cor-Incorporated|anomalyco)\/opencode(?:\.git)?/i.test(out)
+  } catch {
+    return false
+  }
+}
+
+const blockWrongOpencodePrTarget = async (cmd: string, workdir: string | undefined) => {
+  if (!/\bgh\s+pr\s+create\b/i.test(cmd) && !/\bgh\s+api\b[\s\S]*\brepos\/[^/\s]+\/[^/\s]+\/pulls\b/i.test(cmd)) {
+    return
+  }
+  if (!(await isOpencodeWorktree(workdir))) return
+
+  if (/\bgh\s+api\b[\s\S]*\brepos\/anomalyco\/opencode\/pulls\b/i.test(cmd)) {
+    throw new Error(
+      `opencode の PR 作成先は fork の ${OPENCODE_FORK_REPO}:${OPENCODE_BASE} です。` +
+        ` upstream の ${OPENCODE_UPSTREAM_REPO} 宛て PR 作成は禁止です。`,
+    )
+  }
+
+  if (!/\bgh\s+pr\s+create\b/i.test(cmd)) return
+  const repo = shellValue(optionValue(cmd, "--repo", "-R"))
+  const base = shellValue(optionValue(cmd, "--base", "-B"))
+  const head = shellValue(optionValue(cmd, "--head", "-H"))
+
+  if (repo !== OPENCODE_FORK_REPO) {
+    throw new Error(
+      `opencode の PR 作成先は fork の ${OPENCODE_FORK_REPO} です。` +
+        ` gh pr create には --repo ${OPENCODE_FORK_REPO} を明示してください。`,
+    )
+  }
+  if (base !== OPENCODE_BASE) {
+    throw new Error(
+      `opencode の PR base は ${OPENCODE_FORK_REPO}:${OPENCODE_BASE} です。` +
+        ` gh pr create には --base ${OPENCODE_BASE} を明示してください。`,
+    )
+  }
+  if (head.toLowerCase().startsWith("anomalyco:")) {
+    throw new Error(
+      `opencode の PR head は origin / ${OPENCODE_FORK_REPO} 側にしてください。` +
+        ` upstream (${OPENCODE_UPSTREAM_REPO}) を head にした PR 作成は禁止です。`,
+    )
+  }
+}
+
+export default async function gitGuard(input: PluginInput) {
   return {
     // ---------------------------------------------------------------
     // tool.execute.before: 保護ブランチへの push/merge をブロック
     // ---------------------------------------------------------------
-    "tool.execute.before": async (
-      input: { tool: string },
-      output: { args: Record<string, unknown> },
-    ) => {
+    "tool.execute.before": async (input: { tool: string }, output: { args: Record<string, unknown> }) => {
       if (input.tool !== "bash") return
       const cmd = String(output.args?.command ?? "")
       if (!cmd) return
+
+      const workdir = typeof output.args?.workdir === "string" ? output.args.workdir : undefined
+      await blockWrongOpencodePrTarget(cmd, workdir)
 
       const pushes = isPush(cmd)
       const merges = isMerge(cmd)
       if (!pushes && !merges) return
 
       // bash コマンドの workdir を取得して正しい branch を判定
-      const workdir = typeof output.args?.workdir === "string" ? output.args.workdir : undefined
-      const gitArgs = workdir ? ["-C", workdir] : []
-
       let current = ""
       try {
-        const result = await Bun.spawn(["git", ...gitArgs, "branch", "--show-current"], {
+        const result = await Bun.spawn(["git", ...gitArgs(workdir), "branch", "--show-current"], {
           stdout: "pipe",
           stderr: "pipe",
         })
@@ -90,9 +152,7 @@ export default async function gitGuard(input: PluginInput) {
 
       // merge: 保護ブランチ上での直接マージを禁止（PR 経由を強制）
       if (merges && onProtected) {
-        throw new Error(
-          `保護ブランチ '${current}' への直接 merge は禁止です。PR 経由でマージしてください。`,
-        )
+        throw new Error(`保護ブランチ '${current}' への直接 merge は禁止です。PR 経由でマージしてください。`)
       }
 
       // push: 保護ブランチを対象にした push を禁止（force / 非force 問わず）


### PR DESCRIPTION
## ① なぜ

opencode の fork 運用では、`upstream` / `anomalyco/opencode` は最新変更の取得元であり、PR 作成・merge の対象は fork の `Cor-Incorporated/opencode:dev` です。

この target を誤ると upstream 側に不要な PR を作成してしまうため、手順記憶だけではなく plugin 側で `gh pr create` を検査します。

## ② どう実装したか

- standalone `git-guard.ts` に opencode worktree 判定を追加しました。
- `gh pr create` 実行時に `--repo Cor-Incorporated/opencode` と `--base dev` の明示を要求します。
- `--repo anomalyco/opencode` や `gh api repos/anomalyco/opencode/pulls` による upstream PR 作成をブロックします。
- `--head anomalyco:...` もブロックし、origin / fork 側 head を強制します。

## ③ 特にレビューしてほしい点

- fork 側 PR 作成を明示必須にしている点が、通常運用の安全側として過剰でないか。
- `gh pr create` と `gh api .../pulls` の両方を止める検出条件に抜けがないか。

## ④ テスト内容・確認方法

- `bun --check packages/guardrails/profile/plugins/git-guard.ts` → pass
- `bunx prettier --check packages/guardrails/profile/plugins/git-guard.ts` → pass
