### PR TITLE
fix(opencode): local DB の分裂を防ぐ

### DIFF
--- a/packages/opencode/src/cli/cmd/session.ts
+++ b/packages/opencode/src/cli/cmd/session.ts
@@ -1,4 +1,5 @@
 import type { Argv } from "yargs"
+import { Database } from "bun:sqlite"
 import { Effect } from "effect"
 import { cmd } from "./cmd"
 import { effectCmd, fail } from "../effect-cmd"
@@ -7,12 +8,14 @@ import { SessionID } from "../../session/schema"
 import { UI } from "../ui"
 import { Locale } from "@/util/locale"
 import { Flag } from "@opencode-ai/core/flag/flag"
+import { Global } from "@opencode-ai/core/global"
 import { Filesystem } from "@/util/filesystem"
 import { Process } from "@/util/process"
 import { NotFoundError } from "@/storage/storage"
 import { EOL } from "os"
 import path from "path"
 import { which } from "@opencode-ai/core/util/which"
+import { readdirSync } from "fs"
 
 function pagerCmd(): string[] {
   const lessOptions = ["-R", "-S"]
@@ -44,7 +47,8 @@ function pagerCmd(): string[] {
 export const SessionCommand = cmd({
   command: "session",
   describe: "manage sessions",
-  builder: (yargs: Argv) => yargs.command(SessionListCommand).command(SessionDeleteCommand).demandCommand(),
+  builder: (yargs: Argv) =>
+    yargs.command(SessionListCommand).command(SessionLocateCommand).command(SessionDeleteCommand).demandCommand(),
   async handler() {},
 })
 
@@ -115,6 +119,48 @@ export const SessionListCommand = effectCmd({
   }),
 })
 
+type LocatedSession = {
+  database: string
+  id: string
+  title: string
+  directory: string
+  version: string
+  updated: number
+  created: number
+  legacyMessages: number
+  messages: number
+}
+
+export const SessionLocateCommand = cmd({
+  command: "locate <sessionID>",
+  describe: "locate the database containing a session",
+  builder: (yargs: Argv) =>
+    yargs
+      .positional("sessionID", {
+        describe: "session ID to locate",
+        type: "string",
+        demandOption: true,
+      })
+      .option("format", {
+        describe: "output format",
+        type: "string",
+        choices: ["table", "json"],
+        default: "table",
+      }),
+  async handler(args) {
+    const sessionID = SessionID.make(args.sessionID)
+    const sessions = locateSession(sessionID)
+    if (sessions.length === 0) {
+      console.error(`Session not found in ${Global.Path.data}/opencode*.db: ${sessionID}`)
+      process.exitCode = 1
+      return
+    }
+
+    const output = args.format === "json" ? formatLocateJSON(sessions) : formatLocateTable(sessions)
+    console.log(output)
+  },
+})
+
 function formatSessionTable(sessions: Session.Info[]): string {
   const lines: string[] = []
 
@@ -144,4 +190,84 @@ function formatSessionJSON(sessions: Session.Info[]): string {
     directory: session.directory,
   }))
   return JSON.stringify(jsonData, null, 2)
+}
+
+function locateSession(sessionID: SessionID): LocatedSession[] {
+  return readdirSync(Global.Path.data)
+    .filter((file) => /^opencode.*\.db$/.test(file))
+    .flatMap((file) => locateSessionInDatabase(path.join(Global.Path.data, file), sessionID))
+}
+
+function locateSessionInDatabase(filename: string, sessionID: SessionID): LocatedSession[] {
+  try {
+    const db = new Database(filename, { readonly: true, strict: true })
+    try {
+      if (!hasTable(db, "session")) return []
+      const row = db
+        .query<
+          {
+            id: string
+            title: string
+            directory: string
+            version: string
+            time_created: number
+            time_updated: number
+          },
+          [string]
+        >("select id, title, directory, version, time_created, time_updated from session where id = ?")
+        .get(sessionID)
+      if (!row) return []
+
+      return [
+        {
+          database: filename,
+          id: row.id,
+          title: row.title,
+          directory: row.directory,
+          version: row.version,
+          updated: row.time_updated,
+          created: row.time_created,
+          legacyMessages: countSessionRows(db, "message", sessionID),
+          messages: countSessionRows(db, "session_message", sessionID),
+        },
+      ]
+    } finally {
+      db.close()
+    }
+  } catch {
+    return []
+  }
+}
+
+function hasTable(db: Database, name: string) {
+  return Boolean(
+    db.query<{ name: string }, [string]>("select name from sqlite_master where type = 'table' and name = ?").get(name),
+  )
+}
+
+function countSessionRows(db: Database, table: "message" | "session_message", sessionID: SessionID) {
+  if (!hasTable(db, table)) return 0
+  return db
+    .query<{ count: number }, [string]>(`select count(*) as count from ${table} where session_id = ?`)
+    .get(sessionID)!.count
+}
+
+function formatLocateTable(sessions: LocatedSession[]) {
+  const lines = ["Database\tMessages\tUpdated\tTitle\tDirectory"]
+  for (const session of sessions) {
+    lines.push(
+      [
+        session.database,
+        `${session.messages}/${session.legacyMessages}`,
+        new Date(session.updated).toISOString(),
+        session.title,
+        session.directory,
+      ].join("\t"),
+    )
+  }
+  return lines.join(EOL)
+}
+
+function formatLocateJSON(sessions: LocatedSession[]) {
+  return JSON.stringify(sessions, null, 2)
 }

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -45,13 +45,20 @@ import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { SessionMessage } from "@opencode-ai/schema/session-message"
 
