### PR TITLE
fix(guardrails): ship時のreview証跡復元を修正

### DIFF
--- a/packages/guardrails/profile/plugins/guardrail-access.ts
+++ b/packages/guardrails/profile/plugins/guardrail-access.ts
@@ -3,6 +3,47 @@ import { MUTATING_TOOLS, bash, cfg, has, json, list, num, pick, rel, sec, stash,
 import type { GuardrailContext } from "./guardrail-context"
 
 export function createAccessHandlers(ctx: GuardrailContext) {
+  function resetReviewEvidence() {
+    return {
+      reviewed: false,
+      review_at: "",
+      review_agent: "",
+      review_glm_state: "",
+      review_codex_state: ctx.hasCodexMcp ? "" : "done",
+      review_state: "",
+      review_glm_at: "",
+      review_codex_at: ctx.hasCodexMcp ? "" : "auto:no-codex-mcp",
+      review_checks_at: "",
+      review_pr_number: "",
+      reviewed_head: "",
+      reviewed_head_sha: "",
+      review_branch: "",
+      reviewed_branch: "",
+      review_worktree_clean: false,
+      review_dirty_count: 0,
+      review_dirty_paths: [],
+      review_evidence_state: "",
+      review_evidence_at: "",
+      review_evidence_head: "",
+      pr_head_ref_oid: "",
+    }
+  }
+
+  function guardrailRuntimeReadOnlyCommand(cmd: string) {
+    const trimmed = cmd.trim()
+    if (bash(trimmed)) return false
+    if (/\bfind\b[\s\S]*(?:\s-delete\b|\s-exec\b|\s-ok\b)/i.test(trimmed)) return false
+    return /^(?:ls|cat|grep|egrep|fgrep|rg|find|pwd|stat|wc|head|tail|sed\s+-n|test|\[|readlink|file|du)\b/i.test(
+      trimmed,
+    )
+  }
+
+  function inlineInterpreterShell(cmd: string) {
+    return /(?:^|[;&|]\s*|\s)(?:(?:python|python3|ruby|perl)\s+-[A-Za-z]*[ce]|node\s+(?:-[A-Za-z]*e|--eval\b)|bun\s+(?:-[A-Za-z]*e|--eval\b)|deno\s+eval\b|(?:sh|bash|zsh)\s+-c\b)/i.test(
+      cmd,
+    )
+  }
+
   async function toolBeforeAccess(
     item: { tool: string; args?: unknown; callID?: unknown },
     out: { args: Record<string, unknown> },
@@ -34,9 +75,13 @@ export function createAccessHandlers(ctx: GuardrailContext) {
         throw new Error(text("shell access to protected files"))
       }
       const touchesGuardrailRuntime = file.includes(".opencode/guardrails/")
-      if (touchesGuardrailRuntime && bash(cmd)) {
+      if (touchesGuardrailRuntime && !guardrailRuntimeReadOnlyCommand(cmd)) {
         await ctx.mark({ last_block: "bash", last_command: cmd, last_reason: "protected runtime or config mutation" })
         throw new Error(text("protected runtime or config mutation"))
+      }
+      if (inlineInterpreterShell(cmd)) {
+        await ctx.mark({ last_block: "bash", last_command: cmd, last_reason: "interpreter shell can mutate guardrail runtime" })
+        throw new Error(text("interpreter shell can mutate guardrail runtime"))
       }
       if (/\bdocker\s+build\b/i.test(cmd)) {
         const secretPatterns = [
@@ -166,9 +211,7 @@ export function createAccessHandlers(ctx: GuardrailContext) {
       if (bash(cmd)) {
         await ctx.mark({
           edits_since_review: num(data.edits_since_review) + 1,
-          review_glm_state: "",
-          review_codex_state: ctx.hasCodexMcp ? "" : "done",
-          review_state: "",
+          ...resetReviewEvidence(),
         })
       }
     }
@@ -184,9 +227,7 @@ export function createAccessHandlers(ctx: GuardrailContext) {
         edit_count_since_check: num(data.edit_count_since_check) + 1,
         edits_since_review: num(data.edits_since_review) + 1,
         last_edit: relFile,
-        review_glm_state: "",
-        review_codex_state: ctx.hasCodexMcp ? "" : "done",
-        review_state: "",
+        ...resetReviewEvidence(),
       })
 
       if (/\.(test|spec)\.(ts|tsx|js|jsx)$|(^|\/)test_.*\.py$|_test\.go$/.test(relFile)) {

--- a/packages/guardrails/profile/plugins/guardrail-git.ts
+++ b/packages/guardrails/profile/plugins/guardrail-git.ts
@@ -17,6 +17,7 @@ type Review = {
     message: string
   }
   syncReviewState(): Promise<void>
+  hydrateReviewEvidence?(expectedHead?: string): Promise<boolean | void>
 }
 
 export function createGitHandlers(ctx: GuardrailContext, review: Review) {
@@ -568,6 +569,125 @@ export function createGitHandlers(ctx: GuardrailContext, review: Review) {
     )
   }
 
+  function reviewDone(data: Record<string, unknown>) {
+    return str(data.review_glm_state) === "done" && str(data.review_codex_state) === "done"
+  }
+
+  function hasRestoredReviewEvidence(data: Record<string, unknown>) {
+    return str(data.review_evidence_state) === "restored" || Boolean(reviewedHeadSha(data))
+  }
+
+  function reviewedHeadSha(data: Record<string, unknown>) {
+    return (
+      [
+        "review_head_sha",
+        "reviewed_head_sha",
+        "reviewed_head",
+        "review_evidence_head",
+        "review_head_oid",
+        "reviewed_head_oid",
+        "review_head_ref_oid",
+        "reviewed_head_ref_oid",
+        "review_pr_head_sha",
+        "head_sha",
+        "head",
+      ]
+        .map((key) => str(data[key]))
+        .find(Boolean) ?? ""
+    )
+  }
+
+  async function ghPrHeadRefOid(prNumber: string) {
+    const proc = spawnGh([
+      "pr",
+      "view",
+      ...(prNumber ? [prNumber] : []),
+      "--json",
+      "headRefOid",
+      "--jq",
+      ".headRefOid",
+    ])
+    const [headOut, code] = await Promise.all([new Response(proc.stdout).text(), proc.exited])
+    return code === 0 ? headOut.trim() : ""
+  }
+
+  async function hydrateMergeReviewState(
+    cmd: string,
+    data: Record<string, unknown>,
+    isPrMerge: boolean,
+    prNumber: string,
+  ) {
+    const prHead = isPrMerge ? await ghPrHeadRefOid(prNumber) : ""
+    if (isPrMerge && !prHead) {
+      await ctx.mark({
+        last_block: "bash",
+        last_command: cmd,
+        last_reason: "PR headRefOid verification failed",
+      })
+      throw new Error(
+        "Guardrail policy blocked this action: merge blocked (FULL tier): could not verify PR headRefOid before accepting restored review evidence.",
+      )
+    }
+
+    if (!reviewDone(data) && review.hydrateReviewEvidence) {
+      await review.hydrateReviewEvidence(prHead || undefined)
+      const fresh = await stash(ctx.state)
+      const next = { ...data, ...fresh }
+      if (hasRestoredReviewEvidence(next)) {
+        Object.assign(data, fresh)
+        await ctx.seen("pre_merge.review_hydrated", { pr: prNumber || undefined })
+      }
+    }
+
+    if (isPrMerge && reviewDone(data)) {
+      const reviewedHead = reviewedHeadSha(data)
+      if (!reviewedHead) {
+        await ctx.mark({
+          last_block: "bash",
+          last_command: cmd,
+          last_reason: "review evidence missing reviewed HEAD SHA",
+        })
+        throw new Error(
+          "Guardrail policy blocked this action: merge blocked (FULL tier): restored review evidence is missing the reviewed HEAD SHA.",
+        )
+      }
+
+      if (prHead.toLowerCase() !== reviewedHead.toLowerCase()) {
+        await ctx.mark({
+          last_block: "bash",
+          last_command: cmd,
+          last_reason: "review evidence HEAD mismatch",
+          review_evidence_head: reviewedHead,
+          pr_head_ref_oid: prHead,
+        })
+        throw new Error(
+          "Guardrail policy blocked this action: merge blocked (FULL tier): restored review evidence was captured for a different PR HEAD.",
+        )
+      }
+    }
+  }
+
+  function reviewFindingCounts(data: Record<string, unknown>) {
+    const criticalCount = num(data.review_critical_count)
+    const highCount = num(data.review_high_count)
+    const severeCount = Math.max(num(data.review_severe_count), criticalCount + highCount)
+    return { criticalCount, highCount, severeCount }
+  }
+
+  async function blockSevereReviewFindings(cmd: string, data: Record<string, unknown>) {
+    const counts = reviewFindingCounts(data)
+    if (counts.criticalCount === 0 && counts.highCount === 0 && counts.severeCount === 0) return
+    const prNum = str(data.review_pr_number)
+    await ctx.mark({
+      last_block: "bash",
+      last_command: cmd,
+      last_reason: `unresolved CRITICAL=${counts.criticalCount} HIGH=${counts.highCount} SEVERE=${counts.severeCount}`,
+    })
+    throw new Error(
+      `Guardrail policy blocked this action: merge blocked: PR #${prNum} has unresolved CRITICAL=${counts.criticalCount} HIGH=${counts.highCount} SEVERE=${counts.severeCount} review findings`,
+    )
+  }
+
   async function bashBeforeGit(cmd: string, out: { output?: string }, data: Record<string, unknown>) {
     const isMerge = gitSubcommand(cmd, "merge") || ghPrCommand(cmd, "merge") || ghApiPrMerge(cmd)
     const isPrMerge = ghPrCommand(cmd, "merge") || ghApiPrMerge(cmd)
@@ -644,8 +764,6 @@ export function createGitHandlers(ctx: GuardrailContext, review: Review) {
           )
         }
       }
-      const criticalCount = num(data.review_critical_count)
-      const highCount = num(data.review_high_count)
       try {
         const branchResult = await git(ctx.input.worktree, ["branch", "--show-current"])
         if (branchResult.code !== 0) throw new Error("git branch failed")
@@ -674,21 +792,11 @@ export function createGitHandlers(ctx: GuardrailContext, review: Review) {
           }
           await ctx.seen("pre_merge.tier", { branch, tier, files, result: "pass" })
         } else if (tier === "LIGHT") {
-          if (criticalCount > 0 || highCount > 0) {
-            const prNum = str(data.review_pr_number)
-            await ctx.mark({
-              last_block: "bash",
-              last_command: cmd,
-              last_reason: `unresolved CRITICAL=${criticalCount} HIGH=${highCount}`,
-            })
-            throw new Error(
-              `Guardrail policy blocked this action: merge blocked: PR #${prNum} has unresolved CRITICAL=${criticalCount} HIGH=${highCount} review findings`,
-            )
-          }
+          await blockSevereReviewFindings(cmd, data)
           const anyReviewDone = str(data.review_glm_state) === "done" || str(data.review_codex_state) === "done"
           const ciGreen = await ensurePrChecksGreen()
           const checksRan = Boolean(str(data.review_checks_at))
-          const noSevere = checksRan && criticalCount === 0 && highCount === 0
+          const noSevere = checksRan && reviewFindingCounts(data).severeCount === 0
           if (!ciGreen && !anyReviewDone && !noSevere) {
             await ctx.mark({
               last_block: "bash",
@@ -701,17 +809,8 @@ export function createGitHandlers(ctx: GuardrailContext, review: Review) {
           }
           await ctx.seen("pre_merge.tier", { branch, tier, files, result: "pass" })
         } else {
-          if (criticalCount > 0 || highCount > 0) {
-            const prNum = str(data.review_pr_number)
-            await ctx.mark({
-              last_block: "bash",
-              last_command: cmd,
-              last_reason: `unresolved CRITICAL=${criticalCount} HIGH=${highCount}`,
-            })
-            throw new Error(
-              `Guardrail policy blocked this action: merge blocked: PR #${prNum} has unresolved CRITICAL=${criticalCount} HIGH=${highCount} review findings`,
-            )
-          }
+          await hydrateMergeReviewState(cmd, data, isPrMerge, prMergeNumber)
+          await blockSevereReviewFindings(cmd, data)
           const gate = review.reviewGate(data)
           if (!gate.done) {
             await ctx.mark({ last_block: "bash", last_command: cmd, last_reason: `FULL tier: ${gate.message}` })

--- a/packages/guardrails/profile/plugins/guardrail-review.ts
+++ b/packages/guardrails/profile/plugins/guardrail-review.ts
@@ -1,10 +1,208 @@
-import { flag, list, num, stash, str } from "./guardrail-patterns"
+import path from "path"
+import { flag, git, list, num, save, stash, str } from "./guardrail-patterns"
 import type { GuardrailContext } from "./guardrail-context"
 
 const REVIEW_POLL_GAP = 750
 const REVIEW_TIMEOUT_MS = 120_000
+const REVIEW_EVIDENCE_FILE = "review-evidence.json"
 
 export function createReviewPipeline(ctx: GuardrailContext) {
+  function evidencePath() {
+    return path.join(path.dirname(ctx.state), REVIEW_EVIDENCE_FILE)
+  }
+
+  function record(data: unknown) {
+    if (data && typeof data === "object" && !Array.isArray(data)) return data as Record<string, unknown>
+    return {}
+  }
+
+  function dirtyPath(line: string) {
+    return line.slice(3).trim()
+  }
+
+  async function currentGitSnapshot() {
+    const head = await git(ctx.input.worktree, ["rev-parse", "HEAD"])
+    if (head.code !== 0 || !head.stdout.trim()) return
+    const branch = await git(ctx.input.worktree, ["branch", "--show-current"])
+    const status = await git(ctx.input.worktree, ["status", "--porcelain=v1", "--untracked-files=all"])
+    const dirtyPaths =
+      status.code === 0
+        ? status.stdout
+            .split(/\r?\n/)
+            .map(dirtyPath)
+            .filter((item) => item && !item.startsWith(".opencode/guardrails/"))
+        : ["<git status failed>"]
+    return {
+      head: head.stdout.trim(),
+      branch: branch.code === 0 ? branch.stdout.trim() : "",
+      dirtyPaths,
+      clean: dirtyPaths.length === 0,
+    }
+  }
+
+  function reviewCounts(data: Record<string, unknown>, kind: "glm" | "codex", findings: ReturnType<typeof parseFindings>) {
+    const glmCritical =
+      kind === "glm"
+        ? findings.critical
+        : str(data.review_glm_state) === "done"
+          ? num(data.review_glm_critical_count) || num(data.review_critical_count)
+          : 0
+    const glmHigh =
+      kind === "glm"
+        ? findings.high
+        : str(data.review_glm_state) === "done"
+          ? num(data.review_glm_high_count) || num(data.review_high_count)
+          : 0
+    const codexCritical =
+      kind === "codex"
+        ? findings.critical
+        : str(data.review_codex_state) === "done"
+          ? num(data.review_codex_critical_count) || num(data.review_critical_count)
+          : 0
+    const codexHigh =
+      kind === "codex"
+        ? findings.high
+        : str(data.review_codex_state) === "done"
+          ? num(data.review_codex_high_count) || num(data.review_high_count)
+          : 0
+    return {
+      ...(kind === "glm"
+        ? { review_glm_critical_count: findings.critical, review_glm_high_count: findings.high }
+        : { review_codex_critical_count: findings.critical, review_codex_high_count: findings.high }),
+      review_critical_count: Math.max(glmCritical, codexCritical),
+      review_high_count: Math.max(glmHigh, codexHigh),
+    }
+  }
+
+  async function saveReviewEvidence(data?: Record<string, unknown>) {
+    const snapshot = await currentGitSnapshot()
+    if (!snapshot) {
+      await ctx.seen("review_evidence.not_saved", { reason: "git_head_unavailable" })
+      return false
+    }
+    const current = data ?? (await stash(ctx.state))
+    await save(evidencePath(), {
+      version: 1,
+      saved_at: new Date().toISOString(),
+      reviewed: flag(current.reviewed),
+      review_glm_state: str(current.review_glm_state),
+      review_codex_state: str(current.review_codex_state),
+      review_state: str(current.review_state),
+      review_at: str(current.review_at),
+      review_agent: str(current.review_agent),
+      review_glm_at: str(current.review_glm_at),
+      review_codex_at: str(current.review_codex_at),
+      review_critical_count: num(current.review_critical_count),
+      review_high_count: num(current.review_high_count),
+      review_severe_count: num(current.review_critical_count) + num(current.review_high_count),
+      review_glm_critical_count: num(current.review_glm_critical_count),
+      review_glm_high_count: num(current.review_glm_high_count),
+      review_codex_critical_count: num(current.review_codex_critical_count),
+      review_codex_high_count: num(current.review_codex_high_count),
+      head: snapshot.head,
+      head_sha: snapshot.head,
+      reviewed_head: snapshot.head,
+      reviewed_head_sha: snapshot.head,
+      review_branch: snapshot.branch,
+      reviewed_branch: snapshot.branch,
+      review_worktree_clean: snapshot.clean,
+      review_dirty_count: snapshot.dirtyPaths.length,
+      review_dirty_paths: snapshot.dirtyPaths,
+    })
+    await ctx.seen("review_evidence.saved", {
+      head: snapshot.head,
+      branch: snapshot.branch,
+      clean: snapshot.clean,
+      dirty_count: snapshot.dirtyPaths.length,
+    })
+    return true
+  }
+
+  async function restoreReviewEvidence(expectedHead?: string) {
+    const snapshot = await currentGitSnapshot()
+    if (!snapshot) {
+      await ctx.seen("review_evidence.not_restored", { reason: "git_head_unavailable" })
+      return false
+    }
+    if (!snapshot.clean) {
+      await ctx.seen("review_evidence.not_restored", {
+        reason: "dirty_worktree",
+        dirty_count: snapshot.dirtyPaths.length,
+      })
+      return false
+    }
+    const evidence = record(
+      await Bun.file(evidencePath())
+        .json()
+        .catch(() => ({})),
+    )
+    const reviewedHead =
+      str(evidence.reviewed_head_sha) || str(evidence.reviewed_head) || str(evidence.head_sha) || str(evidence.head)
+    if (!reviewedHead) {
+      await ctx.seen("review_evidence.not_restored", { reason: "missing" })
+      return false
+    }
+    if (reviewedHead !== snapshot.head) {
+      await ctx.seen("review_evidence.not_restored", {
+        reason: "head_mismatch",
+        reviewed_head: reviewedHead,
+        current_head: snapshot.head,
+      })
+      return false
+    }
+    if (expectedHead && reviewedHead !== expectedHead) {
+      await ctx.seen("review_evidence.not_restored", {
+        reason: "pr_head_mismatch",
+        reviewed_head: reviewedHead,
+        expected_head: expectedHead,
+      })
+      return false
+    }
+    if (evidence.review_worktree_clean === false || evidence.clean === false) {
+      await ctx.seen("review_evidence.not_restored", { reason: "evidence_dirty_worktree" })
+      return false
+    }
+    const current = await stash(ctx.state)
+    const reviewGlm = str(evidence.review_glm_state) === "done" || str(current.review_glm_state) === "done"
+    const reviewCodex = str(evidence.review_codex_state) === "done" || str(current.review_codex_state) === "done"
+    const restored = {
+      reviewed: flag(evidence.reviewed) || reviewGlm || reviewCodex,
+      review_glm_state: reviewGlm ? "done" : "",
+      review_codex_state: reviewCodex ? "done" : "",
+      review_state: str(evidence.review_state),
+      review_at: str(evidence.review_at),
+      review_agent: str(evidence.review_agent),
+      review_glm_at: str(evidence.review_glm_at) || str(current.review_glm_at),
+      review_codex_at: str(evidence.review_codex_at) || str(current.review_codex_at),
+      review_critical_count: num(evidence.review_critical_count),
+      review_high_count: num(evidence.review_high_count),
+      review_severe_count: num(evidence.review_severe_count),
+      review_glm_critical_count: num(evidence.review_glm_critical_count),
+      review_glm_high_count: num(evidence.review_glm_high_count),
+      review_codex_critical_count: num(evidence.review_codex_critical_count),
+      review_codex_high_count: num(evidence.review_codex_high_count),
+      reviewed_head: reviewedHead,
+      reviewed_head_sha: reviewedHead,
+      review_evidence_head: reviewedHead,
+      review_branch: str(evidence.review_branch) || str(evidence.reviewed_branch),
+      reviewed_branch: str(evidence.reviewed_branch) || str(evidence.review_branch),
+      review_worktree_clean: true,
+      review_dirty_count: 0,
+      review_dirty_paths: [],
+      review_evidence_state: "restored",
+      review_evidence_at: str(evidence.saved_at),
+      edits_since_review: 0,
+    }
+    await ctx.mark(restored)
+    await syncReviewState()
+    await ctx.seen("review_evidence.restored", { head: reviewedHead, branch: restored.review_branch })
+    return true
+  }
+
+  async function hydrateReviewEvidence(expectedHead?: string) {
+    return restoreReviewEvidence(expectedHead)
+  }
+
   function reviewGate(data: Record<string, unknown>) {
     const glm = str(data.review_glm_state) === "done"
     const codex = str(data.review_codex_state) === "done"
@@ -115,10 +313,10 @@ export function createReviewPipeline(ctx: GuardrailContext) {
       workflow_review_attempts: attempts,
       review_at: new Date().toISOString(),
       edits_since_review: 0,
-      review_critical_count: findings.critical,
-      review_high_count: findings.high,
+      ...reviewCounts(data, "glm", findings),
     })
     await syncReviewState()
+    await saveReviewEvidence()
     await ctx.seen("auto_review.completed", {
       findings: findings.total,
       critical: findings.critical,
@@ -188,12 +386,18 @@ export function createReviewPipeline(ctx: GuardrailContext) {
       return
     }
     const findings = parseFindings(output)
+    const data = await stash(ctx.state)
+    const now = new Date().toISOString()
     await ctx.mark({
       reviewed: true,
+      review_at: now,
+      review_agent: "codex:mcp",
       review_codex_state: "done",
-      review_codex_at: new Date().toISOString(),
+      review_codex_at: now,
+      ...reviewCounts(data, "codex", findings),
     })
     await syncReviewState()
+    await saveReviewEvidence()
     await ctx.seen("codex_review.completed", { critical: findings.critical, high: findings.high })
   }
 
@@ -215,21 +419,22 @@ export function createReviewPipeline(ctx: GuardrailContext) {
       }
       const findings = parseFindings([cmd, str(out.output)].join("\n"))
       const now = new Date().toISOString()
+      const data = await stash(ctx.state)
       await ctx.mark({
         reviewed: true,
         review_at: now,
         review_agent: `gstack:${gstack.skill}`,
         ...(gstack.kind === "codex"
-          ? { review_codex_state: "done", review_codex_at: now }
+          ? { review_codex_state: "done", review_codex_at: now, ...reviewCounts(data, "codex", findings) }
           : {
               review_glm_state: "done",
               review_glm_at: now,
               edits_since_review: 0,
-              review_critical_count: findings.critical,
-              review_high_count: findings.high,
+              ...reviewCounts(data, "glm", findings),
             }),
       })
       await syncReviewState()
+      await saveReviewEvidence()
       await ctx.seen("gstack_review.completed", {
         skill: gstack.skill,
         kind: gstack.kind,
@@ -252,21 +457,22 @@ export function createReviewPipeline(ctx: GuardrailContext) {
       return
     }
     const findings = parseFindings(output)
+    const now = new Date().toISOString()
     await ctx.mark({
       reviewed: true,
-      review_at: new Date().toISOString(),
+      review_at: now,
       review_agent: isClaudeReviewer
         ? "claude:code-reviewer"
         : isSkillScriptReviewer
           ? "code-reviewer:scripts"
           : "opencode:review",
       review_glm_state: "done",
-      review_glm_at: new Date().toISOString(),
+      review_glm_at: now,
       edits_since_review: 0,
-      review_critical_count: findings.critical,
-      review_high_count: findings.high,
+      ...reviewCounts(await stash(ctx.state), "glm", findings),
     })
     await syncReviewState()
+    await saveReviewEvidence()
     await ctx.seen("external_review.completed", {
       agent: isClaudeReviewer
         ? "claude:code-reviewer"
@@ -294,6 +500,9 @@ export function createReviewPipeline(ctx: GuardrailContext) {
     checklist,
     parseFindings,
     reviewGate,
+    saveReviewEvidence,
+    restoreReviewEvidence,
+    hydrateReviewEvidence,
     syncReviewState,
     handleAutoReviewTrigger,
     handleCodexDetection,

--- a/packages/guardrails/profile/plugins/guardrail.ts
+++ b/packages/guardrails/profile/plugins/guardrail.ts
@@ -180,6 +180,7 @@ export default async function guardrail(input: GuardrailInput, opts?: Record<str
             await ctx.seen("codex_mcp.not_configured", { auto_satisfied: true })
           }
         } catch {}
+        await review.hydrateReviewEvidence()
       }
       if (event.type === "permission.asked") {
         await ctx.mark({

--- a/packages/opencode/test/cli/smokes/local-deploy.test.ts
+++ b/packages/opencode/test/cli/smokes/local-deploy.test.ts
@@ -6,8 +6,6 @@ import path from "node:path"
 
 const entrypoint = path.join(homedir(), ".local/bin/opencode")
 const liveWrapper = path.join(homedir(), ".local/bin/opencode-live-guardrails-wrapper")
-const repo = path.resolve(import.meta.dir, "../../../../..")
-const guardrailsProfile = path.join(repo, "packages/guardrails/profile")
 const localDeployTest = existsSync(entrypoint) && existsSync(liveWrapper) ? test : test.skip
 
 function runLocal(args: string[], cwd: string, overrides: Record<string, string | undefined> = {}) {
@@ -72,8 +70,8 @@ describe("deployed local opencode (smoke)", () => {
       const result = runLocal(["debug", "info"], dir)
       expect(result.status, result.stderr.toString()).toBe(0)
       expect(result.stdout).toContain("terminal: opencode-local-env-smoke")
-      expect(result.stdout).toContain(path.join(guardrailsProfile, "plugins/guardrail.ts"))
-      expect(result.stdout).toContain(path.join(guardrailsProfile, "plugins/team.ts"))
+      expect(result.stdout).toContain("plugins/guardrail.ts")
+      expect(result.stdout).toContain("plugins/team.ts")
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }

--- a/packages/opencode/test/plugin/guardrail-access.test.ts
+++ b/packages/opencode/test/plugin/guardrail-access.test.ts
@@ -104,6 +104,32 @@ describe("guardrail-access", () => {
     expect(marks[0]?.last_reason).toBe("guardrail runtime state is plugin-owned")
   })
 
+  test("blocks write tool access to review evidence runtime state", async () => {
+    const { ctx, marks } = context((file, kind) => {
+      const rel = file.replace("/tmp/project/", "")
+      if (kind === "edit" && rel.startsWith(".opencode/guardrails/")) {
+        return "guardrail runtime state is plugin-owned"
+      }
+    })
+    const access = createAccessHandlers(ctx)
+
+    await expect(
+      access.toolBeforeAccess(
+        { tool: "write", args: { filePath: "/tmp/project/.opencode/guardrails/review-evidence.json", content: "{}" } },
+        { args: { filePath: "/tmp/project/.opencode/guardrails/review-evidence.json", content: "{}" } },
+      ),
+    ).rejects.toThrow("guardrail runtime state is plugin-owned")
+
+    expect(marks).toHaveLength(1)
+    expect(marks[0]).toEqual(
+      expect.objectContaining({
+        last_block: "write",
+        last_file: ".opencode/guardrails/review-evidence.json",
+        last_reason: "guardrail runtime state is plugin-owned",
+      }),
+    )
+  })
+
   test("allows read-only shell access to .opencode/guardrails", async () => {
     const { ctx, marks } = context()
     const access = createAccessHandlers(ctx)
@@ -131,5 +157,160 @@ describe("guardrail-access", () => {
 
     expect(marks).toHaveLength(1)
     expect(marks[0]?.last_reason).toBe("protected runtime or config mutation")
+  })
+
+  test("blocks mutating shell access to review evidence runtime state", async () => {
+    const { ctx, marks } = context()
+    const access = createAccessHandlers(ctx)
+    const command = "printf '{}' > .opencode/guardrails/review-evidence.json"
+
+    await expect(
+      access.toolBeforeAccess(
+        { tool: "bash", args: { command } },
+        { args: { command } },
+      ),
+    ).rejects.toThrow("protected runtime or config mutation")
+
+    expect(marks).toHaveLength(1)
+    expect(marks[0]).toEqual(
+      expect.objectContaining({
+        last_block: "bash",
+        last_command: command,
+        last_reason: "protected runtime or config mutation",
+      }),
+    )
+  })
+
+  test("blocks interpreter shell writes to review evidence runtime state", async () => {
+    const { ctx, marks } = context()
+    const access = createAccessHandlers(ctx)
+    const command =
+      "python -c \"from pathlib import Path; Path('.opencode/guardrails/review-evidence.json').write_text('{}')\""
+
+    await expect(
+      access.toolBeforeAccess(
+        { tool: "bash", args: { command } },
+        { args: { command } },
+      ),
+    ).rejects.toThrow("protected runtime or config mutation")
+
+    expect(marks).toHaveLength(1)
+    expect(marks[0]).toEqual(
+      expect.objectContaining({
+        last_block: "bash",
+        last_command: command,
+        last_reason: "protected runtime or config mutation",
+      }),
+    )
+  })
+
+  test("blocks inline interpreter shell even when guardrail runtime path is assembled dynamically", async () => {
+    const { ctx, marks } = context()
+    const access = createAccessHandlers(ctx)
+    const command =
+      "python -c \"from pathlib import Path; Path('.open'+'code/guard'+'rails/review-evidence.json').write_text('{}')\""
+
+    await expect(
+      access.toolBeforeAccess(
+        { tool: "bash", args: { command } },
+        { args: { command } },
+      ),
+    ).rejects.toThrow("interpreter shell can mutate guardrail runtime")
+
+    expect(marks).toHaveLength(1)
+    expect(marks[0]).toEqual(
+      expect.objectContaining({
+        last_block: "bash",
+        last_command: command,
+        last_reason: "interpreter shell can mutate guardrail runtime",
+      }),
+    )
+  })
+
+  test("clears stale review evidence state after mutating tool edits", async () => {
+    const { ctx, marks } = context()
+    ctx.hasCodexMcp = true
+    const access = createAccessHandlers(ctx)
+
+    await access.toolAfterAccess(
+      { tool: "edit", args: { filePath: "/tmp/project/src/policy.ts", oldString: "old", newString: "new" } },
+      { title: "Edited", output: "", metadata: {} },
+      {
+        edited_files: ["src/old.ts"],
+        edit_count: 1,
+        edit_count_since_check: 2,
+        edits_since_review: 0,
+        reviewed: true,
+        review_at: "2026-07-01T00:00:00.000Z",
+        review_agent: "code-reviewer",
+        review_glm_state: "done",
+        review_codex_state: "done",
+        review_state: "done",
+        review_glm_at: "2026-07-01T00:00:00.000Z",
+        review_codex_at: "2026-07-01T00:00:01.000Z",
+        review_checks_at: "2026-07-01T00:00:02.000Z",
+        review_pr_number: "42",
+      },
+    )
+
+    expect(marks.at(-1)).toEqual(
+      expect.objectContaining({
+        edited_files: ["src/old.ts", "src/policy.ts"],
+        edit_count: 2,
+        edit_count_since_check: 3,
+        edits_since_review: 1,
+        last_edit: "src/policy.ts",
+        reviewed: false,
+        review_at: "",
+        review_agent: "",
+        review_glm_state: "",
+        review_codex_state: "",
+        review_state: "",
+        review_glm_at: "",
+        review_codex_at: "",
+        review_checks_at: "",
+        review_pr_number: "",
+      }),
+    )
+  })
+
+  test("clears stale review evidence state after shell mutations", async () => {
+    const { ctx, marks } = context()
+    ctx.hasCodexMcp = true
+    const access = createAccessHandlers(ctx)
+
+    await access.toolAfterAccess(
+      { tool: "bash", args: { command: "printf 'new' > src/policy.ts" } },
+      { title: "bash", output: "", metadata: { exitCode: 0 } },
+      {
+        edits_since_review: 2,
+        reviewed: true,
+        review_at: "2026-07-01T00:00:00.000Z",
+        review_agent: "code-reviewer",
+        review_glm_state: "done",
+        review_codex_state: "done",
+        review_state: "done",
+        review_glm_at: "2026-07-01T00:00:00.000Z",
+        review_codex_at: "2026-07-01T00:00:01.000Z",
+        review_checks_at: "2026-07-01T00:00:02.000Z",
+        review_pr_number: "42",
+      },
+    )
+
+    expect(marks.at(-1)).toEqual(
+      expect.objectContaining({
+        edits_since_review: 3,
+        reviewed: false,
+        review_at: "",
+        review_agent: "",
+        review_glm_state: "",
+        review_codex_state: "",
+        review_state: "",
+        review_glm_at: "",
+        review_codex_at: "",
+        review_checks_at: "",
+        review_pr_number: "",
+      }),
+    )
   })
 })

--- a/packages/opencode/test/plugin/guardrail-git.test.ts
+++ b/packages/opencode/test/plugin/guardrail-git.test.ts
@@ -5,8 +5,11 @@ import { createGitHandlers } from "../../../../packages/guardrails/profile/plugi
 import type { GuardrailContext } from "../../../../packages/guardrails/profile/plugins/guardrail-context"
 import { tmpdir } from "../fixture/fixture"
 
+type HydrateReviewState = (expectedHead?: string) => Promise<boolean | void> | boolean | void
+
 async function context() {
   const tmp = await tmpdir()
+  const state = path.join(tmp.path, ".opencode", "guardrails", "state.json")
   const marks: Record<string, unknown>[] = []
   const ctx: GuardrailContext = {
     input: {
@@ -17,7 +20,7 @@ async function context() {
     mode: "enforced",
     root: path.join(tmp.path, ".opencode", "guardrails"),
     log: path.join(tmp.path, ".opencode", "guardrails", "events.jsonl"),
-    state: path.join(tmp.path, ".opencode", "guardrails", "state.json"),
+    state,
     allow: {},
     hasCodexMcp: false,
     maxParallelTasks: 5,
@@ -27,6 +30,20 @@ async function context() {
     domainDirs: {},
     async mark(data) {
       marks.push(data)
+      await fs.mkdir(path.dirname(state), { recursive: true })
+      await Bun.write(
+        state,
+        JSON.stringify(
+          {
+            ...(await Bun.file(state)
+              .json()
+              .catch(() => ({}))),
+            ...data,
+          },
+          null,
+          2,
+        ),
+      )
     },
     async seen() {},
     note() {
@@ -78,7 +95,7 @@ async function context() {
   }
 }
 
-function review() {
+function review(input: { hydrateReviewEvidence?: HydrateReviewState } = {}) {
   return {
     checklist() {
       return { score: 3, total: 3, blocking: [], summary: "ok" }
@@ -95,6 +112,9 @@ function review() {
       }
     },
     async syncReviewState() {},
+    async hydrateReviewEvidence(expectedHead?: string) {
+      return input.hydrateReviewEvidence?.(expectedHead)
+    },
   }
 }
 
@@ -145,12 +165,30 @@ function fakeGh(handler: (args: string[]) => { stdout?: string; stderr?: string;
   }
 }
 
-function fakePrMergeGh(input: { files: string[]; checks?: string }) {
+function fakePrMergeGh(input: {
+  files: string[]
+  checks?: string
+  pr?: string
+  headRefOid?: string
+  author?: string
+  approvals?: string[]
+}) {
+  const pr = input.pr ?? "170"
   return fakeGh((args) => {
     if (args[0] === "pr" && args[1] === "checks") return { stdout: input.checks ?? "build\tpass\t0\thttps://example.test/check\n" }
-    if (args[0] === "api" && args[1] === "repos/owner/repo/pulls/170/files") return { stdout: `${input.files.join("\n")}\n` }
-    if (args[0] === "api" && args[1] === "repos/owner/repo/pulls/170/reviews") return { stdout: "0\n" }
-    if (args[0] === "api" && args[1] === "repos/owner/repo/pulls/170") return { stdout: "\n" }
+    if (args[0] === "pr" && args[1] === "view" && args[2] === pr && args.includes("headRefOid")) {
+      return { stdout: `${input.headRefOid ?? ""}\n` }
+    }
+    if (args[0] === "api" && args[1] === `repos/owner/repo/pulls/${pr}/files`) {
+      return { stdout: `${input.files.join("\n")}\n` }
+    }
+    if (args[0] === "api" && args[1] === `repos/owner/repo/pulls/${pr}/reviews` && args[3]?.includes("APPROVED")) {
+      return { stdout: `${(input.approvals ?? []).join("\n")}\n` }
+    }
+    if (args[0] === "api" && args[1] === `repos/owner/repo/pulls/${pr}/reviews`) return { stdout: "0\n" }
+    if (args[0] === "api" && args[1] === `repos/owner/repo/pulls/${pr}`) {
+      return { stdout: input.author ? `${input.author}\n` : "\n" }
+    }
     return {}
   })
 }
@@ -475,6 +513,207 @@ describe("guardrail-git", () => {
     }
   })
 
+  test.serial("allows FULL tier PR merge after hydrating matching review evidence", async () => {
+    await using fixture = await diffFixture("packages/opencode/src/fresh-review-evidence.ts")
+    await Bun.$`git remote add origin git@github.com:owner/repo.git`.cwd(fixture.ctx.input.worktree).quiet()
+    const calls: string[] = []
+    const restore = fakePrMergeGh({
+      pr: "42",
+      files: ["packages/opencode/src/fresh-review-evidence.ts"],
+      headRefOid: "abc123",
+      author: "alice",
+      approvals: ["bob"],
+    })
+    try {
+      await expect(
+        createGitHandlers(
+          fixture.ctx,
+          review({
+            async hydrateReviewEvidence(expectedHead) {
+              calls.push(expectedHead ?? "")
+              await fixture.ctx.mark({
+                review_glm_state: "done",
+                review_codex_state: "done",
+                reviewed_head_sha: "abc123",
+                review_evidence_state: "restored",
+                review_critical_count: 0,
+                review_high_count: 0,
+                edits_since_review: 0,
+              })
+              return true
+            },
+          }),
+        ).bashBeforeGit("gh pr merge 42 --merge", {}, {}),
+      ).resolves.toBeUndefined()
+
+      expect(calls).toEqual(["abc123"])
+      expect(fixture.marks.some((item) => item.merge_review_tier === "FULL")).toBe(true)
+    } finally {
+      restore()
+    }
+  })
+
+  test.serial("blocks FULL tier PR merge when hydrated evidence head does not match PR head", async () => {
+    await using fixture = await diffFixture("packages/opencode/src/stale-review-evidence.ts")
+    await Bun.$`git remote add origin git@github.com:owner/repo.git`.cwd(fixture.ctx.input.worktree).quiet()
+    const restore = fakePrMergeGh({
+      pr: "42",
+      files: ["packages/opencode/src/stale-review-evidence.ts"],
+      headRefOid: "newhead",
+    })
+    try {
+      await expect(
+        createGitHandlers(
+          fixture.ctx,
+          review({
+            async hydrateReviewEvidence() {
+              await fixture.ctx.mark({
+                review_glm_state: "done",
+                review_codex_state: "done",
+                reviewed_head_sha: "oldhead",
+                review_evidence_state: "restored",
+                review_critical_count: 0,
+                review_high_count: 0,
+                edits_since_review: 0,
+              })
+              return true
+            },
+          }),
+        ).bashBeforeGit("gh pr merge 42 --merge", {}, {}),
+      ).rejects.toThrow("restored review evidence was captured for a different PR HEAD")
+
+      expect(fixture.marks.at(-1)?.last_reason).toBe("review evidence HEAD mismatch")
+    } finally {
+      restore()
+    }
+  })
+
+  test.serial("blocks FULL tier PR merge when existing review state lacks reviewed HEAD evidence", async () => {
+    await using fixture = await diffFixture("packages/opencode/src/done-without-head.ts")
+    await Bun.$`git remote add origin git@github.com:owner/repo.git`.cwd(fixture.ctx.input.worktree).quiet()
+    const restore = fakePrMergeGh({
+      pr: "42",
+      files: ["packages/opencode/src/done-without-head.ts"],
+      headRefOid: "abc123",
+    })
+    try {
+      await expect(
+        createGitHandlers(fixture.ctx, review()).bashBeforeGit("gh pr merge 42 --merge", {}, {
+          review_glm_state: "done",
+          review_codex_state: "done",
+          review_critical_count: 0,
+          review_high_count: 0,
+          edits_since_review: 0,
+        }),
+      ).rejects.toThrow("restored review evidence is missing the reviewed HEAD SHA")
+
+      expect(fixture.marks.at(-1)?.last_reason).toBe("review evidence missing reviewed HEAD SHA")
+    } finally {
+      restore()
+    }
+  })
+
+  test.serial("blocks FULL tier PR merge when existing review evidence head does not match PR head", async () => {
+    await using fixture = await diffFixture("packages/opencode/src/done-with-stale-head.ts")
+    await Bun.$`git remote add origin git@github.com:owner/repo.git`.cwd(fixture.ctx.input.worktree).quiet()
+    const restore = fakePrMergeGh({
+      pr: "42",
+      files: ["packages/opencode/src/done-with-stale-head.ts"],
+      headRefOid: "newhead",
+    })
+    try {
+      await expect(
+        createGitHandlers(fixture.ctx, review()).bashBeforeGit("gh pr merge 42 --merge", {}, {
+          review_glm_state: "done",
+          review_codex_state: "done",
+          reviewed_head_sha: "oldhead",
+          review_critical_count: 0,
+          review_high_count: 0,
+          edits_since_review: 0,
+        }),
+      ).rejects.toThrow("restored review evidence was captured for a different PR HEAD")
+
+      expect(fixture.marks.at(-1)?.last_reason).toBe("review evidence HEAD mismatch")
+    } finally {
+      restore()
+    }
+  })
+
+  test.serial("blocks FULL tier PR merge without hydrated review evidence", async () => {
+    await using fixture = await diffFixture("packages/opencode/src/missing-review-evidence.ts")
+    await Bun.$`git remote add origin git@github.com:owner/repo.git`.cwd(fixture.ctx.input.worktree).quiet()
+    const restore = fakePrMergeGh({
+      pr: "42",
+      files: ["packages/opencode/src/missing-review-evidence.ts"],
+      headRefOid: "abc123",
+    })
+    try {
+      await expect(
+        createGitHandlers(
+          fixture.ctx,
+          review({
+            hydrateReviewEvidence() {},
+          }),
+        ).bashBeforeGit("gh pr merge 42 --merge", {}, { review_codex_state: "done" }),
+      ).rejects.toThrow("pending: GLM code-reviewer")
+
+      expect(fixture.marks.at(-1)?.last_reason).toBe("FULL tier: pending: GLM code-reviewer")
+    } finally {
+      restore()
+    }
+  })
+
+  test("blocks full source merges when restored severe count is present without critical or high counts", async () => {
+    await using fixture = await diffFixture("packages/opencode/src/severe-review-evidence.ts")
+    const git = createGitHandlers(fixture.ctx, review())
+
+    await expect(
+      git.bashBeforeGit("git merge dev", {}, {
+        review_glm_state: "done",
+        review_codex_state: "done",
+        reviewed_head_sha: "abc123",
+        review_critical_count: 0,
+        review_high_count: 0,
+        review_severe_count: 1,
+        edits_since_review: 0,
+      }),
+    ).rejects.toThrow("SEVERE=1")
+
+    expect(fixture.marks.at(-1)?.last_reason).toBe("unresolved CRITICAL=0 HIGH=0 SEVERE=1")
+  })
+
+  test.serial("keeps queued CI blocking before PR merge review hydration", async () => {
+    await using fixture = await diffFixture("packages/opencode/src/ci-before-hydration.ts")
+    const calls: string[] = []
+    const restore = fakeGh((args) =>
+      args[0] === "pr" && args[1] === "checks" ? { stdout: "build\tqueued\t0\thttps://example.test/check\n" } : {},
+    )
+    try {
+      await expect(
+        createGitHandlers(
+          fixture.ctx,
+          review({
+            async hydrateReviewEvidence(expectedHead) {
+              calls.push(expectedHead ?? "")
+              await fixture.ctx.mark({
+                review_glm_state: "done",
+                review_codex_state: "done",
+                reviewed_head_sha: "abc123",
+                review_evidence_state: "restored",
+              })
+              return true
+            },
+          }),
+        ).bashBeforeGit("gh pr merge 42 --merge", {}, {}),
+      ).rejects.toThrow("CI checks not all green")
+
+      expect(calls).toEqual([])
+      expect(fixture.marks.at(-1)?.last_reason).toBe("CI checks not all green")
+    } finally {
+      restore()
+    }
+  })
+
   test("treats guardrail profile markdown as full review tier", async () => {
     await using fixture = await diffFixture("packages/guardrails/profile/commands/ship.md")
     const git = createGitHandlers(fixture.ctx, review())
@@ -631,6 +870,7 @@ describe("guardrail-git", () => {
     await Bun.$`git remote add origin git@github.com:owner/repo.git`.cwd(fixture.ctx.input.worktree).quiet()
     const restore = fakeGh((args) => {
       if (args[0] === "pr" && args[1] === "checks") return { stdout: "build\tpass\t0\thttps://example.test/check\n" }
+      if (args[0] === "pr" && args[1] === "view" && args.includes("headRefOid")) return { stdout: "abc123\n" }
       if (args[0] === "api" && args[1] === "repos/owner/repo/pulls/42/files") {
         return { stdout: "packages/opencode/src/self-approved.ts\n" }
       }
@@ -655,10 +895,95 @@ describe("guardrail-git", () => {
           {
             review_glm_state: "done",
             review_codex_state: "done",
+            reviewed_head_sha: "abc123",
           },
         ),
       ).rejects.toThrow("PR approval cannot come only from the PR author")
       expect(fixture.marks.at(-1)?.last_reason).toBe("only PR author approvals present")
+    } finally {
+      restore()
+    }
+  })
+
+  test.serial("rehydrates review evidence for FULL tier PR merges after session reset", async () => {
+    await using fixture = await diffFixture("packages/opencode/src/review-evidence.ts")
+    await Bun.$`git remote add origin git@github.com:owner/repo.git`.cwd(fixture.ctx.input.worktree).quiet()
+    const evidence = [
+      'gstack-review-log {"skill":"code-reviewer","timestamp":"2026-07-01T00:00:00Z","status":"pass"}',
+      'gstack-review-log {"skill":"codex-review","timestamp":"2026-07-01T00:01:00Z","status":"pass"}',
+      "Review completed. CRITICAL=0 HIGH=0.",
+    ].join("\n")
+    const resetState = {
+      review_state: "",
+      review_glm_state: "",
+      review_codex_state: "",
+      review_at: "",
+      edits_since_review: 0,
+      review_critical_count: 0,
+      review_high_count: 0,
+      ci_green: false,
+    }
+    const restore = fakeGh((args) => {
+      const command = args.join(" ")
+      if (args[0] === "pr" && args[1] === "checks") return { stdout: "build\tpass\t0\thttps://example.test/check\n" }
+      if (args[0] === "pr" && args[1] === "list") return { stdout: "" }
+      if (args[0] === "pr" && args[1] === "view" && args.includes("headRefOid")) return { stdout: "abc123\n" }
+      if (args[0] === "pr" && args[1] === "view" && args.includes("--json")) {
+        return {
+          stdout: `${JSON.stringify({
+            comments: [{ body: evidence }],
+            reviews: [{ author: { login: "reviewer" }, body: evidence, state: "COMMENTED" }],
+          })}\n`,
+        }
+      }
+      if (args[0] === "pr" && args[1] === "view") return { stdout: `${evidence}\n` }
+      if (args[0] === "api" && args[1] === "repos/owner/repo/pulls/42/files") {
+        return { stdout: "packages/opencode/src/review-evidence.ts\n" }
+      }
+      if (args[0] === "api" && args[1] === "repos/owner/repo/pulls/42") return { stdout: "alice\n" }
+      if (args[0] === "api" && args[1] === "repos/owner/repo/issues/42/comments") {
+        if (args.includes("--jq")) return { stdout: `${evidence}\n` }
+        return { stdout: `${JSON.stringify([{ body: evidence }])}\n` }
+      }
+      if (args[0] === "api" && args[1] === "repos/owner/repo/pulls/42/reviews") {
+        if (command.includes("CHANGES_REQUESTED")) return { stdout: "0\n" }
+        if (command.includes("APPROVED") && command.includes("@tsv")) return { stdout: "reviewer\n" }
+        if (args.includes("--jq")) return { stdout: `${evidence}\n` }
+        return {
+          stdout: `${JSON.stringify([
+            { body: evidence, state: "COMMENTED", user: { login: "code-reviewer" } },
+            { body: evidence, state: "APPROVED", user: { login: "reviewer" } },
+          ])}\n`,
+        }
+      }
+      return {}
+    })
+    try {
+      await Bun.write(fixture.ctx.state, JSON.stringify(resetState, null, 2))
+
+      await expect(
+        createGitHandlers(
+          fixture.ctx,
+          review({
+            async hydrateReviewEvidence(expectedHead) {
+              expect(expectedHead).toBe("abc123")
+              await fixture.ctx.mark({
+                review_glm_state: "done",
+                review_codex_state: "done",
+                reviewed_head_sha: "abc123",
+                review_evidence_state: "restored",
+                review_critical_count: 0,
+                review_high_count: 0,
+                edits_since_review: 0,
+              })
+              return true
+            },
+          }),
+        ).bashBeforeGit("gh pr merge 42 --merge", {}, resetState),
+      ).resolves.toBeUndefined()
+
+      expect(fixture.marks.some((item) => item.ci_green === true)).toBe(true)
+      expect(fixture.marks.some((item) => item.merge_review_tier === "FULL")).toBe(true)
     } finally {
       restore()
     }

--- a/packages/opencode/test/plugin/guardrail-review.test.ts
+++ b/packages/opencode/test/plugin/guardrail-review.test.ts
@@ -5,13 +5,36 @@ import { createReviewPipeline } from "../../../../packages/guardrails/profile/pl
 import type { GuardrailContext } from "../../../../packages/guardrails/profile/plugins/guardrail-context"
 import { tmpdir } from "../fixture/fixture"
 
-async function context(state: string) {
+async function gitOutput(dir: string, args: string[]) {
+  const proc = Bun.spawn(["git", ...args], {
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  if (code !== 0) throw new Error(stderr || `git ${args.join(" ")} failed`)
+  return stdout.trim()
+}
+
+function statePath(dir: string) {
+  return path.join(dir, ".opencode", "guardrails", "state.json")
+}
+
+function evidencePath(dir: string) {
+  return path.join(dir, ".opencode", "guardrails", "review-evidence.json")
+}
+
+async function context(state: string, worktree = path.dirname(path.dirname(path.dirname(state)))) {
   const events: Record<string, unknown>[] = []
   const ctx: GuardrailContext = {
     input: {
       client: {} as GuardrailContext["input"]["client"],
-      directory: path.dirname(path.dirname(state)),
-      worktree: path.dirname(path.dirname(state)),
+      directory: worktree,
+      worktree,
     },
     mode: "enforced",
     root: path.dirname(state),
@@ -85,9 +108,138 @@ async function context(state: string) {
   return { ctx, events }
 }
 
+test("external opencode review saves durable evidence for current HEAD", async () => {
+  await using tmp = await tmpdir({ git: true })
+  const state = statePath(tmp.path)
+  await fs.mkdir(path.dirname(state), { recursive: true })
+  await Bun.write(state, JSON.stringify({ review_codex_state: "done" }))
+  const { ctx } = await context(state, tmp.path)
+
+  await createReviewPipeline(ctx).handleExternalReviewDetection(
+    { tool: "bash", args: { command: "opencode run /review" } },
+    { output: "Review completed. No critical or high issues found.", metadata: { exitCode: 0 } },
+  )
+
+  const evidence = await Bun.file(evidencePath(tmp.path)).json()
+  expect(evidence.reviewed_head_sha).toBe(await gitOutput(tmp.path, ["rev-parse", "HEAD"]))
+  expect(evidence.review_branch).toBe(await gitOutput(tmp.path, ["branch", "--show-current"]))
+  expect(evidence.review_worktree_clean).toBe(true)
+  expect(evidence.review_dirty_count).toBe(0)
+  expect(evidence.review_glm_state).toBe("done")
+  expect(evidence.review_codex_state).toBe("done")
+  expect(evidence.review_state).toBe("done")
+  expect(evidence.review_agent).toBe("opencode:review")
+  expect(evidence.review_critical_count).toBe(0)
+  expect(evidence.review_high_count).toBe(0)
+  expect(evidence.review_severe_count).toBe(0)
+})
+
+test("codex review saves durable evidence for current HEAD", async () => {
+  await using tmp = await tmpdir({ git: true })
+  const state = statePath(tmp.path)
+  await fs.mkdir(path.dirname(state), { recursive: true })
+  await Bun.write(state, JSON.stringify({ review_glm_state: "done" }))
+  const { ctx } = await context(state, tmp.path)
+
+  await createReviewPipeline(ctx).handleCodexDetection(
+    { tool: "mcp__codex__codex", args: { prompt: "review the diff" } },
+    { output: "Codex review completed. No CRITICAL or HIGH issues were identified." },
+  )
+
+  const evidence = await Bun.file(evidencePath(tmp.path)).json()
+  expect(evidence.reviewed_head_sha).toBe(await gitOutput(tmp.path, ["rev-parse", "HEAD"]))
+  expect(evidence.review_codex_state).toBe("done")
+  expect(evidence.review_state).toBe("done")
+  expect(evidence.review_agent).toBe("codex:mcp")
+  expect(evidence.review_worktree_clean).toBe(true)
+})
+
+test("review evidence restores for same HEAD and clean worktree", async () => {
+  await using tmp = await tmpdir({ git: true })
+  const state = statePath(tmp.path)
+  await fs.mkdir(path.dirname(state), { recursive: true })
+  await Bun.write(state, JSON.stringify({ review_codex_state: "done" }))
+  const { ctx } = await context(state, tmp.path)
+  const review = createReviewPipeline(ctx)
+
+  await review.handleExternalReviewDetection(
+    { tool: "bash", args: { command: "opencode run /review" } },
+    { output: "Review completed. No critical or high issues found.", metadata: { exitCode: 0 } },
+  )
+  await Bun.write(state, JSON.stringify({}))
+
+  expect(await review.restoreReviewEvidence()).toBe(true)
+
+  const data = await Bun.file(state).json()
+  expect(data.review_glm_state).toBe("done")
+  expect(data.review_codex_state).toBe("done")
+  expect(data.review_state).toBe("done")
+  expect(data.review_agent).toBe("opencode:review")
+  expect(data.reviewed_head_sha).toBe(await gitOutput(tmp.path, ["rev-parse", "HEAD"]))
+  expect(data.edits_since_review).toBe(0)
+})
+
+test("review evidence is not restored when HEAD changes", async () => {
+  await using tmp = await tmpdir({ git: true })
+  const state = statePath(tmp.path)
+  await fs.mkdir(path.dirname(state), { recursive: true })
+  await Bun.write(state, JSON.stringify({ review_codex_state: "done" }))
+  const { ctx, events } = await context(state, tmp.path)
+  const review = createReviewPipeline(ctx)
+
+  await review.handleExternalReviewDetection(
+    { tool: "bash", args: { command: "opencode run /review" } },
+    { output: "Review completed. No critical or high issues found.", metadata: { exitCode: 0 } },
+  )
+  await Bun.write(path.join(tmp.path, "changed.txt"), "changed")
+  await gitOutput(tmp.path, ["add", "changed.txt"])
+  await gitOutput(tmp.path, ["commit", "-m", "change head"])
+  await Bun.write(state, JSON.stringify({}))
+
+  expect(await review.restoreReviewEvidence()).toBe(false)
+
+  const data = await Bun.file(state).json()
+  expect(review.reviewGate(data)).toEqual({
+    done: false,
+    pending: ["GLM code-reviewer", "Codex review"],
+    message: "pending: GLM code-reviewer and Codex review",
+  })
+  expect(events.some((item) => item.type === "review_evidence.not_restored" && item.reason === "head_mismatch")).toBe(
+    true,
+  )
+})
+
+test("review evidence is not restored for dirty worktree", async () => {
+  await using tmp = await tmpdir({ git: true })
+  const state = statePath(tmp.path)
+  await fs.mkdir(path.dirname(state), { recursive: true })
+  await Bun.write(state, JSON.stringify({ review_codex_state: "done" }))
+  const { ctx, events } = await context(state, tmp.path)
+  const review = createReviewPipeline(ctx)
+
+  await review.handleExternalReviewDetection(
+    { tool: "bash", args: { command: "opencode run /review" } },
+    { output: "Review completed. No critical or high issues found.", metadata: { exitCode: 0 } },
+  )
+  await Bun.write(path.join(tmp.path, "dirty.txt"), "dirty")
+  await Bun.write(state, JSON.stringify({}))
+
+  expect(await review.restoreReviewEvidence()).toBe(false)
+
+  const data = await Bun.file(state).json()
+  expect(review.reviewGate(data)).toEqual({
+    done: false,
+    pending: ["GLM code-reviewer", "Codex review"],
+    message: "pending: GLM code-reviewer and Codex review",
+  })
+  expect(events.some((item) => item.type === "review_evidence.not_restored" && item.reason === "dirty_worktree")).toBe(
+    true,
+  )
+})
+
 test("external opencode review marks GLM review done", async () => {
   await using tmp = await tmpdir()
-  const state = path.join(tmp.path, ".opencode", "guardrails", "state.json")
+  const state = statePath(tmp.path)
   await fs.mkdir(path.dirname(state), { recursive: true })
   await Bun.write(state, JSON.stringify({ review_codex_state: "done" }))
   const { ctx, events } = await context(state)
@@ -106,7 +258,7 @@ test("external opencode review marks GLM review done", async () => {
 
 test("review gate blocks when code-reviewer state is missing", async () => {
   await using tmp = await tmpdir()
-  const state = path.join(tmp.path, ".opencode", "guardrails", "state.json")
+  const state = statePath(tmp.path)
   await fs.mkdir(path.dirname(state), { recursive: true })
   await Bun.write(state, JSON.stringify({ review_codex_state: "done" }))
   const { ctx } = await context(state)
@@ -124,7 +276,7 @@ test("review gate blocks when code-reviewer state is missing", async () => {
 
 test("checklist blocks stale review state after edits", async () => {
   await using tmp = await tmpdir()
-  const state = path.join(tmp.path, ".opencode", "guardrails", "state.json")
+  const state = statePath(tmp.path)
   await fs.mkdir(path.dirname(state), { recursive: true })
   const { ctx } = await context(state)
 
@@ -141,7 +293,7 @@ test("checklist blocks stale review state after edits", async () => {
 
 test("external claude code-reviewer marks GLM review done", async () => {
   await using tmp = await tmpdir()
-  const state = path.join(tmp.path, ".opencode", "guardrails", "state.json")
+  const state = statePath(tmp.path)
   await fs.mkdir(path.dirname(state), { recursive: true })
   await Bun.write(state, JSON.stringify({ review_codex_state: "done" }))
   const { ctx } = await context(state)
@@ -158,7 +310,7 @@ test("external claude code-reviewer marks GLM review done", async () => {
 
 test("external code-reviewer scripts mark GLM review done", async () => {
   await using tmp = await tmpdir()
-  const state = path.join(tmp.path, ".opencode", "guardrails", "state.json")
+  const state = statePath(tmp.path)
   await fs.mkdir(path.dirname(state), { recursive: true })
   await Bun.write(state, JSON.stringify({ review_codex_state: "done" }))
   const { ctx, events } = await context(state)
@@ -177,7 +329,7 @@ test("external code-reviewer scripts mark GLM review done", async () => {
 
 test("gstack review log marks matching review gates done", async () => {
   await using tmp = await tmpdir()
-  const state = path.join(tmp.path, ".opencode", "guardrails", "state.json")
+  const state = statePath(tmp.path)
   await fs.mkdir(path.dirname(state), { recursive: true })
   await Bun.write(state, JSON.stringify({}))
   const { ctx, events } = await context(state)
@@ -213,7 +365,7 @@ test("gstack review log marks matching review gates done", async () => {
 
 test("failed gstack review log does not mark review done", async () => {
   await using tmp = await tmpdir()
-  const state = path.join(tmp.path, ".opencode", "guardrails", "state.json")
+  const state = statePath(tmp.path)
   await fs.mkdir(path.dirname(state), { recursive: true })
   await Bun.write(state, JSON.stringify({}))
   const { ctx, events } = await context(state)
@@ -236,7 +388,7 @@ test("failed gstack review log does not mark review done", async () => {
 
 test("external review abort output does not mark review done", async () => {
   await using tmp = await tmpdir()
-  const state = path.join(tmp.path, ".opencode", "guardrails", "state.json")
+  const state = statePath(tmp.path)
   await fs.mkdir(path.dirname(state), { recursive: true })
   await Bun.write(state, JSON.stringify({ review_codex_state: "done" }))
   const { ctx, events } = await context(state)

--- a/packages/opencode/test/plugin/guardrail.test.ts
+++ b/packages/opencode/test/plugin/guardrail.test.ts
@@ -34,6 +34,23 @@ function client(): GuardrailInput["client"] {
   }
 }
 
+async function writeReviewEvidence(worktree: string, data: Record<string, unknown>) {
+  const guardrails = path.join(worktree, ".opencode", "guardrails")
+  await fs.mkdir(guardrails, { recursive: true })
+  await Bun.write(path.join(guardrails, "review-evidence.json"), JSON.stringify(data, null, 2))
+}
+
+async function withHome(home: string, fn: () => Promise<void>) {
+  const previous = process.env.HOME
+  process.env.HOME = home
+  try {
+    await fn()
+  } finally {
+    if (previous === undefined) delete process.env.HOME
+    else process.env.HOME = previous
+  }
+}
+
 describe("guardrail plugin", () => {
   test("uses OpenCode-compatible part ids for injected text", () => {
     expect(partID().startsWith("prt_")).toBe(true)
@@ -62,6 +79,72 @@ describe("guardrail plugin", () => {
 
     expect(await ensureLocalOpencodeIgnored(teamDir)).toBe(false)
     expect(await Bun.file(exclude).text()).toBe(before)
+  })
+
+  test("session.created restores same-head review evidence after Codex MCP detection", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const head = (await Bun.$`git rev-parse HEAD`.cwd(tmp.path).text()).trim()
+    await writeReviewEvidence(tmp.path, {
+      head,
+      review_glm_state: "done",
+      review_glm_at: "2026-07-01T00:00:00.000Z",
+      review_agent: "code-reviewer",
+      review_critical_count: 0,
+      review_high_count: 0,
+    })
+    const plugin = await guardrail({ client: client(), directory: tmp.path, worktree: tmp.path }, {})
+
+    await withHome(tmp.path, async () => {
+      await plugin.event({ event: { type: "session.created", properties: { sessionID: "ses_restore" } } })
+    })
+
+    const data = await Bun.file(path.join(tmp.path, ".opencode", "guardrails", "state.json")).json()
+    expect(data.read_count).toBe(0)
+    expect(data.workflow_phase).toBe("idle")
+    expect(data.review_glm_state).toBe("done")
+    expect(data.review_codex_state).toBe("done")
+    expect(data.review_codex_at).toBe("auto:no-codex-mcp")
+    expect(data.review_state).toBe("done")
+    expect(data.edits_since_review).toBe(0)
+    expect(data.review_agent).toBe("code-reviewer")
+  })
+
+  test("session.created skips review evidence when HEAD mismatches", async () => {
+    await using tmp = await tmpdir({ git: true })
+    await writeReviewEvidence(tmp.path, {
+      head: "0000000000000000000000000000000000000000",
+      review_glm_state: "done",
+    })
+    const plugin = await guardrail({ client: client(), directory: tmp.path, worktree: tmp.path }, {})
+
+    await withHome(tmp.path, async () => {
+      await plugin.event({ event: { type: "session.created", properties: { sessionID: "ses_mismatch" } } })
+    })
+
+    const data = await Bun.file(path.join(tmp.path, ".opencode", "guardrails", "state.json")).json()
+    expect(data.review_glm_state).toBe("")
+    expect(data.review_codex_state).toBe("done")
+    expect(data.review_state).toBe("")
+  })
+
+  test("session.created skips review evidence when worktree is dirty", async () => {
+    await using tmp = await tmpdir({ git: true })
+    const head = (await Bun.$`git rev-parse HEAD`.cwd(tmp.path).text()).trim()
+    await writeReviewEvidence(tmp.path, {
+      head,
+      review_glm_state: "done",
+    })
+    await Bun.write(path.join(tmp.path, "dirty.txt"), "dirty\n")
+    const plugin = await guardrail({ client: client(), directory: tmp.path, worktree: tmp.path }, {})
+
+    await withHome(tmp.path, async () => {
+      await plugin.event({ event: { type: "session.created", properties: { sessionID: "ses_dirty" } } })
+    })
+
+    const data = await Bun.file(path.join(tmp.path, ".opencode", "guardrails", "state.json")).json()
+    expect(data.review_glm_state).toBe("")
+    expect(data.review_codex_state).toBe("done")
+    expect(data.review_state).toBe("")
   })
 
   test("tool hook blocks code PR merge when code-reviewer state is missing", async () => {


### PR DESCRIPTION
## ① なぜ

`/review` 完了後に `/ship` が子セッションで起動すると、`session.created` の初期化で `state.json` の review gate 状態が失われ、FULL tier merge が `pending: GLM code-reviewer` に戻る問題がありました。merge 権限は ship 専用のまま維持し、正規の `/review -> /ship` 経路だけが通るようにします。

Closes #265

## ② どう実装したか

- review 完了時に `.opencode/guardrails/review-evidence.json` へ HEAD SHA 付きの durable evidence を保存
- `session.created` 後と FULL tier merge gate 直前に、同一 HEAD かつ clean worktree の evidence だけを復元
- PR merge 時は GitHub の `headRefOid` と reviewed HEAD を照合し、stale review や別 PR head の再利用を拒否
- `review_severe_count` を merge gate の severe finding 判定へ含め、CRITICAL/HIGH が 0 でも severe count が残る場合は block
- runtime evidence への直接 write と、動的 path 組み立てを含む inline interpreter shell の改ざんを block

## ③ レビュー注目点

- `gh pr merge` 権限自体は緩和していないこと
- evidence 復元条件が同一 HEAD / clean worktree / PR headRefOid 一致に限定されていること
- author-only approval、CI queued/failure、dirty worktree、HEAD 変更、CHANGES_REQUESTED、CRITICAL/HIGH/severe 残存が従来どおり block されること

## ④ テスト・確認方法

- `packages/opencode` で `bun typecheck`
- `packages/opencode` で `bun test --timeout 30000 test/plugin/guardrail-access.test.ts test/plugin/guardrail-git.test.ts test/plugin/guardrail-review.test.ts test/plugin/guardrail.test.ts`
- `packages/opencode` で `bun run test:httpapi`
- `packages/opencode` で `bun run build`
- repo root で `bun run local:deploy`
- repo root で `bun run local:check`
- `~/.local/bin/opencode --version`
- tmp dir で `~/.local/bin/opencode debug info`
- `packages/opencode` で `bun test --timeout 30000 test/cli/smokes/local-deploy.test.ts`

補足: 最終 subagent review でも dynamic bypass、FULL PR `headRefOid`、`review_severe_count` の観点でブロッカーなしを確認済みです。
