### PR TITLE
chore(ci): forkのpublish待機を解消

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,12 @@ permissions:
   packages: write
 
 jobs:
+  fork-noop:
+    if: github.repository != 'anomalyco/opencode'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "publish workflow is upstream-only; skipping release jobs on this fork."
+
   version:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     if: github.repository == 'anomalyco/opencode'


### PR DESCRIPTION
## ① なぜ
PR #258 の merge 後、fork 側の `publish` workflow が job なしの pending run として残ることを確認しました。blacksmith runner 待ちではありませんが、fork CI/CD の状態確認を短くする目的には反するため、fork では短時間で完了する明示的な noop job を追加します。

Closes #259

## Live evidence
- PR #258 merge 後の `publish` run `28494381751` が `jobs: []` かつ `status: pending` のまま残ることを確認しました。
- `bun run local:check` は 2026-07-01 JST に再実行済みです。
- Browser evidence は対象外です。この PR は GitHub Actions workflow の条件最適化のみで、画面 UI 変更を含みません。

## ② どう実装したか
- `publish.yml` に `fork-noop` job を追加しました。
- `fork-noop` は fork 側でだけ `ubuntu-latest` で即時完了します。
- upstream の release job 群は既存の `github.repository == 'anomalyco/opencode'` guard のまま維持します。

## ③ 特にレビューしてほしい点
- fork-only noop job が upstream の release 動線に影響しないこと。
- fork の `publish` workflow が pending ではなく完了状態に落ちること。

## ④ テスト内容・確認方法
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish.yml")'`
- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore 'label "blacksmith' -ignore 'shellcheck reported issue' .github/workflows/publish.yml`
- `bun run local:check`
- push hook: `bun turbo typecheck` 29/29 pass