-const parentTitlePrefix = "New session - "
-const childTitlePrefix = "Child session - "
+const parentDefaultTitle = "Untitled session"
+const childDefaultTitle = "Untitled child session"
+const legacyParentTitlePrefix = "New session - "
+const legacyChildTitlePrefix = "Child session - "
 
 export function isDefaultTitle(title: string) {
+  if (title === parentDefaultTitle || title === childDefaultTitle) return true
   return new RegExp(
-    `^(${parentTitlePrefix}|${childTitlePrefix})\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z$`,
+    `^(${legacyParentTitlePrefix}|${legacyChildTitlePrefix})\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z$`,
   ).test(title)
+}
+
+function defaultTitle(parentID?: SessionID) {
+  return parentID ? childDefaultTitle : parentDefaultTitle
 }
 
 type SessionRow = typeof SessionTable.$inferSelect
@@ -520,7 +527,7 @@ const layer: Layer.Layer<
         path: input.path,
         workspaceID: input.workspaceID,
         parentID: input.parentID,
-        title: input.title ?? (input.parentID ? childTitlePrefix : parentTitlePrefix) + new Date().toISOString(),
+        title: input.title ?? defaultTitle(input.parentID),
         agent: input.agent,
         model: input.model,
         metadata: input.metadata,

--- a/packages/opencode/test/cli/help/__snapshots__/help-snapshots.test.ts.snap
+++ b/packages/opencode/test/cli/help/__snapshots__/help-snapshots.test.ts.snap
@@ -354,6 +354,7 @@ manage sessions
 
 Commands:
   opencode session list                list sessions
+  opencode session locate <sessionID>  locate the database containing a session
   opencode session delete <sessionID>  delete a session
 
 Options:
@@ -562,6 +563,23 @@ Options:
       --log-level   log level                   [string] [choices: "DEBUG", "INFO", "WARN", "ERROR"]
       --pure        run without external plugins                                           [boolean]
   -n, --max-count   limit to N most recent sessions                                         [number]
