### PR TITLE
fix(guardrails): UAT証跡guardの誤検知を修正

### DIFF
--- a/packages/guardrails/profile/plugins/guardrail-git.ts
+++ b/packages/guardrails/profile/plugins/guardrail-git.ts
@@ -408,13 +408,68 @@ export function createGitHandlers(ctx: GuardrailContext, review: Review) {
     )
   }
 
-  function uatEvidenceCommand(cmd: string) {
+  function ghIssueCloseCommand(cmd: string) {
+    if (/\bgh\s+issue\s+close\b/i.test(cmd)) return true
+    if (/\bgh\s+issue\s+edit\b/i.test(cmd) && /\s--state(?:=|\s+)closed\b/i.test(cmd)) return true
+    return ghApiIssueCloseMutation(cmd)
+  }
+
+  function ghApiIssueCloseMutation(cmd: string) {
+    return ghCommandTokens(cmd).some((tokens) => {
+      const apiIndex = tokens.findIndex((token) => token === "api")
+      if (apiIndex === -1) return false
+      const endpoint = tokens
+        .slice(apiIndex + 1)
+        .map((token) =>
+          token
+            .replace(/^https:\/\/api\.github\.com\//i, "")
+            .replace(/^\/+/, "")
+            .replace(/\?.*$/, "")
+            .replace(/\/+$/, ""),
+        )
+        .find((token) => /^repos\/[^/]+\/[^/]+\/issues\/\d+$/i.test(token))
+      if (!endpoint) return false
+      const method = ghApiMethod(tokens)
+      if (method === "GET") return false
+      if (method && !["PATCH", "PUT"].includes(method)) return false
+      return (
+        ghApiField(tokens, "state").toLowerCase() === "closed" ||
+        /\bstate=(?:closed|completed)\b|["']state["']\s*:\s*["']closed["']/i.test(cmd)
+      )
+    })
+  }
+
+  function uatLifecycleCommand(cmd: string) {
+    return ghIssueCloseCommand(cmd) || ghPrCommand(cmd, "merge") || ghPrCommand(cmd, "ready") || ghApiPrMerge(cmd)
+  }
+
+  function uatStatusCommand(cmd: string) {
     return (
-      /\bgh\s+issue\s+(?:create|close|comment|edit)\b/i.test(cmd) ||
-      /\bgh\s+pr\s+(?:merge|ready|comment|review)\b/i.test(cmd) ||
-      ghApiPrMerge(cmd) ||
+      /\bgh\s+issue\s+(?:create|comment|edit)\b/i.test(cmd) ||
+      /\bgh\s+pr\s+(?:create|comment|review)\b/i.test(cmd) ||
       ghApiIssueMutation(cmd)
     )
+  }
+
+  function uatCompletionDeclaration(cmd: string) {
+    return (
+      /\b(?:close|closing|closed|merge|merged|ready\s+for\s+review|pr\s+ready|mark(?:ed)?\s+ready|ready\s+to\s+(?:close|merge|ship))\b/i.test(
+        cmd,
+      ) ||
+      /\b(?:UAT|UX|E2E|end-to-end|browser[- ]tested|browser[- ]verified|browser verification|browser test(?:ed|ing)?|live verification|live smoke|user journey|manual QA)\b[\s\S]{0,120}\b(?:complete|completed|done|pass(?:ed)?|verified|confirmed|resolved|fixed|ready)\b/i.test(
+        cmd,
+      ) ||
+      /\b(?:complete|completed|done|pass(?:ed)?|verified|confirmed|resolved|fixed|ready)\b[\s\S]{0,120}\b(?:UAT|UX|E2E|end-to-end|browser[- ]tested|browser[- ]verified|browser verification|browser test(?:ed|ing)?|live verification|live smoke|user journey|manual QA)\b/i.test(
+        cmd,
+      ) ||
+      /(?:操作テスト|ブラウザ|受入|検証)[\s\S]{0,120}(?:完了|確認済|検証済|テスト済|解決|修正済)|(?:完了|確認済|検証済|テスト済|解決|修正済)[\s\S]{0,120}(?:操作テスト|ブラウザ|受入|検証)/i.test(
+        cmd,
+      )
+    )
+  }
+
+  function uatEvidenceCommand(cmd: string) {
+    return uatLifecycleCommand(cmd) || (uatStatusCommand(cmd) && uatCompletionDeclaration(cmd))
   }
 
   function ghApiIssueMutation(cmd: string) {
@@ -445,15 +500,16 @@ export function createGitHandlers(ctx: GuardrailContext, review: Review) {
       flag(data.ux_evidence_required) ||
       flag(data.e2e_evidence_required) ||
       flag(data.browser_evidence_required) ||
-      /\b(?:UAT|UX|E2E|end-to-end|browser[- ]tested|browser[- ]verified|browser verification|browser test(?:ed|ing)?|live verification|live smoke|user journey|acceptance criteria|manual QA|issue close|close issue|closed issue)\b|操作テスト|ブラウザ|テスト済|検証済|確認済|完了|β\s*Ready|クローズ|マージ済/i.test(
+      /\b(?:UAT|UX|E2E|end-to-end|browser[- ]tested|browser[- ]verified|browser verification|browser test(?:ed|ing)?|live verification|live smoke|user journey|acceptance criteria|manual QA)\b|操作テスト|ブラウザ/i.test(
         cmd,
       )
     )
   }
 
-  function blockerIssueCommand(cmd: string) {
-    if (!/\bgh\s+issue\s+(?:create|close|comment|edit)\b/i.test(cmd) && !ghApiIssueMutation(cmd)) return false
-    return /\b(?:blocker|blocked|unverified-restart-condition|restart condition|unable to verify|cannot verify|verification blocked|blocked by)\b/i.test(
+  function nonFinalUatStatusCommand(cmd: string) {
+    if (uatLifecycleCommand(cmd)) return false
+    if (!uatStatusCommand(cmd)) return false
+    return /\b(?:blocker|blocked|unverified|not\s+verified|unverified-restart-condition|restart condition|unable to verify|cannot verify|verification blocked|blocked by|investigat(?:e|ion)|research|plan(?:ning)?|read-only|triage|status update|draft|proposal|follow-up|followup)\b|未検証|未確認|未取得|調査|計画|ブロッカー|保留/i.test(
       cmd,
     )
   }
@@ -495,8 +551,8 @@ export function createGitHandlers(ctx: GuardrailContext, review: Review) {
   async function blockMissingUatEvidence(cmd: string, data: Record<string, unknown>) {
     if (!uatEvidenceCommand(cmd)) return
     if (!uatScoped(cmd, data)) return
-    if (blockerIssueCommand(cmd)) {
-      await ctx.seen("uat_evidence.blocker_allowed", { command: cmd.slice(0, 500) })
+    if (nonFinalUatStatusCommand(cmd)) {
+      await ctx.seen("uat_evidence.non_final_status_allowed", { command: cmd.slice(0, 500) })
       return
     }
     if (hasUatEvidence(cmd, data)) {

--- a/packages/opencode/test/plugin/guardrail-git.test.ts
+++ b/packages/opencode/test/plugin/guardrail-git.test.ts
@@ -253,6 +253,78 @@ describe("guardrail-git", () => {
     ).rejects.toThrow("UAT/UX/E2E/browser-tested issue or PR completion requires browser/live evidence markers")
   })
 
+  test("allows read-only UAT planning and investigation shell commands", async () => {
+    await using fixture = await context()
+    const git = createGitHandlers(fixture.ctx, review())
+
+    await expect(
+      git.bashBeforeGit(
+        "rg -n 'UAT evidence plan investigation unverified blocker completion close merge PR ready' packages/guardrails",
+        {},
+        {},
+      ),
+    ).resolves.toBeUndefined()
+  })
+
+  test("allows UAT investigation comments that explicitly stay unverified", async () => {
+    await using fixture = await context()
+    const git = createGitHandlers(fixture.ctx, review())
+
+    await expect(
+      git.bashBeforeGit(
+        "gh issue comment 42 --body 'Investigation complete: UAT remains unverified; blocker is OAuth sandbox outage. No browser evidence captured yet.'",
+        {},
+        {},
+      ),
+    ).resolves.toBeUndefined()
+
+    expect(fixture.marks).toHaveLength(0)
+  })
+
+  test("allows UAT planning status comments without browser evidence", async () => {
+    await using fixture = await context()
+    const git = createGitHandlers(fixture.ctx, review())
+
+    await expect(
+      git.bashBeforeGit(
+        "gh issue comment 42 --body 'Plan complete for UAT verification: inspect login flow, then capture browser evidence before close.'",
+        {},
+        {},
+      ),
+    ).resolves.toBeUndefined()
+  })
+
+  test("blocks UAT completion comments without browser or live evidence", async () => {
+    await using fixture = await context()
+    const git = createGitHandlers(fixture.ctx, review())
+
+    await expect(
+      git.bashBeforeGit("gh issue comment 42 --body 'UAT login flow complete and ready to close'", {}, {}),
+    ).rejects.toThrow("UAT/UX/E2E/browser-tested issue or PR completion requires browser/live evidence markers")
+  })
+
+  test("blocks UAT PR ready commands without browser or live evidence", async () => {
+    await using fixture = await context()
+    const git = createGitHandlers(fixture.ctx, review())
+
+    await expect(git.bashBeforeGit("gh pr ready 42 # UX UAT ready for review", {}, {})).rejects.toThrow(
+      "UAT/UX/E2E/browser-tested issue or PR completion requires browser/live evidence markers",
+    )
+  })
+
+  test("blocks GitHub API issue close mutations without browser or live evidence", async () => {
+    await using fixture = await context()
+    const git = createGitHandlers(fixture.ctx, review())
+
+    await expect(
+      git.bashBeforeGit(
+        "gh api -X PATCH repos/Cor-Incorporated/opencode/issues/42 -f state=closed -f body='UAT complete'",
+        {},
+        {},
+      ),
+    ).rejects.toThrow("UAT/UX/E2E/browser-tested issue or PR completion requires browser/live evidence markers")
+  })
+
   test("allows UAT issue close commands with browser and live evidence markers", async () => {
     await using fixture = await context()
     const git = createGitHandlers(fixture.ctx, review())

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1024,7 +1024,7 @@ it.instance(
         expect(exit.value.info.role).toBe("assistant")
       }
     }),
-  3_000,
+  10_000,
 )
 
 it.instance(
@@ -1050,7 +1050,7 @@ it.instance(
         }
       }
     }),
-  3_000,
+  10_000,
 )
 
 raceNoLLMServer.instance(
@@ -1357,7 +1357,7 @@ it.instance(
       if (!Array.isArray(messages)) throw new Error("expected LLM messages")
       expect(messages.at(-1)).toEqual({ role: "user", content: "second" })
     }),
-  3_000,
+  10_000,
 )
 
 it.instance(
@@ -2177,7 +2177,7 @@ it.instance(
         expect(last.info.error?.name).toBe("MessageAbortedError")
       }
     }),
-  3_000,
+  10_000,
 )
 
 // Agent variant


### PR DESCRIPTION
## なぜ

Closes #253

UAT evidence guard は、コード完成だけで完了扱いしないために必要だが、read-only の計画・調査や blocker/unverified status まで止めると、原因調査や再開条件の記録ができなくなるため。

## どう実装したか

- lifecycle 操作を issue close / PR merge / PR ready / GitHub API close mutation に分離。
- status 操作は、完了宣言を含む場合のみ evidence guard 対象にした。
- read-only planning / investigation と blocker/unverified status は allow。
- UAT completion comment、PR ready、GitHub API issue close mutation は browser/live evidence なしでは block。

## レビュー注目点

- `uatLifecycleCommand` と `uatStatusCommand` の境界。
- `nonFinalUatStatusCommand` が terminal operation を許可しないこと。
- 既存の evidence marker 付き issue close が引き続き allow されること。

## テスト/確認方法

- PASS `bun test test/plugin/guardrail-git.test.ts` 44 pass
- PASS related guardrail plugin tests 70 pass
- PASS `bun run --cwd packages/opencode typecheck`
- PASS `git diff --check`
- PASS `bunx prettier --check packages/guardrails/profile/plugins/guardrail-git.ts`
- PASS local OpenCode help/debug startup checks

## 証跡

- `/private/tmp/opencode-uat-guardrail-evidence-20260624.md`

## 既知の制約

OpenCode CLI runtime で LLM/API を呼ばずに `tool.execute.before` へ dummy bash を流す安全経路は特定できなかったため、hook behavior は plugin handler tests で固定している。
