### PR TITLE
chore(ci): forkのCI/CD実行を最適化

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   sync:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: write

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   build:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       REGISTRY: ghcr.io/${{ github.repository_owner }}

--- a/.github/workflows/duplicate-issues.yml
+++ b/.github/workflows/duplicate-issues.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check-duplicates:
-    if: github.event.action == 'opened'
+    if: github.repository == 'anomalyco/opencode' && github.event.action == 'opened'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
@@ -140,7 +140,7 @@ jobs:
           Remember: post at most ONE comment combining all findings. If everything is fine, post nothing."
 
   recheck-compliance:
-    if: github.event.action == 'edited' && contains(github.event.issue.labels.*.name, 'needs:compliance')
+    if: github.repository == 'anomalyco/opencode' && github.event.action == 'edited' && contains(github.event.issue.labels.*.name, 'needs:compliance')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   generate:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: write

--- a/.github/workflows/nix-hashes.yml
+++ b/.github/workflows/nix-hashes.yml
@@ -25,6 +25,7 @@ jobs:
   # Native runners required: bun install cross-compilation flags (--os/--cpu)
   # do not produce byte-identical node_modules as native installs.
   compute-hash:
+    if: github.repository == 'anomalyco/opencode'
     strategy:
       fail-fast: false
       matrix:
@@ -90,7 +91,7 @@ jobs:
 
   update-hashes:
     needs: compute-hash
-    if: github.event_name != 'pull_request'
+    if: github.repository == 'anomalyco/opencode' && github.event_name != 'pull_request'
     runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:

--- a/.github/workflows/notify-discord.yml
+++ b/.github/workflows/notify-discord.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   notify:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Send nicely-formatted embed to Discord

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -9,10 +9,13 @@ on:
 jobs:
   opencode:
     if: |
-      contains(github.event.comment.body, ' /oc') ||
-      startsWith(github.event.comment.body, '/oc') ||
-      contains(github.event.comment.body, ' /opencode') ||
-      startsWith(github.event.comment.body, '/opencode')
+      github.repository == 'anomalyco/opencode' &&
+      (
+        contains(github.event.comment.body, ' /oc') ||
+        startsWith(github.event.comment.body, '/oc') ||
+        contains(github.event.comment.body, ' /opencode') ||
+        startsWith(github.event.comment.body, '/opencode')
+      )
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       id-token: write

--- a/.github/workflows/publish-github-action.yml
+++ b/.github/workflows/publish-github-action.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   publish:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   publish:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -411,7 +411,7 @@ jobs:
       - build-cli
       - sign-cli-windows
       - build-electron
-    if: always() && !failure() && !cancelled()
+    if: github.repository == 'anomalyco/opencode' && always() && !failure() && !cancelled()
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0

--- a/.github/workflows/release-github-action.yml
+++ b/.github/workflows/release-github-action.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   release:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   check-guidelines:
     if: |
+      github.repository == 'anomalyco/opencode' &&
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '/review') &&
       contains(fromJson('["OWNER","MEMBER"]'), github.event.comment.author_association)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ concurrency:
 
 permissions:
   contents: read
-  checks: write
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -84,36 +83,12 @@ jobs:
         working-directory: packages/opencode
         run: bun run test:httpapi
 
-      - name: Publish unit reports
-        if: always()
-        uses: mikepenz/action-junit-report@bccf2e31636835cf0874589931c4116687171386 # v6.4.0
-        with:
-          report_paths: packages/*/.artifacts/unit/junit.xml
-          check_name: "unit results (${{ matrix.settings.name }})"
-          detailed_summary: true
-          include_time_in_summary: true
-          fail_on_failure: false
-
-      - name: Upload unit artifacts
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: unit-${{ matrix.settings.name }}-${{ github.run_attempt }}
-          include-hidden-files: true
-          if-no-files-found: ignore
-          retention-days: 7
-          path: packages/*/.artifacts/unit/junit.xml
-
   e2e:
     name: e2e (${{ matrix.settings.name }})
     strategy:
       fail-fast: false
       matrix:
-        settings:
-          - name: linux
-            host: ubuntu-latest
-          - name: windows
-            host: windows-latest
+        settings: ${{ github.event_name == 'pull_request' && fromJSON('[{"name":"linux","host":"ubuntu-latest"}]') || fromJSON('[{"name":"linux","host":"ubuntu-latest"},{"name":"windows","host":"windows-latest"}]') }}
     runs-on: ${{ matrix.settings.host }}
     env:
       PLAYWRIGHT_BROWSER_CHANNEL: chrome
@@ -163,11 +138,10 @@ jobs:
         run: bun --cwd packages/app test:e2e:local
         env:
           CI: true
-          PLAYWRIGHT_JUNIT_OUTPUT: e2e/junit-${{ matrix.settings.name }}.xml
         timeout-minutes: 30
 
       - name: Upload Playwright artifacts
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-${{ matrix.settings.name }}-${{ github.run_attempt }}

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   triage:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read


### PR DESCRIPTION
## ① なぜ
fork 側では blacksmith runner と upstream secrets を前提にした release、maintenance、AI automation が queued のまま残り、CI/CD 状態確認が不必要に長くなっていたためです。

Closes #257

## Live evidence
- 2026-07-01 JST に local deploy/fire verification を実施済みです。
- `bun run local:deploy` と `bun run local:check` で active binary、guardrails profile、guardrail policy、team/background/team_status、read-only entrypoint command を確認しました。
- CLI/TUI runtime evidence として `~/.local/bin/opencode --version`、tmp dir の `debug info`、`.env` 読み込み、PTY 経由の TUI 起動 smoke を確認しました。
- Browser evidence は対象外です。この PR は GitHub Actions workflow の条件最適化のみで、画面 UI 変更を含みません。

## ② どう実装したか
- upstream 専用 workflow は削除せず、job-level の `github.repository == 'anomalyco/opencode'` guard で fork では no-op にしました。
- `publish.yml` は最終 `publish` job にも repository guard を追加し、先行 job が skip された fork で queued にならないようにしました。
- `test.yml` は PR では Linux e2e のみ、`dev` push と manual では Linux/Windows e2e を維持する matrix にしました。
- JUnit report publish と常時 artifact upload を外し、Playwright artifact は failure 時だけにしました。

## ③ 特にレビューしてほしい点
- fork で不要な automation の no-op 対象が過不足ないか。
- Windows e2e を PR から外し、`dev` push/manual に残すバランスが妥当か。
- upstream workflow 本体を残す方針で、今後の upstream sync 時に扱いやすい差分になっているか。

## ④ テスト内容・確認方法
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f) }'`
- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore 'label "blacksmith' -ignore 'constant expression "false"' -ignore 'shellcheck reported issue' -ignore 'potentially untrusted'`
- `gh workflow list --repo Cor-Incorporated/opencode --all`
- `bun typecheck` (`packages/opencode`)
- `bun run test:httpapi` (`packages/opencode`)
- `bun run build` (`packages/opencode`)
- `bun run local:deploy`
- `bun run local:check`
- `~/.local/bin/opencode --version`
- tmp dir で `~/.local/bin/opencode debug info`
- `bun test --timeout 30000 test/cli/smokes/local-deploy.test.ts` (`packages/opencode`)
- `.env` 読み込み確認: `terminal: opencode-cicd-smoke / dumb`
- PTY 経由の TUI 起動 smoke: `TUI startup smoke passed`
- push hook: `bun turbo typecheck` 29/29 pass