+      --format      output format             [string] [choices: "table", "json"] [default: "table"]"
+`;
+
+exports[`opencode CLI help-text snapshots every documented command emits stable help text: opencode session locate --help 1`] = `
+"opencode session locate <sessionID>
+
+locate the database containing a session
+
+Positionals:
+  sessionID  session ID to locate                                                [string] [required]
+
+Options:
+  -h, --help        show help                                                              [boolean]
+  -v, --version     show version number                                                    [boolean]
+      --print-logs  print logs to stderr                                                   [boolean]
+      --log-level   log level                   [string] [choices: "DEBUG", "INFO", "WARN", "ERROR"]
+      --pure        run without external plugins                                           [boolean]
       --format      output format             [string] [choices: "table", "json"] [default: "table"]"
 `;
 

--- a/packages/opencode/test/cli/help/help-snapshots.test.ts
+++ b/packages/opencode/test/cli/help/help-snapshots.test.ts
@@ -79,6 +79,7 @@ const SUBCOMMANDS = [
   ["agent", "create"],
   ["agent", "list"],
   ["session", "list"],
+  ["session", "locate"],
   ["session", "delete"],
   ["github", "install"],
   ["github", "run"],

--- a/packages/opencode/test/cli/smokes/local-deploy.test.ts
+++ b/packages/opencode/test/cli/smokes/local-deploy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { spawnSync } from "node:child_process"
-import { existsSync, mkdtempSync, readlinkSync, rmSync, writeFileSync } from "node:fs"
+import { existsSync, mkdtempSync, readFileSync, readlinkSync, rmSync, writeFileSync } from "node:fs"
 import { homedir, tmpdir } from "node:os"
 import path from "node:path"
 
@@ -10,9 +10,10 @@ const repo = path.resolve(import.meta.dir, "../../../../..")
 const guardrailsProfile = path.join(repo, "packages/guardrails/profile")
 const localDeployTest = existsSync(entrypoint) && existsSync(liveWrapper) ? test : test.skip
 
-function runLocal(args: string[], cwd: string) {
+function runLocal(args: string[], cwd: string, overrides: Record<string, string | undefined> = {}) {
   const env = { ...process.env }
   for (const key of [
+    "OPENCODE_DB",
     "OPENCODE_CONFIG",
     "OPENCODE_CONFIG_CONTENT",
     "OPENCODE_CONFIG_DIR",
@@ -21,6 +22,10 @@ function runLocal(args: string[], cwd: string) {
     "TERM_PROGRAM_VERSION",
   ]) {
     delete env[key]
+  }
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) delete env[key]
+    else env[key] = value
   }
   return spawnSync(entrypoint, args, {
     cwd,
@@ -34,6 +39,29 @@ function runLocal(args: string[], cwd: string) {
 describe("deployed local opencode (smoke)", () => {
   localDeployTest("entrypoint points at the guardrails live wrapper", () => {
     expect(readlinkSync(entrypoint)).toBe(liveWrapper)
+  })
+
+  localDeployTest("wrapper defaults to a stable local database and preserves explicit database overrides", () => {
+    expect(readFileSync(liveWrapper, "utf8")).toContain("OPENCODE_DB=${OPENCODE_DB:-opencode-local.db}")
+
+    const dir = mkdtempSync(path.join(tmpdir(), "opencode-local-db-"))
+    try {
+      const defaultResult = runLocal(["db", "path"], dir, {
+        XDG_DATA_HOME: path.join(dir, "data"),
+      })
+      expect(defaultResult.status, defaultResult.stderr.toString()).toBe(0)
+      expect(defaultResult.stdout.trim()).toBe(path.join(dir, "data", "opencode", "opencode-local.db"))
+
+      const explicitDatabase = path.join(dir, "explicit.db")
+      const explicitResult = runLocal(["db", "path"], dir, {
+        OPENCODE_DB: explicitDatabase,
+        XDG_DATA_HOME: path.join(dir, "data"),
+      })
+      expect(explicitResult.status, explicitResult.stderr.toString()).toBe(0)
+      expect(explicitResult.stdout.trim()).toBe(explicitDatabase)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 
   localDeployTest("runs a read-only command through the guardrails profile and cwd .env", () => {

--- a/packages/opencode/test/session/default-title.test.ts
+++ b/packages/opencode/test/session/default-title.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test"
+import { Session } from "@/session/session"
+
+describe("session default title detection", () => {
+  test("treats stable placeholder titles as default", () => {
+    expect(Session.isDefaultTitle("Untitled session")).toBe(true)
+    expect(Session.isDefaultTitle("Untitled child session")).toBe(true)
+  })
+
+  test("keeps legacy timestamp placeholders eligible for title replacement", () => {
+    expect(Session.isDefaultTitle("New session - 2026-07-01T00:00:00.000Z")).toBe(true)
+    expect(Session.isDefaultTitle("Child session - 2026-07-01T00:00:00.000Z")).toBe(true)
+  })
+})

--- a/scripts/local-dev-deploy.sh
+++ b/scripts/local-dev-deploy.sh
@@ -8,6 +8,7 @@ GUARDRAILS_PROFILE="$ROOT/packages/guardrails/profile"
 ALLOWED_WRITE_ROOT="$HOME/.local/bin"
 ENTRYPOINT="${OPENCODE_LOCAL_ENTRYPOINT:-$ALLOWED_WRITE_ROOT/opencode}"
 LIVE_WRAPPER="${OPENCODE_LOCAL_WRAPPER:-$ALLOWED_WRITE_ROOT/opencode-live-guardrails-wrapper}"
+LOCAL_DB="${OPENCODE_LOCAL_DB:-opencode-local.db}"
 BUN_BIN="${BUN_BIN:-$(command -v bun 2>/dev/null || true)}"
 if [[ -z "$BUN_BIN" && -x "$HOME/.bun/bin/bun" ]]; then
   BUN_BIN="$HOME/.bun/bin/bun"
@@ -72,12 +73,15 @@ Usage:
   bash scripts/local-dev-deploy.sh [--check|--fix|--no-build|--check-zai-coding-plan|--check-openrouter-catalog]
 
 Deploy the local opencode development build into the fixed local runtime path.
+The wrapper defaults OPENCODE_DB to opencode-local.db unless the caller
+explicitly provides OPENCODE_DB.
 
 Default:
   1. build packages/opencode
   2. point packages/opencode/bin/.opencode at the new dist binary
   3. point ~/.local/bin/opencode at the guardrails live wrapper
-  4. verify /auto and /plan are available from the guardrails profile
+  4. default local runtime DB to opencode-local.db
+  5. verify /auto and /plan are available from the guardrails profile
 
 Modes:
   --check     validate only
@@ -603,13 +607,15 @@ repair_links() {
   # HIGH fix (review #205, codex): shell-escape paths in the heredoc so that
   # spaces or metacharacters in repo path / GUARDRAILS_BIN cannot break the
   # generated wrapper or inject shell.
-  local active_q guard_q bun_q
+  local active_q guard_q bun_q local_db_q
   active_q=$(printf '%q' "$ACTIVE_BINARY")
   guard_q=$(printf '%q' "$GUARDRAILS_BIN")
   bun_q=$(printf '%q' "$BUN_BIN")
+  local_db_q=$(printf '%q' "$LOCAL_DB")
   cat > "$LIVE_WRAPPER" <<EOF
 #!/bin/zsh
 export OPENCODE_BIN_PATH=$active_q
+export OPENCODE_DB=\${OPENCODE_DB:-$local_db_q}
 exec $bun_q $guard_q "\$@"
 EOF
   chmod 755 "$LIVE_WRAPPER"
@@ -682,7 +688,9 @@ mark "$([[ -x "$ACTIVE_BINARY" ]] && echo ok || echo fail)" "active binary is ex
 active_q_check=$(printf '%q' "$ACTIVE_BINARY")
 guard_q_check=$(printf '%q' "$GUARDRAILS_BIN")
 bun_q_check=$(printf '%q' "$BUN_BIN")
+local_db_q_check=$(printf '%q' "$LOCAL_DB")
 mark "$(grep -Fq "OPENCODE_BIN_PATH=$active_q_check" "$LIVE_WRAPPER" 2>/dev/null && echo ok || echo fail)" "live wrapper pins active binary"
+mark "$(grep -Fq "OPENCODE_DB=\${OPENCODE_DB:-$local_db_q_check}" "$LIVE_WRAPPER" 2>/dev/null && echo ok || echo fail)" "live wrapper defaults stable local database: $LOCAL_DB"
 mark "$(grep -Fq "exec $bun_q_check $guard_q_check" "$LIVE_WRAPPER" 2>/dev/null && echo ok || echo fail)" "live wrapper enters guardrails profile"
 
 entry_version="$("$ENTRYPOINT" --version 2>/dev/null || true)"


### PR DESCRIPTION
Closes #261

## ① なぜ

local deploy の wrapper が build channel 由来の DB を既定にすると、branch 名や日時を含む channel ごとに `opencode-*.db` が分かれます。その結果、既存 session が別 DB に残っているのに `opencode -s <session>` が現在 channel の DB だけを見て `Session not found` になる状態が起きます。

## ② どう実装したか

- local deploy wrapper の未指定時 DB を `opencode-local.db` に固定しました
- `OPENCODE_DB=/abs/path.db` の明示指定は上書きせず、旧 DB の復旧に使えるようにしました
- `opencode session locate <sessionID>` を追加し、`~/.local/share/opencode/opencode*.db` から session 所在を read-only で探せるようにしました
- 新規 session の仮タイトルは `Untitled session` 系に変更し、日時 prefix は DB/channel/lookup key 的に使わない形にしました
- 既存の `New session - <ISO>` / `Child session - <ISO>` は互換的に既定タイトルとして扱います

## ③ レビュー注目点

- wrapper が明示 `OPENCODE_DB` を維持する挙動
- `session locate` が DB を変更せず read-only 探索に限定されていること
- 既存の日時付き仮タイトル互換を壊していないこと

## ④ テスト・確認方法

- `bun typecheck`
- `bun run test:httpapi`
- `bun run build`
- `bun run local:deploy`
- `bun run local:check`
- `bun test --timeout 30000 test/session/default-title.test.ts test/cli/help/help-snapshots.test.ts test/cli/smokes/local-deploy.test.ts`
- `OPENCODE_DB=/Users/teradakousuke/.local/share/opencode/opencode-chore-upstream-sync-20260623.db opencode session list --format json | rg ses_0e47eb992ffeoax2WGPMiK8yjH`
- `opencode session locate ses_0e47eb992ffeoax2WGPMiK8yjH --format json`
- `timeout 5 opencode -s ses_0e47eb992ffeoax2WGPMiK8yjH` で `Session not found` ではなく TUI 起動まで到達すること
